### PR TITLE
fix: proper browse and request condition and testings

### DIFF
--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -9,6 +9,7 @@ import {
   useCoursePriceForUserSubsidy,
 } from './data/hooks';
 import { features } from '../../config';
+import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 
 export const INCLUDED_IN_SUBSCRIPTION_MESSAGE = 'Included in your subscription';
 export const FREE_WHEN_APPROVED_MESSAGE = 'Free to me\n(when approved)';
@@ -17,6 +18,7 @@ const CourseSidebarPrice = () => {
   const { state: courseData } = useContext(CourseContext);
   const { activeCourseRun, userSubsidyApplicableToCourse } = courseData;
   const { enterpriseConfig } = useContext(AppContext);
+  const { subsidyRequestConfiguration } = useContext(SubsidyRequestsContext);
 
   const [coursePrice, currency] = useCoursePriceForUserSubsidy({
     activeCourseRun, userSubsidyApplicableToCourse,
@@ -49,17 +51,20 @@ const CourseSidebarPrice = () => {
   }
 
   const hasDiscountedPrice = coursePrice.discounted < coursePrice.list;
-  // Case 3: No subsidies found but Browse and Request Enabled
-  if (!hasDiscountedPrice && features.FEATURE_BROWSE_AND_REQUEST) {
+  // Case 2: No subsidies found but Browse and Request Enabled
+  if (!hasDiscountedPrice
+      && features.FEATURE_BROWSE_AND_REQUEST
+      && subsidyRequestConfiguration?.subsidyRequestsEnabled
+  ) {
     return (
-      <span style={{ whiteSpace: 'pre-wrap' }}>
+      <span style={{ whiteSpace: 'pre-wrap' }} data-testid="browse-and-request-pricing">
         <s>${originalPriceDisplay} {currency}</s><br />
         {FREE_WHEN_APPROVED_MESSAGE}
       </span>
     );
   }
 
-  // Case 4: No subsidies found
+  // Case 3: No subsidies found
   if (!hasDiscountedPrice) {
     return <span>${originalPriceDisplay} {currency}</span>;
   }

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -8,7 +8,6 @@ import { numberWithPrecision, hasLicenseSubsidy } from './data/utils';
 import {
   useCoursePriceForUserSubsidy,
 } from './data/hooks';
-import { features } from '../../config';
 import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 
 export const INCLUDED_IN_SUBSCRIPTION_MESSAGE = 'Included in your subscription';
@@ -52,9 +51,7 @@ const CourseSidebarPrice = () => {
 
   const hasDiscountedPrice = coursePrice.discounted < coursePrice.list;
   // Case 2: No subsidies found but Browse and Request Enabled
-  if (!hasDiscountedPrice
-      && features.FEATURE_BROWSE_AND_REQUEST
-      && subsidyRequestConfiguration?.subsidyRequestsEnabled
+  if (!hasDiscountedPrice && subsidyRequestConfiguration?.subsidyRequestsEnabled
   ) {
     return (
       <span style={{ whiteSpace: 'pre-wrap' }} data-testid="browse-and-request-pricing">

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -12,9 +12,6 @@ import {
   OFFER_SUBSIDY_TYPE,
   SUBSIDY_DISCOUNT_TYPE_MAP,
 } from '../data/constants';
-import * as config from '../../../config';
-
-jest.mock('../../../config');
 
 const appStateWithOrigPriceHidden = {
   enterpriseConfig: {
@@ -112,7 +109,6 @@ const SPONSORED_BY_TEXT = 'Sponsored by test-enterprise';
 describe('<CourseSidebarPrice/> ', () => {
   describe('Browse and Request', () => {
     test('Display correct message when browse and request on and no subsidy', () => {
-      config.features.FEATURE_BROWSE_AND_REQUEST = true;
       render(
         <SidebarWithContext
           initialCourseState={courseStateWithNoOffersNoLicenseSubsidy}

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -5,12 +5,16 @@ import PropTypes from 'prop-types';
 
 import { AppContext } from '@edx/frontend-platform/react';
 import { CourseContextProvider } from '../CourseContextProvider';
+import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import CourseSidebarPrice, { INCLUDED_IN_SUBSCRIPTION_MESSAGE } from '../CourseSidebarPrice';
 import {
   LICENSE_SUBSIDY_TYPE,
   OFFER_SUBSIDY_TYPE,
   SUBSIDY_DISCOUNT_TYPE_MAP,
 } from '../data/constants';
+import * as config from '../../../config';
+
+jest.mock('../../../config');
 
 const appStateWithOrigPriceHidden = {
   enterpriseConfig: {
@@ -73,15 +77,25 @@ const courseStateWithNoOffersNoLicenseSubsidy = {
   catalog: { catalogList: ['bears'] },
 };
 
+const defaultSubsidyRequestsState = {
+  subsidyRequestConfiguration: null,
+  licenseRequests: [],
+  couponCodeRequests: [],
+  isLoading: false,
+};
+
 // eslint-disable-next-line react/prop-types
 const SidebarWithContext = ({
   initialAppState = appStateWithOrigPriceHidden,
+  subsidyRequestsState = defaultSubsidyRequestsState,
   initialCourseState,
 }) => (
   <AppContext.Provider value={initialAppState}>
-    <CourseContextProvider initialState={initialCourseState}>
-      <CourseSidebarPrice />
-    </CourseContextProvider>
+    <SubsidyRequestsContext.Provider value={subsidyRequestsState}>
+      <CourseContextProvider initialState={initialCourseState}>
+        <CourseSidebarPrice />
+      </CourseContextProvider>
+    </SubsidyRequestsContext.Provider>
   </AppContext.Provider>
 );
 
@@ -89,74 +103,96 @@ SidebarWithContext.propTypes = {
   initialAppState: PropTypes.shape({}).isRequired,
   initialCourseState: PropTypes.shape({}).isRequired,
   userSubsidyState: PropTypes.shape({}).isRequired,
+  subsidyRequestsState: PropTypes.shape({}).isRequired,
 };
 
 const SPONSORED_BY_TEXT = 'Sponsored by test-enterprise';
 
-describe('Sidebar price display with hideCourseOriginalPrice ON, No subsidies', () => {
-  test('no subsidies, shows original price, no messages', () => {
-    render(<SidebarWithContext initialCourseState={courseStateWithNoOffersNoLicenseSubsidy} />);
-    expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
-    expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
-    expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
+describe('<CourseSidebarPrice/> ', () => {
+  describe('Browse and Request', () => {
+    test('Display correct message when browse and request on and no subsidy', () => {
+      config.features.FEATURE_BROWSE_AND_REQUEST = true;
+      render(
+        <SidebarWithContext
+          initialCourseState={courseStateWithNoOffersNoLicenseSubsidy}
+          subsidyRequestsState={{
+            ...defaultSubsidyRequestsState,
+            subsidyRequestConfiguration: { subsidyRequestsEnabled: true },
+          }}
+        />,
+      );
+      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+      expect(screen.getByTestId('browse-and-request-pricing')).toBeInTheDocument();
+      expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
+      expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
+    });
   });
-});
 
-describe('Sidebar price display with hideCourseOriginalPrice ON', () => {
-  test('subscription license subsidy, shows no price, correct message', () => {
-    render(<SidebarWithContext initialCourseState={courseStateWithLicenseSubsidy} />);
-    expect(screen.queryByText(/\$7.50 USD/)).not.toBeInTheDocument();
-    expect(screen.getByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).toBeInTheDocument();
-    expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
+  describe('Sidebar price display with hideCourseOriginalPrice ON, No subsidies', () => {
+    test('no subsidies, shows original price, no messages', () => {
+      render(<SidebarWithContext initialCourseState={courseStateWithNoOffersNoLicenseSubsidy} />);
+      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+      expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
+      expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
+    });
   });
-  test('offer 100% subsidy, shows no price, correct message', () => {
-    render(<SidebarWithContext
-      initialCourseState={courseStateFullOfferSubsidy}
-    />);
-    expect(screen.queryByText(/\$7.50 USD/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/\$0.00 USD/)).not.toBeInTheDocument();
-    expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
-    expect(screen.getByText(SPONSORED_BY_TEXT)).toBeInTheDocument();
-  });
-  test('offer non-full subsidy, shows discounted price only, correct message', () => {
-    render(<SidebarWithContext
-      initialCourseState={courseStatePartialOfferSubsidy}
-    />);
-    expect(screen.getByText(/\$0.75 USD/)).toBeInTheDocument();
-    expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
-    expect(screen.getByText(SPONSORED_BY_TEXT)).toBeInTheDocument();
-  });
-});
 
-// We only test price here, since messages are already tested above
-describe('Sidebar price display with hideCourseOriginalPrice OFF', () => {
-  test('no subsidies, shows original price, no messages', () => {
-    render(<SidebarWithContext
-      initialAppState={appStateWithOrigPriceShowing}
-      initialCourseState={courseStateWithNoOffersNoLicenseSubsidy}
-    />);
-    expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+  describe('Sidebar price display with hideCourseOriginalPrice ON', () => {
+    test('subscription license subsidy, shows no price, correct message', () => {
+      render(<SidebarWithContext initialCourseState={courseStateWithLicenseSubsidy} />);
+      expect(screen.queryByText(/\$7.50 USD/)).not.toBeInTheDocument();
+      expect(screen.getByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
+    });
+    test('offer 100% subsidy, shows no price, correct message', () => {
+      render(<SidebarWithContext
+        initialCourseState={courseStateFullOfferSubsidy}
+      />);
+      expect(screen.queryByText(/\$7.50 USD/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/\$0.00 USD/)).not.toBeInTheDocument();
+      expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
+      expect(screen.getByText(SPONSORED_BY_TEXT)).toBeInTheDocument();
+    });
+    test('offer non-full subsidy, shows discounted price only, correct message', () => {
+      render(<SidebarWithContext
+        initialCourseState={courseStatePartialOfferSubsidy}
+      />);
+      expect(screen.getByText(/\$0.75 USD/)).toBeInTheDocument();
+      expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
+      expect(screen.getByText(SPONSORED_BY_TEXT)).toBeInTheDocument();
+    });
   });
-  test('subscription license subsidy, shows orig crossed out price, correct message', () => {
-    render(<SidebarWithContext
-      initialAppState={appStateWithOrigPriceShowing}
-      initialCourseState={courseStateWithLicenseSubsidy}
-    />);
-    expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
-  });
-  test('offer 100% subsidy, shows orig price, correct message', () => {
-    render(<SidebarWithContext
-      initialAppState={appStateWithOrigPriceShowing}
-      initialCourseState={courseStateFullOfferSubsidy}
-    />);
-    expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
-  });
-  test('offer non-full subsidy, shows orig and discounted price only, correct message', () => {
-    render(<SidebarWithContext
-      initialAppState={appStateWithOrigPriceShowing}
-      initialCourseState={courseStatePartialOfferSubsidy}
-    />);
-    expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
-    expect(screen.getByText(/\$0.75 USD/)).toBeInTheDocument();
+
+  // We only test price here, since messages are already tested above
+  describe('Sidebar price display with hideCourseOriginalPrice OFF', () => {
+    test('no subsidies, shows original price, no messages', () => {
+      render(<SidebarWithContext
+        initialAppState={appStateWithOrigPriceShowing}
+        initialCourseState={courseStateWithNoOffersNoLicenseSubsidy}
+      />);
+      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+    });
+    test('subscription license subsidy, shows orig crossed out price, correct message', () => {
+      render(<SidebarWithContext
+        initialAppState={appStateWithOrigPriceShowing}
+        initialCourseState={courseStateWithLicenseSubsidy}
+      />);
+      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+    });
+    test('offer 100% subsidy, shows orig price, correct message', () => {
+      render(<SidebarWithContext
+        initialAppState={appStateWithOrigPriceShowing}
+        initialCourseState={courseStateFullOfferSubsidy}
+      />);
+      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+    });
+    test('offer non-full subsidy, shows orig and discounted price only, correct message', () => {
+      render(<SidebarWithContext
+        initialAppState={appStateWithOrigPriceShowing}
+        initialCourseState={courseStatePartialOfferSubsidy}
+      />);
+      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+      expect(screen.getByText(/\$0.75 USD/)).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { AppContext } from '@edx/frontend-platform/react';
 import { CourseContextProvider } from '../CourseContextProvider';
 import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
-import CourseSidebarPrice, { INCLUDED_IN_SUBSCRIPTION_MESSAGE } from '../CourseSidebarPrice';
+import CourseSidebarPrice, { INCLUDED_IN_SUBSCRIPTION_MESSAGE, FREE_WHEN_APPROVED_MESSAGE } from '../CourseSidebarPrice';
 import {
   LICENSE_SUBSIDY_TYPE,
   OFFER_SUBSIDY_TYPE,
@@ -84,7 +84,7 @@ const defaultSubsidyRequestsState = {
   isLoading: false,
 };
 
-// eslint-disable-next-line react/prop-types
+/* eslint-disable react/prop-types */
 const SidebarWithContext = ({
   initialAppState = appStateWithOrigPriceHidden,
   subsidyRequestsState = defaultSubsidyRequestsState,
@@ -98,6 +98,7 @@ const SidebarWithContext = ({
     </SubsidyRequestsContext.Provider>
   </AppContext.Provider>
 );
+/* eslint-enable react/prop-types */
 
 SidebarWithContext.propTypes = {
   initialAppState: PropTypes.shape({}).isRequired,
@@ -121,7 +122,8 @@ describe('<CourseSidebarPrice/> ', () => {
           }}
         />,
       );
-      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+      expect(screen.getByText(/\$7.50 USD/));
+      expect(screen.getByText(FREE_WHEN_APPROVED_MESSAGE.replace('\n', ' ')));
       expect(screen.getByTestId('browse-and-request-pricing')).toBeInTheDocument();
       expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
       expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
@@ -141,7 +143,7 @@ describe('<CourseSidebarPrice/> ', () => {
     test('subscription license subsidy, shows no price, correct message', () => {
       render(<SidebarWithContext initialCourseState={courseStateWithLicenseSubsidy} />);
       expect(screen.queryByText(/\$7.50 USD/)).not.toBeInTheDocument();
-      expect(screen.getByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).toBeInTheDocument();
+      expect(screen.getByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE));
       expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
     });
     test('offer 100% subsidy, shows no price, correct message', () => {
@@ -151,15 +153,15 @@ describe('<CourseSidebarPrice/> ', () => {
       expect(screen.queryByText(/\$7.50 USD/)).not.toBeInTheDocument();
       expect(screen.queryByText(/\$0.00 USD/)).not.toBeInTheDocument();
       expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
-      expect(screen.getByText(SPONSORED_BY_TEXT)).toBeInTheDocument();
+      expect(screen.getByText(SPONSORED_BY_TEXT));
     });
     test('offer non-full subsidy, shows discounted price only, correct message', () => {
       render(<SidebarWithContext
         initialCourseState={courseStatePartialOfferSubsidy}
       />);
-      expect(screen.getByText(/\$0.75 USD/)).toBeInTheDocument();
+      expect(screen.getByText(/\$0.75 USD/));
       expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
-      expect(screen.getByText(SPONSORED_BY_TEXT)).toBeInTheDocument();
+      expect(screen.getByText(SPONSORED_BY_TEXT));
     });
   });
 
@@ -170,29 +172,29 @@ describe('<CourseSidebarPrice/> ', () => {
         initialAppState={appStateWithOrigPriceShowing}
         initialCourseState={courseStateWithNoOffersNoLicenseSubsidy}
       />);
-      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+      expect(screen.getByText(/\$7.50 USD/));
     });
     test('subscription license subsidy, shows orig crossed out price, correct message', () => {
       render(<SidebarWithContext
         initialAppState={appStateWithOrigPriceShowing}
         initialCourseState={courseStateWithLicenseSubsidy}
       />);
-      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+      expect(screen.getByText(/\$7.50 USD/));
     });
     test('offer 100% subsidy, shows orig price, correct message', () => {
       render(<SidebarWithContext
         initialAppState={appStateWithOrigPriceShowing}
         initialCourseState={courseStateFullOfferSubsidy}
       />);
-      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+      expect(screen.getByText(/\$7.50 USD/));
     });
     test('offer non-full subsidy, shows orig and discounted price only, correct message', () => {
       render(<SidebarWithContext
         initialAppState={appStateWithOrigPriceShowing}
         initialCourseState={courseStatePartialOfferSubsidy}
       />);
-      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
-      expect(screen.getByText(/\$0.75 USD/)).toBeInTheDocument();
+      expect(screen.getByText(/\$7.50 USD/));
+      expect(screen.getByText(/\$0.75 USD/));
     });
   });
 });


### PR DESCRIPTION
Closes [Closes 5380](https://openedx.atlassian.net/browse/ENT-5380)

When displaying browse and request pricing we also check customer configuration. Added test to check we properly display it. 
