### PR TITLE
fix: fix course enrollments useMemo bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13636,6 +13636,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "history": "4.10.1",
     "iso-639-1": "2.1.4",
     "lodash.camelcase": "4.3.0",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "moment": "2.29.1",
     "prop-types": "15.7.2",

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -58,7 +58,7 @@ const CourseEnrollments = ({ children }) => {
 
   const savedForLaterCourseEnrollments = useMemo(
     () => sortedEnrollmentsByEnrollmentDate(courseEnrollmentsByStatus.savedForLater),
-    [courseEnrollmentsByStatus.savedCourseEnrollments],
+    [courseEnrollmentsByStatus.savedForLater],
   );
 
   return (

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -4,6 +4,7 @@ import {
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { logError } from '@edx/frontend-platform/logging';
 import _camelCase from 'lodash.camelcase';
+import _cloneDeep from 'lodash.clonedeep';
 import * as service from './service';
 import { groupCourseEnrollmentsByStatus, transformCourseEnrollment } from './utils';
 
@@ -37,7 +38,7 @@ export const useCourseEnrollments = (enterpriseUUID) => {
     const originalStatusCamelCased = _camelCase(originalStatus);
     const newStatusCamelCased = _camelCase(newStatus);
 
-    const newCourseEnrollmentsByStatus = { ...courseEnrollmentsByStatus };
+    const newCourseEnrollmentsByStatus = _cloneDeep(courseEnrollmentsByStatus);
     const courseEnrollmentToUpdate = newCourseEnrollmentsByStatus[originalStatusCamelCased].find(
       ce => ce.courseRunId === courseRunId,
     );


### PR DESCRIPTION
Current enrollments accordion was not updating because the dependency array for usememo was pointing to the same array reference. Deep cloning courseEnrollmentsByStatus as a solution. Also fix a blatant typo.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
