### PR TITLE
ENT-4859: Added Program template container page.

### DIFF
--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -10,6 +10,7 @@ import {
 } from '../enterprise-redirects';
 import { DashboardPage } from '../dashboard';
 import { CoursePage } from '../course';
+import { ProgramPage } from '../program';
 import { SearchPage } from '../search';
 import { LicenseActivationPage } from '../license-activation';
 import { SkillsQuizPage } from '../skills-quiz';
@@ -31,6 +32,7 @@ export default function App() {
         <PageRoute exact path="/:enterpriseSlug" component={DashboardPage} />
         <PageRoute exact path="/:enterpriseSlug/search" component={SearchPage} />
         <PageRoute exact path="/:enterpriseSlug/course/:courseKey" component={CoursePage} />
+        <PageRoute exact path="/:enterpriseSlug/program/:programUuid" component={ProgramPage} />
         <PageRoute exact path="/:enterpriseSlug/licenses/:activationKey/activate" component={LicenseActivationPage} />
         <PageRoute exact path="/:enterpriseSlug/skills-quiz" component={SkillsQuizPage} />
         <PageRoute path="*" component={NotFoundPage} />

--- a/src/components/program/Program.jsx
+++ b/src/components/program/Program.jsx
@@ -1,0 +1,75 @@
+import React, { useContext, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+import MediaQuery from 'react-responsive';
+import { breakpoints, Container, Row } from '@edx/paragon';
+import { AppContext, ErrorPage } from '@edx/frontend-platform/react';
+
+import { MainContent, Sidebar } from '../layout';
+import { LoadingSpinner } from '../loading-spinner';
+import { ProgramContextProvider } from './ProgramContextProvider';
+import ProgramHeader from './ProgramHeader';
+import ProgramMainContent from './ProgramMainContent';
+import ProgramSidebar from './ProgramSidebar';
+
+import { useAllProgramData } from './data/hooks';
+
+const Program = () => {
+  const { programUuid } = useParams();
+  const { enterpriseConfig } = useContext(AppContext);
+
+  const [programData, fetchError] = useAllProgramData({ programUuid });
+
+  const initialState = useMemo(
+    () => {
+      if (!programData) {
+        return undefined;
+      }
+      const { programDetails } = programData;
+
+      return {
+        program: programDetails,
+      };
+    },
+    [programData],
+  );
+
+  if (fetchError) {
+    return <ErrorPage message={fetchError.message} />;
+  }
+
+  if (!initialState) {
+    return (
+      <Container size="lg" className="py-5">
+        <LoadingSpinner screenReaderText="loading program" />
+      </Container>
+    );
+  }
+
+  const PAGE_TITLE = `${initialState.program.title} - ${enterpriseConfig.name}`;
+
+  return (
+    <>
+      <Helmet title={PAGE_TITLE} />
+      <ProgramContextProvider initialState={initialState}>
+        <ProgramHeader />
+        <Container size="lg" className="py-5">
+          <Row>
+            <MainContent>
+              <ProgramMainContent />
+            </MainContent>
+            <MediaQuery minWidth={breakpoints.large.minWidth}>
+              {matches => matches && (
+                <Sidebar>
+                  <ProgramSidebar />
+                </Sidebar>
+              )}
+            </MediaQuery>
+          </Row>
+        </Container>
+      </ProgramContextProvider>
+    </>
+  );
+};
+
+export default Program;

--- a/src/components/program/ProgramContextProvider.jsx
+++ b/src/components/program/ProgramContextProvider.jsx
@@ -1,0 +1,19 @@
+import React, { createContext } from 'react';
+import PropTypes from 'prop-types';
+
+export const ProgramContext = createContext();
+
+export function ProgramContextProvider({ children, initialState }) {
+  return (
+    <ProgramContext.Provider value={initialState}>
+      {children}
+    </ProgramContext.Provider>
+  );
+}
+
+ProgramContextProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  initialState: PropTypes.shape({
+    program: PropTypes.shape({}).isRequired,
+  }).isRequired,
+};

--- a/src/components/program/ProgramHeader.jsx
+++ b/src/components/program/ProgramHeader.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { Container } from '@edx/paragon';
+
+const ProgramHeader = () => (
+  <div className="program-header">
+    <Container size="lg">
+      <h1>Program Header Placeholder.</h1>
+    </Container>
+  </div>
+);
+
+export default ProgramHeader;

--- a/src/components/program/ProgramMainContent.jsx
+++ b/src/components/program/ProgramMainContent.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ProgramMainContent = () => (
+  <div>Program Main Content Placeholder</div>
+);
+
+export default ProgramMainContent;

--- a/src/components/program/ProgramPage.jsx
+++ b/src/components/program/ProgramPage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import Program from './Program';
+import AuthenticatedUserSubsidyPage from '../app/AuthenticatedUserSubsidyPage';
+
+const ProgramPage = () => (
+  <AuthenticatedUserSubsidyPage>
+    <Program />
+  </AuthenticatedUserSubsidyPage>
+);
+
+export default ProgramPage;

--- a/src/components/program/ProgramSidebar.jsx
+++ b/src/components/program/ProgramSidebar.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ProgramSidebar = () => (
+  <div>Program Sidebar Placeholder</div>
+);
+
+export default ProgramSidebar;

--- a/src/components/program/data/hooks.jsx
+++ b/src/components/program/data/hooks.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { logError } from '@edx/frontend-platform/logging';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
+
+import ProgramService from './service';
+
+export function useAllProgramData({ programUuid }) {
+  const [programData, setProgramData] = useState();
+  const [fetchError, setFetchError] = useState();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (programUuid) {
+        const programService = new ProgramService({ programUuid });
+        try {
+          const data = await programService.fetchAllProgramData();
+          setProgramData(data);
+        } catch (error) {
+          logError(error);
+          setFetchError(error);
+        }
+      }
+      return undefined;
+    };
+    fetchData();
+  }, [programUuid]);
+  return [camelCaseObject(programData), fetchError];
+}

