### PR TITLE
feat: added new step to show courses grouped with skills user selected and job skills

### DIFF
--- a/src/components/skills-quiz/CardLoadingSkeleton.jsx
+++ b/src/components/skills-quiz/CardLoadingSkeleton.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Card } from '@edx/paragon';
+import Skeleton from 'react-loading-skeleton';
+import { LOADING_NO_OF_CARDS } from './constants';
+
+const CardLoadingSkeleton = () => (
+  <div className="row col col-12 p-0">
+    <div className="skill-quiz-results align-items-l-between col col-xl-10">
+      {Array.from({ length: LOADING_NO_OF_CARDS }, (_, i) => (
+        <div
+          className="search-result-card mb-4"
+          role="group"
+          key={i}
+        >
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <Link to="#">
+            <Card>
+              <Card.Img
+                as={Skeleton}
+                variant="top"
+                duration={0}
+                height={100}
+                data-testid="card-img-loading"
+              />
+              <div className="partner-logo-wrapper">
+                <Skeleton width={90} height={42} data-testid="partner-logo-loading" />
+              </div>
+              <Card.Body>
+                <Card.Title as="h4" className="card-title mb-2">
+                  <Skeleton count={2} data-testid="course-title-loading" />
+                </Card.Title>
+                <Skeleton duration={0} data-testid="partner-name-loading" />
+                <Skeleton count={1} data-testid="skills-loading" />
+              </Card.Body>
+            </Card>
+          </Link>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default CardLoadingSkeleton;

--- a/src/components/skills-quiz/SearchCourseCard.jsx
+++ b/src/components/skills-quiz/SearchCourseCard.jsx
@@ -1,7 +1,6 @@
 import React, {
   useContext, useMemo, useState, useEffect,
 } from 'react';
-import qs from 'query-string';
 import PropTypes from 'prop-types';
 import Truncate from 'react-truncate';
 import { Link } from 'react-router-dom';
@@ -11,8 +10,6 @@ import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { Badge, Card, StatusAlert } from '@edx/paragon';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearchMinus } from '@fortawesome/free-solid-svg-icons';
-import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { SkillsContext } from './SkillsContextProvider';
 
@@ -21,26 +18,9 @@ import { ELLIPSIS_STR } from '../course/data/constants';
 import { shortenString } from '../course/data/utils';
 import { SKILL_NAME_CUTOFF_LIMIT, MAX_VISIBLE_SKILLS_COURSE, NO_COURSES_ALERT_MESSAGE } from './constants';
 import { useSelectedSkillsAndJobSkills } from './data/hooks';
-import getCommonSkills from './data/utils';
+import getCommonSkills, { linkToCourse } from './data/utils';
 import { useDefaultSearchFilters } from '../search/data/hooks';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
-
-const linkToCourse = (course, slug, enterpriseUUID) => {
-  if (!Object.keys(course).length) {
-    return '#';
-  }
-  const queryParams = {
-    queryId: course.queryId,
-    objectId: course.objectId,
-  };
-  const { userId } = getAuthenticatedUser();
-  sendEnterpriseTrackEvent(
-    enterpriseUUID,
-    'edx.ui.enterprise.learner_portal.skills_quiz.course.clicked',
-    { userId, enterprise: slug, selectedCourse: course.key },
-  );
-  return `/${slug}/course/${course.key}?${qs.stringify(queryParams)}`;
-};
 
 const renderDialog = () => (
   <div className="lead d-flex align-items-center py-3">

--- a/src/components/skills-quiz/SkillsCourses.jsx
+++ b/src/components/skills-quiz/SkillsCourses.jsx
@@ -1,0 +1,285 @@
+import React, {
+  useEffect, useState, useContext, useMemo,
+} from 'react';
+import { Card, Badge, StatusAlert } from '@edx/paragon';
+import {
+  SearchContext,
+} from '@edx/frontend-enterprise-catalog-search';
+import { Link } from 'react-router-dom';
+import { AppContext } from '@edx/frontend-platform/react';
+
+import Skeleton from 'react-loading-skeleton';
+import Truncate from 'react-truncate';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSearchMinus } from '@fortawesome/free-solid-svg-icons';
+import PropTypes from 'prop-types';
+import { useSelectedSkillsAndJobSkills } from './data/hooks';
+import { SkillsContext } from './SkillsContextProvider';
+import { ELLIPSIS_STR } from '../course/data/constants';
+import { UserSubsidyContext } from '../enterprise-user-subsidy';
+import { useDefaultSearchFilters } from '../search/data/hooks';
+import getCommonSkills, { linkToCourse } from './data/utils';
+import {
+  HITS_PER_PAGE,
+  MAX_VISIBLE_SKILLS_COURSE,
+  NO_COURSES_ALERT_MESSAGE_AGAINST_SKILLS,
+  SKILL_NAME_CUTOFF_LIMIT,
+} from './constants';
+import { shortenString } from '../course/data/utils';
+import { isDefinedAndNotNull } from '../../utils/common';
+import CardLoadingSkeleton from './CardLoadingSkeleton';
+
+const renderDialog = () => (
+  <div className="lead d-flex align-items-center py-3">
+    <div className="mr-3">
+      <FontAwesomeIcon icon={faSearchMinus} size="2x" />
+    </div>
+    <p>
+      { NO_COURSES_ALERT_MESSAGE_AGAINST_SKILLS }
+    </p>
+  </div>
+);
+
+const SkillsCourses = ({ index }) => {
+  const { enterpriseConfig } = useContext(AppContext);
+  const { slug, uuid } = enterpriseConfig;
+  const { state } = useContext(SkillsContext);
+  const [isLoading, setIsLoading] = useState(false);
+  const [courses, setCourses] = useState([]);
+  const [hitCount, setHitCount] = useState(undefined);
+  const { refinements } = useContext(SearchContext);
+  const { skill_names: skills } = refinements;
+  const { selectedJob } = state;
+  const allSkills = useSelectedSkillsAndJobSkills({ getAllSkills: true });
+
+  const { subscriptionPlan, subscriptionLicense, offers: { offers } } = useContext(UserSubsidyContext);
+  const offerCatalogs = offers.map((offer) => offer.catalog);
+
+  const { filters } = useDefaultSearchFilters({
+    enterpriseConfig,
+    subscriptionPlan,
+    subscriptionLicense,
+    offerCatalogs,
+  });
+  const skillsFacetFilter = useMemo(
+    () => {
+      if (allSkills) {
+        return allSkills.map((skill) => `skill_names:${skill}`);
+      }
+      return [];
+    },
+    [allSkills],
+  );
+  useEffect(
+    () => {
+      let fetch = true;
+      fetchCourses(); // eslint-disable-line no-use-before-define
+      return () => {
+        fetch = false;
+      };
+
+      async function fetchCourses() {
+        setIsLoading(true);
+        const { hits, nbHits } = await index.search('', {
+          hitsPerPage: HITS_PER_PAGE,
+          filters: `content_type:course AND ${filters}`, // eslint-disable-line object-shorthand
+          facetFilters: [
+            skillsFacetFilter,
+          ],
+        });
+        if (!fetch) {
+          return;
+        }
+        if (nbHits > 0) {
+          setCourses(camelCaseObject(hits));
+          setHitCount(nbHits);
+          setIsLoading(false);
+        } else {
+          setHitCount(nbHits);
+          setIsLoading(false);
+        }
+      }
+    },
+    [selectedJob, skills],
+  );
+  const skillsWithSignificanceOrder = useSelectedSkillsAndJobSkills(
+    { getAllSkills: false, getAllSkillsWithSignificanceOrder: true },
+  );
+  const coursesWithSkills = useMemo(() => {
+    const coursesWithSkill = [];
+    skillsWithSignificanceOrder.forEach((skill) => {
+      const coursesWithCurrentSkill = courses.filter(course => course.skillNames.includes(skill.key))
+        .slice(0, 3);
+      if (coursesWithCurrentSkill.length > 0) {
+        coursesWithSkill.push({
+          key: skill.key,
+          value: coursesWithCurrentSkill,
+        });
+      }
+    });
+    return coursesWithSkill;
+  }, [skillsWithSignificanceOrder]);
+
+  const partnerDetails = useMemo(
+    () => {
+      const partners = {};
+      courses.forEach((course) => {
+        if (!Object.keys(course).length || !isDefinedAndNotNull(course.partners)) {
+          partners[course.key] = {};
+        }
+        partners[course.key] = {
+          primaryPartner: course.partners.length > 0 ? course.partners[0] : undefined,
+          showPartnerLogo: course.partners.length === 1,
+        };
+      });
+      return partners;
+    },
+    [JSON.stringify(courses)],
+  );
+
+  return (
+    <div style={{ paddingLeft: '15%' }}>
+      {hitCount > 0 && <h3>Skills</h3>}
+      <div className="skills-badge">
+        {isLoading ? <Badge as={Skeleton} width={100} count={6} className="course-skill" variant="top" duration={0} height={25} />
+          : coursesWithSkills?.map(coursesWithSkill => (
+            <Badge
+              as={Link}
+              to={`/${enterpriseConfig.slug}/search?skill_names=${coursesWithSkill.key}`}
+              key={coursesWithSkill.key}
+              className="course-skill"
+              variant="light"
+            >
+              {coursesWithSkill.key}
+            </Badge>
+          )) }
+      </div>
+      {isLoading ? <CardLoadingSkeleton /> : coursesWithSkills?.map((coursesWithSkill) => (
+        <>
+          <h3> Top courses in {coursesWithSkill.key}</h3>
+          <div className="row col col-12 p-0">
+            <div className="skill-quiz-results align-items-l-between col col-xl-10">
+              {coursesWithSkill?.value.map((course) => (
+                <div
+                  className="search-result-card mb-4"
+                  role="group"
+                  aria-label={course.title}
+                  key={course.title}
+                >
+                  {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                  <Link to={isLoading ? '#' : linkToCourse(course, slug, uuid)}>
+                    <Card>
+                      {isLoading ? (
+                        <Card.Img
+                          as={Skeleton}
+                          variant="top"
+                          duration={0}
+                          height={100}
+                          data-testid="card-img-loading"
+                        />
+                      ) : (
+                        <Card.Img
+                          variant="top"
+                          src={course.cardImageUrl}
+                          alt=""
+                        />
+                      )}
+                      {isLoading && (
+                        <div className="partner-logo-wrapper">
+                          <Skeleton width={90} height={42} data-testid="partner-logo-loading" />
+                        </div>
+                      )}
+                      {(!isLoading
+                        && partnerDetails[course.key].primaryPartner && partnerDetails[course.key].showPartnerLogo) && (
+                        <div className="partner-logo-wrapper">
+                          <img
+                            src={partnerDetails[course.key].primaryPartner.logoImageUrl}
+                            className="partner-logo"
+                            alt={partnerDetails[course.key].primaryPartner.name}
+                          />
+                        </div>
+                      )}
+                      <Card.Body>
+                        <Card.Title as="h4" className="card-title mb-2">
+                          {isLoading ? (
+                            <Skeleton count={2} data-testid="course-title-loading" />
+                          ) : (
+                            <Truncate lines={course.skillNames?.length < 5 ? 3 : 2} trimWhitespace>
+                              {course.title}
+                            </Truncate>
+                          )}
+                        </Card.Title>
+                        {isLoading ? (
+                          <Skeleton duration={0} data-testid="partner-name-loading" />
+                        ) : (
+                          <>
+                            {course.partners.length > 0 && (
+                              <p className="partner text-muted m-0">
+                                <Truncate lines={2} trimWhitespace>
+                                  {course.partners.map(partner => partner.name)
+                                    .join(', ')}
+                                </Truncate>
+                              </p>
+                            )}
+                          </>
+                        )}
+                        {isLoading ? (
+                          <Skeleton count={1} data-testid="skills-loading" />
+                        ) : (
+                          <>
+                            {course.skillNames?.length > 0 && (
+                              <div className="mb-2 d-inline">
+                                {getCommonSkills(course, allSkills, MAX_VISIBLE_SKILLS_COURSE)
+                                  .map((skill) => (
+                                    <Badge
+                                      key={skill}
+                                      className="skill-badge"
+                                      variant="light"
+                                    >
+                                      {shortenString(skill, SKILL_NAME_CUTOFF_LIMIT, ELLIPSIS_STR)}
+                                    </Badge>
+                                  ))}
+                              </div>
+                            )}
+                          </>
+                        )}
+                      </Card.Body>
+                    </Card>
+                  </Link>
+                </div>
+              ))}
+            </div>
+            <Link
+              className="more-courses-link col col-2 text-muted"
+              to={`/${enterpriseConfig.slug}/search?skill_names=${coursesWithSkill.key}`}
+            >
+              See more courses
+            </Link>
+          </div>
+        </>
+      ))}
+      <div>
+        { hitCount === 0 && (
+          <StatusAlert
+            className="mt-4 mb-5"
+            alertType="info"
+            dialog={renderDialog()}
+            dismissible={false}
+            open
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+SkillsCourses.propTypes = {
+  index: PropTypes.shape({
+    appId: PropTypes.string,
+    indexName: PropTypes.string,
+    search: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+export default SkillsCourses;

--- a/src/components/skills-quiz/SkillsCourses.jsx
+++ b/src/components/skills-quiz/SkillsCourses.jsx
@@ -139,7 +139,7 @@ const SkillsCourses = ({ index }) => {
   );
 
   return (
-    <div style={{ paddingLeft: '15%' }}>
+    <div className="mt-4" style={{ paddingLeft: '15%' }}>
       {hitCount > 0 && <h3>Skills</h3>}
       <div className="skills-badge">
         {isLoading ? <Badge as={Skeleton} width={100} count={6} className="course-skill" variant="top" duration={0} height={25} />

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -23,13 +23,12 @@ import SearchCourseCard from './SearchCourseCard';
 import SearchProgramCard from './SearchProgramCard';
 import SelectJobCard from './SelectJobCard';
 import TagCloud from '../TagCloud';
+import SkillsCourses from './SkillsCourses';
 
-import { fixedEncodeURIComponent } from '../../utils/common';
 import { useDefaultSearchFilters } from '../search/data/hooks';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
-import { useSelectedSkillsAndJobSkills } from './data/hooks';
 import {
-  DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE, STEP1, STEP2, SKILLS_QUIZ_SEARCH_PAGE_MESSAGE,
+  DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE, STEP1, STEP2, STEP3, SKILLS_QUIZ_SEARCH_PAGE_MESSAGE,
 } from './constants';
 import { SkillsContext } from './SkillsContextProvider';
 import { SET_KEY_VALUE } from './data/constants';
@@ -71,30 +70,10 @@ const SkillsQuizStepper = () => {
     offerCatalogs,
   });
   const history = useHistory();
-  const selectedSkillsAndJobSkills = useSelectedSkillsAndJobSkills({ getAllSkills: true });
-  const getQueryParamString = () => {
-    if (selectedSkillsAndJobSkills) {
-      const queryParams = selectedSkillsAndJobSkills.map((skill) => `skill_names=${ fixedEncodeURIComponent(skill)}`);
-      return queryParams.join('&');
-    }
-    return '';
-  };
 
   const goalExceptImproveAndJobSelected = checkValidGoalAndJobSelected(goal, jobs, false);
   const improveGoalAndCurrentJobSelected = checkValidGoalAndJobSelected(goal, currentJob, true);
   const canContinueToRecommendedCourses = goalExceptImproveAndJobSelected || improveGoalAndCurrentJobSelected;
-  const handleSeeMoreButtonClick = () => {
-    const queryString = getQueryParamString();
-    const ENT_PATH = `/${enterpriseConfig.slug}`;
-    let SEARCH_PATH = queryString ? `${ENT_PATH}/search?${queryString}` : `${ENT_PATH}/search`;
-    SEARCH_PATH = SEARCH_PATH.replace(/\/\/+/g, '/'); // to remove duplicate slashes that can occur
-    history.push(SEARCH_PATH);
-    sendEnterpriseTrackEvent(
-      enterpriseConfig.uuid,
-      'edx.ui.enterprise.learner_portal.skills_quiz.see_more_courses.clicked',
-      { userId, enterprise: enterpriseConfig.slug },
-    );
-  };
 
   const closeSkillsQuiz = () => {
     history.push(`/${enterpriseConfig.slug}/search`);
@@ -271,7 +250,7 @@ const SkillsQuizStepper = () => {
                   }
                 </div>
               </Stepper.Step>
-              <Stepper.Step eventKey="recommended-courses" title="View Recommendations">
+              <Stepper.Step eventKey="courses-with-jobs" title="Recommended Courses With Jobs">
                 <div className="row mb-4 pl-2 mt-4">
                   <h2>Start Exploring Courses!</h2>
                 </div>
@@ -290,8 +269,13 @@ const SkillsQuizStepper = () => {
                   )}
                 </div>
                 <div className="row justify-content-center">
-                  <Button variant="outline-primary" onClick={handleSeeMoreButtonClick}>See more course recommendations</Button>
+                  <Button variant="outline-primary" onClick={() => setCurrentStep(STEP3)}>See more course recommendations</Button>
                 </div>
+              </Stepper.Step>
+            </Container>
+            <Container size="xl">
+              <Stepper.Step eventKey="courses-with-skills" title="Recommended Courses With Skills">
+                <SkillsCourses index={courseIndex} />
               </Stepper.Step>
             </Container>
           </ModalDialog.Body>
@@ -307,8 +291,15 @@ const SkillsQuizStepper = () => {
               >Continue
               </Button>
             </Stepper.ActionRow>
-            <Stepper.ActionRow eventKey="recommended-courses">
+            <Stepper.ActionRow eventKey="courses-with-jobs">
               <Button variant="outline-primary" onClick={() => setCurrentStep(STEP1)}>
+                Go back
+              </Button>
+              <Stepper.ActionRow.Spacer />
+              <Button onClick={() => setCurrentStep(STEP3)}>Continue</Button>
+            </Stepper.ActionRow>
+            <Stepper.ActionRow eventKey="courses-with-skills">
+              <Button variant="outline-primary" onClick={() => setCurrentStep(STEP2)}>
                 Go back
               </Button>
               <Stepper.ActionRow.Spacer />

--- a/src/components/skills-quiz/constants.js
+++ b/src/components/skills-quiz/constants.js
@@ -42,10 +42,12 @@ export const DESIRED_JOB_FACET = {
 export const JOBS_ERROR_ALERT_MESSAGE = 'An error occured while fetching your selected job. Please try again later.';
 export const COURSES_ERROR_ALERT_MESSAGE = 'An error occured while fetching courses. Please try again later.';
 export const NO_COURSES_ALERT_MESSAGE = 'No courses were found. Please search for another job, or click see more courses.';
+export const NO_COURSES_ALERT_MESSAGE_AGAINST_SKILLS = 'No courses were found. Please search for another job or skills.';
 export const NO_PROGRAMS_ALERT_MESSAGE = 'No programs were found. Please search for another job, or click see more courses.';
 
 export const STEP1 = 'skills-search';
-export const STEP2 = 'recommended-courses';
+export const STEP2 = 'courses-with-jobs';
+export const STEP3 = 'courses-with-skills';
 
 export const SKILL_NAME_CUTOFF_LIMIT = 50;
 
@@ -54,3 +56,5 @@ export const MAX_VISIBLE_SKILLS_COURSE = 6;
 export const MAX_VISIBLE_SKILLS_PROGRAM = 3;
 
 export const SKILLS_QUIZ_SEARCH_PAGE_MESSAGE = 'Let edX be your guide. We combine the educational expertise of the world\'s leading institutions with labor market data to find the right course(s) and program(s) to help you reach your learning and professional goals.';
+export const HITS_PER_PAGE = 500;
+export const LOADING_NO_OF_CARDS = 9;

--- a/src/components/skills-quiz/data/tests/hooks.test.jsx
+++ b/src/components/skills-quiz/data/tests/hooks.test.jsx
@@ -17,6 +17,10 @@ const SearchWrapper = (searchContext, initialSkillsState) => ({ children }) => (
 const skills = ['test-skill-1', 'test-skill-2'];
 const SELECTED_JOB_SKILL_NAME = 'test-skill-3';
 const CURRENT_JOB_SKILL_NAME = 'test-skill-4';
+const SELECTED_JOB_SKILL_NAME_ONE = 'selected-skill-1';
+const SELECTED_JOB_SKILL_NAME_TWO = 'selected-skill-2';
+const SELECTED_JOB_SKILL_NAME_THREE = 'selected-skill-3';
+const SELECTED_JOB_SKILL_NAME_FOUR = 'selected-skill-4';
 const searchContext = {
   refinements: { skill_names: skills },
 };
@@ -80,6 +84,102 @@ describe('useSelectedSkillsAndJobSkills hook', () => {
     }), { wrapper: SearchWrapper(searchContext, skillsContextWithCurrentRole) });
     const skillsArray = result.current;
     const expected = [CURRENT_JOB_SKILL_NAME];
+    expect(skillsArray).toEqual(expected);
+  });
+
+  test('with getAllSkillsWithSignificanceOrder true, returns learner selected skills and'
+    + ' job-skills with significance order', () => {
+    const skillsContextWithSignificanceOrder = {
+      state: {
+        goal: DROPDOWN_OPTION_GET_PROMOTED,
+        selectedJob: 'job-1',
+        interestedJobs: [
+          {
+            name: 'job-1',
+            skills: [
+              {
+                name: SELECTED_JOB_SKILL_NAME_ONE,
+                significance: 230,
+              },
+              {
+                name: SELECTED_JOB_SKILL_NAME_TWO,
+                significance: 400,
+              },
+              {
+                name: SELECTED_JOB_SKILL_NAME_THREE,
+                significance: 120,
+              },
+              {
+                name: SELECTED_JOB_SKILL_NAME_FOUR,
+                significance: 401,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const { result } = renderHook(() => useSelectedSkillsAndJobSkills({
+      getAllSkills: false,
+      getAllSkillsWithSignificanceOrder: true,
+    }), { wrapper: SearchWrapper(searchContext, skillsContextWithSignificanceOrder) });
+
+    const skillsArray = result.current;
+    const expected = [
+      { key: SELECTED_JOB_SKILL_NAME_FOUR, value: 401 },
+      { key: SELECTED_JOB_SKILL_NAME_TWO, value: 400 },
+      { key: SELECTED_JOB_SKILL_NAME_ONE, value: 230 },
+      { key: SELECTED_JOB_SKILL_NAME_THREE, value: 120 },
+      { key: 'test-skill-1', value: undefined },
+      { key: 'test-skill-2', value: undefined },
+    ];
+    expect(skillsArray).toEqual(expected);
+  });
+
+  test('with getAllSkillsWithSignificanceOrder true, returns learner selected skills and'
+    + ' job-skills for current job with significance order', () => {
+    const skillsContextWithSignificanceOrder = {
+      state: {
+        goal: DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE,
+        selectedJob: 'job-1',
+        currentJobRole: [
+          {
+            name: 'job-1',
+            skills: [
+              {
+                name: SELECTED_JOB_SKILL_NAME_ONE,
+                significance: 230,
+              },
+              {
+                name: SELECTED_JOB_SKILL_NAME_TWO,
+                significance: 400,
+              },
+              {
+                name: SELECTED_JOB_SKILL_NAME_THREE,
+                significance: 820,
+              },
+              {
+                name: SELECTED_JOB_SKILL_NAME_FOUR,
+                significance: 401,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const { result } = renderHook(() => useSelectedSkillsAndJobSkills({
+      getAllSkills: false,
+      getAllSkillsWithSignificanceOrder: true,
+    }), { wrapper: SearchWrapper(searchContext, skillsContextWithSignificanceOrder) });
+
+    const skillsArray = result.current;
+    const expected = [
+      { key: SELECTED_JOB_SKILL_NAME_THREE, value: 820 },
+      { key: SELECTED_JOB_SKILL_NAME_FOUR, value: 401 },
+      { key: SELECTED_JOB_SKILL_NAME_TWO, value: 400 },
+      { key: SELECTED_JOB_SKILL_NAME_ONE, value: 230 },
+      { key: 'test-skill-1', value: undefined },
+      { key: 'test-skill-2', value: undefined },
+    ];
     expect(skillsArray).toEqual(expected);
   });
 });

--- a/src/components/skills-quiz/data/utils.jsx
+++ b/src/components/skills-quiz/data/utils.jsx
@@ -1,6 +1,32 @@
 // get common skills between a course/program and the job selected by the learner
 // here content can either be a course or a program
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
+import qs from 'query-string';
+
 export default function getCommonSkills(content, selectedJobSkills, MAX_VISIBLE_SKILLS) {
   const contentSkills = content.skillNames || [];
   return contentSkills.filter(skill => selectedJobSkills.includes(skill)).slice(0, MAX_VISIBLE_SKILLS);
+}
+
+export function sortSkillsWithSignificance(job) {
+  return job?.skills?.sort((a, b) => (
+    (a.significance < b.significance) ? 1 : -1));
+}
+
+export function linkToCourse(course, slug, enterpriseUUID) {
+  if (!Object.keys(course).length) {
+    return '#';
+  }
+  const queryParams = {
+    queryId: course.queryId,
+    objectId: course.objectId,
+  };
+  const { userId } = getAuthenticatedUser();
+  sendEnterpriseTrackEvent(
+    enterpriseUUID,
+    'edx.ui.enterprise.learner_portal.skills_quiz.course.clicked',
+    { userId, enterprise: slug, selectedCourse: course.key },
+  );
+  return `/${slug}/course/${course.key}?${qs.stringify(queryParams)}`;
 }

--- a/src/components/skills-quiz/styles/_SearchContentCard.scss
+++ b/src/components/skills-quiz/styles/_SearchContentCard.scss
@@ -81,3 +81,14 @@
  flex-direction: row;
  column-gap: 1.0rem;
 }
+
+.more-courses-link {
+  float: right;
+  align-self: center;
+  text-decoration: underline;
+}
+
+.skills-badge {
+  margin-bottom: 30px;
+}
+

--- a/src/components/skills-quiz/tests/SkillsCourses.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsCourses.test.jsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { screen, act } from '@testing-library/react';
+import { AppContext } from '@edx/frontend-platform/react';
+import '@testing-library/jest-dom/extend-expect';
+import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
+import { UserSubsidyContext } from '../../enterprise-user-subsidy';
+import SkillsCourses from '../SkillsCourses';
+
+import { renderWithRouter } from '../../../utils/tests';
+import { TEST_IMAGE_URL, TEST_ENTERPRISE_SLUG } from '../../search/tests/constants';
+import { NO_COURSES_ALERT_MESSAGE_AGAINST_SKILLS } from '../constants';
+import { SkillsContext } from '../SkillsContextProvider';
+
+jest.mock('@edx/frontend-platform/auth', () => ({
+  ...jest.requireActual('@edx/frontend-platform/auth'),
+  getAuthenticatedUser: () => ({ username: 'myspace-tom' }),
+}));
+
+jest.mock('@edx/frontend-enterprise-utils', () => ({
+  ...jest.requireActual('@edx/frontend-enterprise-utils'),
+  sendEnterpriseTrackEvent: jest.fn(),
+}));
+
+jest.mock('react-truncate', () => ({
+  __esModule: true,
+  default: ({ children }) => children,
+}));
+
+jest.mock('react-loading-skeleton', () => ({
+  __esModule: true,
+  // eslint-disable-next-line react/prop-types
+  default: (props = {}) => <div data-testid={props['data-testid']} />,
+}));
+
+/* eslint-disable react/prop-types */
+const SkillsCoursesWithContext = ({
+  initialAppState,
+  initialSkillsState,
+  initialUserSubsidyState,
+  searchContext,
+  index,
+}) => (
+  <AppContext.Provider value={initialAppState}>
+    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+      <SearchContext.Provider value={searchContext}>
+        <SkillsContext.Provider value={initialSkillsState}>
+          <SkillsCourses index={index} />
+        </SkillsContext.Provider>
+      </SearchContext.Provider>
+    </UserSubsidyContext.Provider>
+  </AppContext.Provider>
+);
+/* eslint-enable react/prop-types */
+
+const TEST_COURSE_KEY = 'test-course-key';
+const SKILLS_HEADING = 'Skills';
+const TEST_TITLE = 'Test Title';
+const TEST_CARD_IMG_URL = 'http://fake.image';
+const TEST_PARTNER = {
+  name: 'Partner Name',
+  logo_image_url: TEST_IMAGE_URL,
+};
+
+const courses = {
+  hits: [
+    {
+      key: TEST_COURSE_KEY,
+      title: TEST_TITLE,
+      card_image_url: TEST_CARD_IMG_URL,
+      partners: [TEST_PARTNER],
+      skill_names: ['test-skill-1'],
+    },
+  ],
+  nbHits: 1,
+};
+
+const testIndex = {
+  indexName: 'test-index-name',
+  search: jest.fn().mockImplementation(() => Promise.resolve(courses)),
+};
+
+const initialAppState = {
+  enterpriseConfig: {
+    slug: 'test-enterprise-slug',
+  },
+};
+
+const searchContext = {
+  refinements: { skill_names: ['test-skill-3'] },
+  dispatch: () => null,
+};
+
+const initialSkillsState = {
+  state: {
+    goal: 'Goal',
+    selectedJob: 'job-1',
+    interestedJobs: [
+      {
+        name: 'job-1',
+        skills: [
+          {
+            name: 'test-skill-1',
+          },
+          {
+            name: 'test-skill-2',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const defaultOffersState = {
+  offers: [],
+  loading: false,
+  offersCount: 0,
+};
+
+const initialUserSubsidyState = {
+  offers: defaultOffersState,
+};
+
+describe('<SkillsCourses />', () => {
+  test('renders the correct data', async () => {
+    let containerDOM = {};
+    await act(async () => {
+      const { container } = renderWithRouter(
+        <SkillsCoursesWithContext
+          initialAppState={initialAppState}
+          initialSkillsState={initialSkillsState}
+          initialUserSubsidyState={initialUserSubsidyState}
+          index={testIndex}
+          searchContext={searchContext}
+        />,
+      );
+      containerDOM = container;
+    });
+
+    expect(screen.getByText(SKILLS_HEADING)).toBeInTheDocument();
+    expect(screen.getByAltText(TEST_PARTNER.name)).toBeInTheDocument();
+
+    expect(containerDOM.querySelector('.search-result-card > a')).toHaveAttribute(
+      'href',
+      `/${TEST_ENTERPRISE_SLUG}/course/${TEST_COURSE_KEY}`,
+    );
+    expect(containerDOM.querySelector('p.partner')).toHaveTextContent(TEST_PARTNER.name);
+    expect(containerDOM.querySelector('.card-img-top')).toHaveAttribute('src', TEST_CARD_IMG_URL);
+  });
+
+  test('renders an alert in case of no courses returned', async () => {
+    const noCourses = {
+      hits: [],
+      nbHits: 0,
+    };
+    const courseIndex = {
+      indexName: 'test-index-name',
+      search: jest.fn().mockImplementation(() => Promise.resolve(noCourses)),
+    };
+    await act(async () => {
+      renderWithRouter(
+        <SkillsCoursesWithContext
+          initialAppState={initialAppState}
+          initialSkillsState={initialSkillsState}
+          initialUserSubsidyState={initialUserSubsidyState}
+          index={courseIndex}
+          searchContext={searchContext}
+        />,
+      );
+    });
+    expect(screen.getByText(NO_COURSES_ALERT_MESSAGE_AGAINST_SKILLS)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
**Tickets**: [ENT5275](https://openedx.atlassian.net/browse/ENT-5275), [ENT5276](https://openedx.atlassian.net/browse/ENT-5276)
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change
<img width="1671" alt="Screenshot 2022-01-25 at 2 17 06 PM" src="https://user-images.githubusercontent.com/11922730/150948034-c78c4cd2-2fb2-4b13-b2e9-10b207a06917.png">



- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
