### PR TITLE
fix: update styles for course title in enrollment cards

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -293,13 +293,14 @@ class BaseCourseCard extends Component {
         <div className="d-flex">
           <div className="flex-grow-1 mr-4 mb-3">
             {this.renderMicroMastersTitle()}
-            <div className="d-flex align-items-center flex-wrap mb-1">
+            <div className="d-flex align-items-start justify-content-between mb-1">
               <h4 className="course-title mb-0 mr-2">
                 <a className="h3" href={linkToCourse}>{title}</a>
               </h4>
               {
                 BADGE_PROPS_BY_COURSE_STATUS[type] && (
                   <Badge
+                    className="mt-1"
                     {...BADGE_PROPS_BY_COURSE_STATUS[type]}
                   />
                 )


### PR DESCRIPTION
# Description

When the course title takes up more than 1 line, the enrollment status badge (e.g., "In Progress") also drops down to the 2nd+ line, which results in the badge kind of appearing randomly throughout the UI rather than in a cohesive fixed location within the course enrollment cards.

This PR changes the styles slightly to make it such that the badge stays fixed to the top right at all times, regardless of course title.

## Before

![image](https://user-images.githubusercontent.com/2828721/152592683-a8f780ea-dc18-4322-b333-91c8529f0078.png)

## After

![image](https://user-images.githubusercontent.com/2828721/152592581-56de8766-5788-4a45-8a21-d0dc97ca3460.png)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