--- a/src/components/program/data/service.js
+++ b/src/components/program/data/service.js
@@ -1,0 +1,35 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
+import { getConfig } from '@edx/frontend-platform/config';
+
+export default class ProgramService {
+  constructor(options = {}) {
+    const { programUuid } = options;
+    this.config = getConfig();
+
+    this.cachedAuthenticatedHttpClient = getAuthenticatedHttpClient({
+      useCache: this.config.USE_API_CACHE,
+    });
+
+    this.programUuid = programUuid;
+  }
+
+  async fetchAllProgramData() {
+    const programDataRaw = await Promise.all([
+      this.fetchProgramDetails(),
+    ])
+      .then((responses) => responses.map(res => res.data));
+
+    const programData = camelCaseObject(programDataRaw);
+    const programDetails = programData[0];
+
+    return {
+      programDetails,
+    };
+  }
+
+  fetchProgramDetails() {
+    const url = `${this.config.DISCOVERY_API_BASE_URL}/api/v1/programs/${this.programUuid}/`;
+    return this.cachedAuthenticatedHttpClient.get(url);
+  }
+}

--- a/src/components/program/index.js
+++ b/src/components/program/index.js
@@ -1,0 +1,1 @@
+export { default as ProgramPage } from './ProgramPage';

--- a/src/components/program/tests/Program.test.jsx
+++ b/src/components/program/tests/Program.test.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { AppContext } from '@edx/frontend-platform/react';
+import { screen, render, act } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { UserSubsidyContext } from '../../enterprise-user-subsidy';
+import Program from '../Program';
+import { useAllProgramData } from '../data/hooks';
+
+const waitForAsync = () => new Promise(resolve => setImmediate(resolve));
+
+const programData = {
+  title: 'Test Program Title',
+  uuid: 'abcd-1234-213',
+};
+
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(() => ({ programUuid: programData.uuid })),
+}));
+
+jest.mock('@edx/frontend-platform/auth', () => ({
+  getAuthenticatedHttpClient: jest.fn(),
+}));
+
+jest.mock('../data/hooks', () => ({
+  useAllProgramData: jest.fn(),
+}));
+
+/* eslint-disable react/prop-types */
+const ProgramWithContext = ({
+  initialAppState = {},
+  initialUserSubsidyState = {},
+}) => (
+  <AppContext.Provider value={initialAppState}>
+    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+      <Program />
+    </UserSubsidyContext.Provider>
+  </AppContext.Provider>
+);
+/* eslint-enable react/prop-types */
+
+describe('<Program />', () => {
+  const initialAppState = {
+    enterpriseConfig: {
+      slug: 'test-enterprise-slug',
+      name: 'Test Enterprise',
+    },
+  };
+
+  const initialUserSubsidyState = {
+    subscriptionLicense: {
+      uuid: 'test-license-uuid',
+    },
+    offers: {
+      offers: [],
+      offersCount: 0,
+    },
+  };
+
+  test('renders program.', async () => {
+    useAllProgramData.mockImplementation(() => ([{ programDetails: programData }, null]));
+
+    await act(async () => {
+      render(
+        <ProgramWithContext
+          initialAppState={initialAppState}
+          initialUserSubsidyState={initialUserSubsidyState}
+        />,
+      );
+      await waitForAsync();
+
+      expect(screen.getByText('Program Main Content Placeholder')).toBeInTheDocument();
+      expect(screen.getByText('Program Header Placeholder.')).toBeInTheDocument();
+    });
+  });
+
+  test('renders program error.', async () => {
+    useAllProgramData.mockImplementation(() => ([{}, { message: 'This is a test message.' }]));
+
+    await act(async () => {
+      render(
+        <ProgramWithContext
+          initialAppState={initialAppState}
+          initialUserSubsidyState={initialUserSubsidyState}
+        />,
+      );
+      await waitForAsync();
+
+      expect(screen.getByText('This is a test message.')).toBeInTheDocument();
+      expect(screen.getByText('Try again')).toBeInTheDocument();
+    });
+  });
+
+  test('handle invalid data.', async () => {
+    useAllProgramData.mockImplementation(() => ([null, null]));
+
+    await act(async () => {
+      render(
+        <ProgramWithContext
+          initialAppState={initialAppState}
+          initialUserSubsidyState={initialUserSubsidyState}
+        />,
+      );
+      await waitForAsync();
+
+      expect(screen.getByText('loading program')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/program/tests/ProgramHeader.test.jsx
+++ b/src/components/program/tests/ProgramHeader.test.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { AppContext } from '@edx/frontend-platform/react';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { UserSubsidyContext } from '../../enterprise-user-subsidy';
+import { ProgramContextProvider } from '../ProgramContextProvider';
+import ProgramHeader from '../ProgramHeader';
+
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn(),
+}));
+
+/* eslint-disable react/prop-types */
+const ProgramHeaderWithContext = ({
+  initialAppState = {},
+  initialProgramState = {},
+  initialUserSubsidyState = {},
+}) => (
+  <AppContext.Provider value={initialAppState}>
+    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+      <ProgramContextProvider initialState={initialProgramState}>
+        <ProgramHeader />
+      </ProgramContextProvider>
+    </UserSubsidyContext.Provider>
+  </AppContext.Provider>
+);
+/* eslint-enable react/prop-types */
+
+describe('<ProgramHeader />', () => {
+  const initialAppState = {
+    enterpriseConfig: {
+      slug: 'test-enterprise-slug',
+    },
+  };
+  const initialProgramState = {
+    program: {
+      title: 'Test Program Title',
+    },
+  };
+  const initialUserSubsidyState = {
+    subscriptionLicense: {
+      uuid: 'test-license-uuid',
+    },
+    offers: {
+      offers: [],
+      offersCount: 0,
+    },
+  };
+
+  test('renders program header.', () => {
+    render(
+      <ProgramHeaderWithContext
+        initialAppState={initialAppState}
+        initialProgramState={initialProgramState}
+        initialUserSubsidyState={initialUserSubsidyState}
+      />,
+    );
+
+    expect(screen.getByText('Program Header Placeholder.')).toBeInTheDocument();
+  });
+});

--- a/src/components/program/tests/ProgramMainContent.test.jsx
+++ b/src/components/program/tests/ProgramMainContent.test.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { AppContext } from '@edx/frontend-platform/react';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { UserSubsidyContext } from '../../enterprise-user-subsidy';
+import { ProgramContextProvider } from '../ProgramContextProvider';
+import ProgramMainContent from '../ProgramMainContent';
+
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn(),
+}));
+
+/* eslint-disable react/prop-types */
+const ProgramMainContentWithContext = ({
+  initialAppState = {},
+  initialProgramState = {},
+  initialUserSubsidyState = {},
+}) => (
+  <AppContext.Provider value={initialAppState}>
+    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+      <ProgramContextProvider initialState={initialProgramState}>
+        <ProgramMainContent />
+      </ProgramContextProvider>
+    </UserSubsidyContext.Provider>
+  </AppContext.Provider>
+);
+/* eslint-enable react/prop-types */
+
+describe('<ProgramMainContent />', () => {
+  const initialAppState = {
+    enterpriseConfig: {
+      slug: 'test-enterprise-slug',
+    },
+  };
+  const initialProgramState = {
+    program: {
+      title: 'Test Program Title',
+    },
+  };
+  const initialUserSubsidyState = {
+    subscriptionLicense: {
+      uuid: 'test-license-uuid',
+    },
+    offers: {
+      offers: [],
+      offersCount: 0,
+    },
+  };
+
+  test('renders program main content.', () => {
+    render(
+      <ProgramMainContentWithContext
+        initialAppState={initialAppState}
+        initialProgramState={initialProgramState}
+        initialUserSubsidyState={initialUserSubsidyState}
+      />,
+    );
+
+    expect(screen.getByText('Program Main Content Placeholder')).toBeInTheDocument();
+  });
+});

--- a/src/components/program/tests/ProgramSidebar.test.jsx
+++ b/src/components/program/tests/ProgramSidebar.test.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { AppContext } from '@edx/frontend-platform/react';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { UserSubsidyContext } from '../../enterprise-user-subsidy';
+import { ProgramContextProvider } from '../ProgramContextProvider';
+import ProgramSidebar from '../ProgramSidebar';
+
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn(),
+}));
+
+/* eslint-disable react/prop-types */
+const ProgramSidebarWithContext = ({
+  initialAppState = {},
+  initialProgramState = {},
+  initialUserSubsidyState = {},
+}) => (
+  <AppContext.Provider value={initialAppState}>
+    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+      <ProgramContextProvider initialState={initialProgramState}>
+        <ProgramSidebar />
+      </ProgramContextProvider>
+    </UserSubsidyContext.Provider>
+  </AppContext.Provider>
+);
+/* eslint-enable react/prop-types */
+
+describe('<ProgramSidebar />', () => {
+  const initialAppState = {
+    enterpriseConfig: {
+      slug: 'test-enterprise-slug',
+    },
+  };
+  const initialProgramState = {
+    program: {
+      title: 'Test Program Title',
+    },
+  };
+  const initialUserSubsidyState = {
+    subscriptionLicense: {
+      uuid: 'test-license-uuid',
+    },
+    offers: {
+      offers: [],
+      offersCount: 0,
+    },
+  };
+
+  test('renders program sidebar.', () => {
+    render(
+      <ProgramSidebarWithContext
+        initialAppState={initialAppState}
+        initialProgramState={initialProgramState}
+        initialUserSubsidyState={initialUserSubsidyState}
+      />,
+    );
+
+    expect(screen.getByText('Program Sidebar Placeholder')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
__Description:__
This PR adds a container page for program details page in learner portal. The container page for the Programs template in the Learner Portal is accessible at 
https://enterprise.edx.org/enterprise-slug/program/{program-uuid}

__JIRA Ticket:__ [ENT-4859](https://openedx.atlassian.net/browse/ENT-4859)