### PR TITLE
fix: when logging out, enable user to stay on logged out page ENT-5369

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3766,6 +3766,15 @@
         "@types/testing-library__react-hooks": "^3.4.0"
       }
     },
+    "@testing-library/user-event": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@testing-library/jest-dom": "5.11.9",
     "@testing-library/react": "11.2.7",
     "@testing-library/react-hooks": "3.7.0",
+    "@testing-library/user-event": "^13.5.0",
     "acorn": "^8.5.0",
     "axios-mock-adapter": "1.19.0",
     "coveralls": "3.1.0",

--- a/src/components/app/AuthenticatedPage.jsx
+++ b/src/components/app/AuthenticatedPage.jsx
@@ -37,9 +37,8 @@ export default function AuthenticatedPage({ children, useEnterpriseConfigCache }
     return (
       <ErrorPage title="You are now logged out." showSiteFooter={false}>
         Please log back in {' '}
-        <Hyperlink
-          destination={`${config.BASE_URL}/${enterpriseSlug}`}
-        >here
+        <Hyperlink destination={`${config.BASE_URL}/${enterpriseSlug}`}>
+          here.
         </Hyperlink>
       </ErrorPage>
     );

--- a/src/components/app/AuthenticatedPage.jsx
+++ b/src/components/app/AuthenticatedPage.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Cookies from 'universal-cookie';
+import { useParams, useLocation } from 'react-router-dom';
+
 import { LoginRedirect } from '@edx/frontend-enterprise-logistration';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 import { Hyperlink } from '@edx/paragon';
-import { useParams } from 'react-router-dom';
 import { EnterprisePage } from '../enterprise-page';
 import { EnterpriseBanner } from '../enterprise-banner';
 import { Layout } from '../layout';
@@ -13,7 +14,8 @@ import LoginRefresh from './LoginRefresh';
 import { ErrorPage } from '../error-page';
 
 export default function AuthenticatedPage({ children, useEnterpriseConfigCache }) {
-  const params = new URLSearchParams(document.location.search);
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
   const { enterpriseSlug } = useParams();
   const isLogoutWorkflow = params.get('logout');
   const config = getConfig();
@@ -29,9 +31,11 @@ export default function AuthenticatedPage({ children, useEnterpriseConfigCache }
 
   // in the special case where there is not authenticated user and we are being told it's the logout
   // flow, we can show the logout message safely
+  // not rendering the SiteFooter here since it looks like it requires additional setup
+  // not available in the logged out state (errors with InjectIntl errors)
   if (!user && isLogoutWorkflow) {
     return (
-      <ErrorPage title="You are now logged out.">
+      <ErrorPage title="You are now logged out." showSiteFooter={false}>
         Please log back in {' '}
         <Hyperlink
           destination={`${config.BASE_URL}/${enterpriseSlug}`}

--- a/src/components/app/AuthenticatedPage.jsx
+++ b/src/components/app/AuthenticatedPage.jsx
@@ -4,13 +4,18 @@ import Cookies from 'universal-cookie';
 import { LoginRedirect } from '@edx/frontend-enterprise-logistration';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
-
+import { Hyperlink } from '@edx/paragon';
+import { useParams } from 'react-router-dom';
 import { EnterprisePage } from '../enterprise-page';
 import { EnterpriseBanner } from '../enterprise-banner';
 import { Layout } from '../layout';
 import LoginRefresh from './LoginRefresh';
+import { ErrorPage } from '../error-page';
 
 export default function AuthenticatedPage({ children, useEnterpriseConfigCache }) {
+  const params = new URLSearchParams(document.location.search);
+  const { enterpriseSlug } = useParams();
+  const isLogoutWorkflow = params.get('logout');
   const config = getConfig();
   const user = getAuthenticatedUser();
 
@@ -22,6 +27,19 @@ export default function AuthenticatedPage({ children, useEnterpriseConfigCache }
     cookies.remove(config.INTEGRATION_WARNING_DISMISSED_COOKIE_NAME);
   }
 
+  // in the special case where there is not authenticated user and we are being told it's the logout
+  // flow, we can show the logout message safely
+  if (!user && isLogoutWorkflow) {
+    return (
+      <ErrorPage title="You are now logged out.">
+        Please log back in {' '}
+        <Hyperlink
+          destination={`${config.BASE_URL}/${enterpriseSlug}`}
+        >here
+        </Hyperlink>
+      </ErrorPage>
+    );
+  }
   return (
     <LoginRedirect>
       <LoginRefresh>

--- a/src/components/app/AuthenticatedPage.test.jsx
+++ b/src/components/app/AuthenticatedPage.test.jsx
@@ -18,7 +18,7 @@ describe('AuthenticatedPage tests', () => {
   test('page shows logout component when logout mode is detected and user is logged off', () => {
     render(
       <AuthenticatedPage>
-        <div>Your Child, I am but I won{'\''}t be rendered!</div>
+        <div>Your Child, I am but I won&apos;t be rendered!</div>
       </AuthenticatedPage>,
     );
     expect(screen.getByText('You are now logged out.')).toBeInTheDocument();

--- a/src/components/app/AuthenticatedPage.test.jsx
+++ b/src/components/app/AuthenticatedPage.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import AuthenticatedPage from './AuthenticatedPage';
+
+jest.mock('@edx/frontend-platform/auth', () => ({
+  ...jest.requireActual('@edx/frontend-platform/auth'),
+  getAuthenticatedUser: () => undefined,
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn().mockReturnValue({ search: '?logout=true', pathname: '/test-enterprise-slug' }),
+  useParams: jest.fn().mockReturnValue({ enterpriseSlug: 'test-enterprise-slug' }),
+}));
+
+describe('AuthenticatedPage tests', () => {
+  test('page shows logout component when logout mode is detected and user is logged off', () => {
+    render(
+      <AuthenticatedPage>
+        <div>Your Child, I am but I won{'\''}t be rendered!</div>
+      </AuthenticatedPage>,
+    );
+    expect(screen.getByText('You are now logged out.')).toBeInTheDocument();
+  });
+});

--- a/src/components/error-page/ErrorPage.jsx
+++ b/src/components/error-page/ErrorPage.jsx
@@ -15,6 +15,7 @@ import ErrorPageHeader from './ErrorPageHeader';
 const ErrorPage = ({
   title,
   subtitle,
+  showSiteFooter,
   children,
 }) => (
   <>
@@ -32,7 +33,7 @@ const ErrorPage = ({
         </Col>
       </Container>
     </main>
-    <SiteFooter />
+    {showSiteFooter && <SiteFooter />}
   </>
 );
 
@@ -40,11 +41,13 @@ ErrorPage.propTypes = {
   children: PropTypes.node.isRequired,
   title: PropTypes.node,
   subtitle: PropTypes.node,
+  showSiteFooter: PropTypes.bool,
 };
 
 ErrorPage.defaultProps = {
   title: 'Error occurred while processing your request',
   subtitle: null,
+  showSiteFooter: true,
 };
 
 export default ErrorPage;

--- a/src/components/error-page/ErrorPageHeader.jsx
+++ b/src/components/error-page/ErrorPageHeader.jsx
@@ -37,7 +37,7 @@ const ErrorPageHeader = () => {
               Help
             </a>
             {/* this section makes sense only if the user is logged in */}
-            { username && (
+            {username && (
               <Dropdown>
                 <Dropdown.Toggle showLabel as={AvatarButton} src={profileImage?.imageUrlMedium}>
                   {username}

--- a/src/components/error-page/ErrorPageHeader.jsx
+++ b/src/components/error-page/ErrorPageHeader.jsx
@@ -12,11 +12,14 @@ import { getConfig } from '@edx/frontend-platform/config';
 /**
  * React component for the invite page error case. Renders a minimal header
  * with just a logo that is not linked.
+ *
+ * This component also acts as a message page for the logout case, hence adding some checks for
+ * non existent variables.
  */
 const ErrorPageHeader = () => {
   const config = getConfig();
   const authenticatedUser = getAuthenticatedUser();
-  const { username, profileImage } = authenticatedUser;
+  const { username, profileImage } = authenticatedUser || { username: '', profileImage: '' };
 
   return (
     <header>
@@ -33,17 +36,20 @@ const ErrorPageHeader = () => {
             <a href={config.LEARNER_SUPPORT_URL} className="text-gray-700 mr-3">
               Help
             </a>
-            <Dropdown>
-              <Dropdown.Toggle showLabel as={AvatarButton} src={profileImage.imageUrlMedium}>
-                {username}
-              </Dropdown.Toggle>
-              <Dropdown.Menu
-                style={{ maxWidth: 280 }}
-                alignRight
-              >
-                <Dropdown.Item href={`${config.LOGOUT_URL}?next=${global.location}`}>Sign out</Dropdown.Item>
-              </Dropdown.Menu>
-            </Dropdown>
+            {/* this section makes sense only if the user is logged in */}
+            { username && (
+              <Dropdown>
+                <Dropdown.Toggle showLabel as={AvatarButton} src={profileImage?.imageUrlMedium}>
+                  {username}
+                </Dropdown.Toggle>
+                <Dropdown.Menu
+                  style={{ maxWidth: 280 }}
+                  alignRight
+                >
+                  <Dropdown.Item href={`${config.LOGOUT_URL}?next=${global.location}`}>Sign out</Dropdown.Item>
+                </Dropdown.Menu>
+              </Dropdown>
+            )}
           </nav>
         </Container>
       </Navbar>

--- a/src/components/error-page/__snapshots__/ErrorPage.test.jsx.snap
+++ b/src/components/error-page/__snapshots__/ErrorPage.test.jsx.snap
@@ -29,24 +29,6 @@ Array [
           >
             Help
           </a>
-          <div
-            className="dropdown"
-          >
-            <button
-              aria-expanded={false}
-              aria-haspopup={true}
-              className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                className="pgn__avatar pgn__avatar-sm"
-                src="htts://img.url"
-              />
-            </button>
-          </div>
         </nav>
       </div>
     </nav>
@@ -109,24 +91,6 @@ Array [
           >
             Help
           </a>
-          <div
-            className="dropdown"
-          >
-            <button
-              aria-expanded={false}
-              aria-haspopup={true}
-              className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                className="pgn__avatar pgn__avatar-sm"
-                src="htts://img.url"
-              />
-            </button>
-          </div>
         </nav>
       </div>
     </nav>
@@ -189,24 +153,6 @@ Array [
           >
             Help
           </a>
-          <div
-            className="dropdown"
-          >
-            <button
-              aria-expanded={false}
-              aria-haspopup={true}
-              className="btn-avatar pgn__avatar-button-avatar pgn__avatar-button-avatar-md dropdown-toggle btn btn-tertiary btn-md"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <img
-                alt=""
-                className="pgn__avatar pgn__avatar-sm"
-                src="htts://img.url"
-              />
-            </button>
-          </div>
         </nav>
       </div>
     </nav>

--- a/src/components/site-header/AvatarDropdown.jsx
+++ b/src/components/site-header/AvatarDropdown.jsx
@@ -15,9 +15,12 @@ const AvatarDropdown = ({ showLabel }) => {
   const { enterpriseConfig, authenticatedUser } = useContext(AppContext);
   const { username, profileImage } = authenticatedUser;
   const enterpriseDashboardLink = `/${enterpriseConfig.slug}`;
+
+  const idpPresent = enterpriseConfig.identity_providers.length > 0;
   // we insert the logout=true in this case to avoid the redirect back to IDP
   // which brings the user right back in, disallowing a proper logout
-  const nextURL = `${BASE_URL}${enterpriseDashboardLink}${encodeURIComponent('?')}logout=true`;
+  const logoutHint = idpPresent ? `${encodeURIComponent('?')}logout=true` : '';
+  const nextURL = `${BASE_URL}${enterpriseDashboardLink}${logoutHint}`;
   const logoutUrl = `${LOGOUT_URL}?next=${nextURL}`;
   return (
     <Dropdown>

--- a/src/components/site-header/AvatarDropdown.jsx
+++ b/src/components/site-header/AvatarDropdown.jsx
@@ -4,6 +4,7 @@ import { NavLink } from 'react-router-dom';
 import { getConfig } from '@edx/frontend-platform/config';
 import { AppContext } from '@edx/frontend-platform/react';
 import { AvatarButton, Dropdown } from '@edx/paragon';
+import { isDefinedAndNotNull } from '../../utils/common';
 
 const AvatarDropdown = ({ showLabel }) => {
   const {
@@ -16,7 +17,7 @@ const AvatarDropdown = ({ showLabel }) => {
   const { username, profileImage } = authenticatedUser;
   const enterpriseDashboardLink = `/${enterpriseConfig.slug}`;
 
-  const idpPresent = enterpriseConfig.identity_providers.length > 0;
+  const idpPresent = isDefinedAndNotNull(enterpriseConfig.identityProvider);
   // we insert the logout=true in this case to avoid the redirect back to IDP
   // which brings the user right back in, disallowing a proper logout
   const logoutHint = idpPresent ? `${encodeURIComponent('?')}logout=true` : '';

--- a/src/components/site-header/AvatarDropdown.jsx
+++ b/src/components/site-header/AvatarDropdown.jsx
@@ -21,8 +21,8 @@ const AvatarDropdown = ({ showLabel }) => {
   // we insert the logout=true in this case to avoid the redirect back to IDP
   // which brings the user right back in, disallowing a proper logout
   const logoutHint = idpPresent ? `${encodeURIComponent('?')}logout=true` : '';
-  const nextURL = `${BASE_URL}${enterpriseDashboardLink}${logoutHint}`;
-  const logoutUrl = `${LOGOUT_URL}?next=${nextURL}`;
+  const nextUrl = `${BASE_URL}${enterpriseDashboardLink}${logoutHint}`;
+  const logoutUrl = `${LOGOUT_URL}?next=${nextUrl}`;
   return (
     <Dropdown>
       <Dropdown.Toggle showLabel={showLabel} as={AvatarButton} src={profileImage.imageUrlMedium}>

--- a/src/components/site-header/AvatarDropdown.jsx
+++ b/src/components/site-header/AvatarDropdown.jsx
@@ -15,6 +15,10 @@ const AvatarDropdown = ({ showLabel }) => {
   const { enterpriseConfig, authenticatedUser } = useContext(AppContext);
   const { username, profileImage } = authenticatedUser;
   const enterpriseDashboardLink = `/${enterpriseConfig.slug}`;
+  // we insert the logout=true in this case to avoid the redirect back to IDP
+  // which brings the user right back in, disallowing a proper logout
+  const nextURL = `${BASE_URL}${enterpriseDashboardLink}${encodeURIComponent('?')}logout=true`;
+  const logoutUrl = `${LOGOUT_URL}?next=${nextURL}`;
   return (
     <Dropdown>
       <Dropdown.Toggle showLabel={showLabel} as={AvatarButton} src={profileImage.imageUrlMedium}>
@@ -43,7 +47,7 @@ const AvatarDropdown = ({ showLabel }) => {
         <Dropdown.Item href={`${LMS_BASE_URL}/account/settings`}>Account settings</Dropdown.Item>
         <Dropdown.Item href={LEARNER_SUPPORT_URL}>Help</Dropdown.Item>
         <Dropdown.Divider className="border-light" />
-        <Dropdown.Item href={`${LOGOUT_URL}?next=${BASE_URL}${enterpriseDashboardLink}`}>Sign out</Dropdown.Item>
+        <Dropdown.Item href={logoutUrl}>Sign out</Dropdown.Item>
       </Dropdown.Menu>
     </Dropdown>
   );

--- a/src/components/site-header/tests/SiteHeader.test.jsx
+++ b/src/components/site-header/tests/SiteHeader.test.jsx
@@ -79,4 +79,22 @@ describe('<SiteHeader />', () => {
     // note: the values of these come from the process.env vars in setupTest.js
     expect(logoutLink.getAttribute('href')).toBe('http://localhost:18000/logout?next=http://localhost:8734/bears-r-us');
   });
+  test('renders logout-specific logout link in presence of IDP', () => {
+    const appStateWithIDP = {
+      ...appState,
+      enterpriseConfig: {
+        ...appState.enterpriseConfig,
+        identityProvider: 'a-provider',
+      },
+    };
+    renderWithRouter(
+      <SiteHeaderWithContext initialAppState={appStateWithIDP} />,
+    );
+
+    userEvent.click(screen.getByText('papa'));
+    expect(screen.getByText('Sign out')).toBeInTheDocument();
+    const logoutLink = screen.getByText('Sign out');
+    // note: the values of these come from the process.env vars in setupTest.js
+    expect(logoutLink.getAttribute('href')).toBe('http://localhost:18000/logout?next=http://localhost:8734/bears-r-us%3Flogout=true');
+  });
 });

--- a/src/components/site-header/tests/SiteHeader.test.jsx
+++ b/src/components/site-header/tests/SiteHeader.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { breakpoints } from '@edx/paragon';
+import userEvent from '@testing-library/user-event';
 
 import { AppContext } from '@edx/frontend-platform/react';
 import SiteHeader from '../SiteHeader';
@@ -66,5 +67,16 @@ describe('<SiteHeader />', () => {
     );
     expect(screen.getByTestId('header-logo-image-id'));
     expect(screen.queryByTestId('header-logo-link-id')).toBeFalsy();
+  });
+  test('renders regular logout link in absence of IDP', () => {
+    renderWithRouter(
+      <SiteHeaderWithContext initialAppState={appState} />,
+    );
+
+    userEvent.click(screen.getByText('papa'));
+    expect(screen.getByText('Sign out')).toBeInTheDocument();
+    const logoutLink = screen.getByText('Sign out');
+    // note: the values of these come from the process.env vars in setupTest.js
+    expect(logoutLink.getAttribute('href')).toBe('http://localhost:18000/logout?next=http://localhost:8734/bears-r-us');
   });
 });

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -10,6 +10,8 @@ configure({ adapter: new Adapter() });
 
 process.env.LMS_BASE_URL = 'http://localhost:18000';
 process.env.MARKETING_SITE_BASE_URL = 'http://marketing.url';
+process.env.LOGOUT_URL = 'http://localhost:18000/logout';
+process.env.BASE_URL = 'http://localhost:8734';
 
 // testing utility to mock window width, etc.
 global.window.matchMedia = matchMediaMock.create();


### PR DESCRIPTION
if IDP found and if logout=true url param, then don't redirect to proxy login flow

when an IDP is detected, the logout button now sets `next` to http://<logoutURL_from_today>/?logout=true to make this work

- [x] tests pending
- [x] we also want to run this by UX team before merge

only if idp is present, the logout button will add logout=true to the next param which in turns ends up as the url param when we are redirected after logout concludes, hence the learner portal can use this flag (plus the fact that user is not currently logged in), to show the logout page instead of going back into the redirect system. This fixes the issue that when an IDP is present, a user can't really logout because of the self-loop-back to the IDP which is automatic today

<img width="1563" alt="Screen Shot 2022-02-25 at 3 26 36 PM" src="https://user-images.githubusercontent.com/528166/155797182-6b789ef7-eaa9-4ae9-97df-527e3a59b780.png">

the link there takes user to the learner portal main url such as https://localhost:8734/test-enterprise

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
