### PR TITLE
fix: Center align content in step 2 of skills quiz

### DIFF
--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -269,22 +269,23 @@ const SkillsQuizStepper = () => {
                 </div>
               </Stepper.Step>
               <Stepper.Step eventKey="courses-with-jobs" title="Recommended Courses With Jobs">
-                <div className="row mb-4 pl-2 mt-4">
-                  <h2>Start Exploring Courses!</h2>
-                </div>
-                <div className="search-job-card mb-4">
-                  { canContinueToRecommendedCourses ? <SelectJobCard /> : null}
-                </div>
-                <SelectedJobSkills />
-                <div>
-                  { (selectedJob || skills || goal === DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE)
-                  && (
-                    <div>
-                      <SearchCourseCard index={courseIndex} />
-                      <SearchProgramCard index={courseIndex} />
-                    </div>
-
-                  )}
+                <div style={{ paddingLeft: '10%' }}>
+                  <div className="row mb-4 pl-2 mt-4">
+                    <h2>Start Exploring Courses!</h2>
+                  </div>
+                  <div className="search-job-card mb-4">
+                    { canContinueToRecommendedCourses ? <SelectJobCard /> : null}
+                  </div>
+                  <SelectedJobSkills />
+                  <div>
+                    { (selectedJob || skills || goal === DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE)
+                      && (
+                        <div>
+                          <SearchCourseCard index={courseIndex} />
+                          <SearchProgramCard index={courseIndex} />
+                        </div>
+                      )}
+                  </div>
                 </div>
                 <div className="row justify-content-center">
                   <Button variant="outline-primary" onClick={() => setCurrentStep(STEP3)}>See more course recommendations</Button>


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-5374

**Changes**: Added an outer `<div>` to center align all elements in step 2 of skills-quiz 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots


**BEFORE:**
<img width="1440" alt="Screenshot 2022-02-11 at 1 13 31 PM" src="https://user-images.githubusercontent.com/55431213/153557613-3b71bbcc-21ea-412b-a77b-de70225ca790.png">


**AFTER:**
<img width="1440" alt="Screenshot 2022-02-11 at 1 13 09 PM" src="https://user-images.githubusercontent.com/55431213/153557641-c446c179-24d6-42fc-a622-ce55ae899406.png">

<img width="1440" alt="Screenshot 2022-02-11 at 1 15 04 PM" src="https://user-images.githubusercontent.com/55431213/153557740-2cf2ae9b-6b81-469e-b0cf-e0c2a162975f.png">
