### PR TITLE
fix: add login refresh after linking enterprise & fix subsidy request button 

### DIFF
--- a/src/components/course/CourseRunCard.jsx
+++ b/src/components/course/CourseRunCard.jsx
@@ -24,7 +24,7 @@ import { formatStringAsNumber } from '../../utils/common';
 import { useSubsidyDataForCourse } from './enrollment/hooks';
 import { useCourseEnrollmentUrl } from './data/hooks';
 import { determineEnrollmentType } from './enrollment/utils';
-import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
+import { useUserHasSubsidyRequestForCourse } from '../enterprise-subsidy-requests/data/hooks';
 
 const DATE_FORMAT = 'MMM D';
 const DEFAULT_BUTTON_LABEL = 'Enroll';
@@ -34,6 +34,7 @@ const CourseRunCard = ({
   userEntitlements,
   courseRun,
   userEnrollments,
+  courseKey,
 }) => {
   const {
     availability,
@@ -58,9 +59,7 @@ const CourseRunCard = ({
     [userEnrollments, key],
   );
 
-  const {
-    subsidyRequestConfiguration,
-  } = useContext(SubsidyRequestsContext);
+  const userHasSubsidyRequestForCourse = useUserHasSubsidyRequestForCourse(courseKey);
 
   const isUserEnrolled = !!userEnrollment;
 
@@ -93,7 +92,7 @@ const CourseRunCard = ({
       enrollmentUrl,
       courseHasOffer,
     },
-    subsidyRequestConfiguration,
+    userHasSubsidyRequestForCourse,
     isUserEnrolled,
     isEnrollable,
     isCourseStarted,
@@ -214,6 +213,7 @@ const CourseRunCard = ({
 };
 
 CourseRunCard.propTypes = {
+  courseKey: PropTypes.string.isRequired,
   courseRun: PropTypes.shape({
     availability: PropTypes.string.isRequired,
     isEnrollable: PropTypes.bool.isRequired,

--- a/src/components/course/CourseRunCards.jsx
+++ b/src/components/course/CourseRunCards.jsx
@@ -15,11 +15,14 @@ const CourseRunCards = () => {
     catalog: { catalogList },
   } = courseData;
 
+  const { course: { key } } = courseData;
+
   return (
     <CardGrid columnSizes={{ sm: 12, lg: 5 }}>
       {availableCourseRuns.map((courseRun) => (
         <CourseRunCard
           key={`course-run-card-${courseRun.key}`}
+          courseKey={key}
           userEnrollments={userEnrollments}
           courseRun={courseRun}
           catalogList={catalogList}

--- a/src/components/course/SubsidyRequestButton.jsx
+++ b/src/components/course/SubsidyRequestButton.jsx
@@ -40,8 +40,9 @@ const SubsidyRequestButton = ({ enterpriseSlug }) => {
   const {
     key: courseKey,
     courseRunKeys,
-    userSubsidyApplicableToCourse,
   } = course;
+
+  const { userSubsidyApplicableToCourse } = state;
 
   const isCourseInCatalog = catalog.containsContentItems;
 
@@ -52,7 +53,7 @@ const SubsidyRequestButton = ({ enterpriseSlug }) => {
     () => {
       if (courseRunKeys) {
         const enrollments = courseRunKeys.filter(
-          (runKey) => findUserEnrollmentForCourseRun({ userEnrollments, runKey }),
+          (key) => findUserEnrollmentForCourseRun({ userEnrollments, key }),
         );
         return enrollments.length > 0;
       }
@@ -61,23 +62,23 @@ const SubsidyRequestButton = ({ enterpriseSlug }) => {
     [courseRunKeys, userEnrollments],
   );
 
+  const userHasSubsidyRequest = useUserHasSubsidyRequestForCourse(courseKey);
+
   /**
    * Show subsidy request button if:
    *  - subsidy requests is enabled
-   *  - course is in catalog
-   *  - user not already enrolled in crouse
-   *  - user has no subsidy for course
+   *    - user has a subsidy request for course
+   *      OR
+   *    - course is in catalog
+   *    - user not already enrolled in crouse
+   *    - user has no subsidy for course
    */
   const showSubsidyRequestButton = subsidyRequestConfiguration?.subsidyRequestsEnabled
-    && isCourseInCatalog
-    && !isUserEnrolled
-    && !userSubsidyApplicableToCourse;
+    && (userHasSubsidyRequest || (isCourseInCatalog && !isUserEnrolled && !userSubsidyApplicableToCourse));
 
   if (!showSubsidyRequestButton) {
     return null;
   }
-
-  const userHasSubsidyRequest = useUserHasSubsidyRequestForCourse(courseKey);
 
   /**
    * @returns {string} one of `request`, `pending`, or `requested`

--- a/src/components/course/enrollment/utils.js
+++ b/src/components/course/enrollment/utils.js
@@ -22,14 +22,18 @@ export function determineEnrollmentType({
   isUserEnrolled,
   isEnrollable,
   isCourseStarted,
-  subsidyRequestConfiguration,
+  userHasSubsidyRequestForCourse,
 }) {
   const isSubscriptionValid = subscriptionLicense?.uuid;
   if (isUserEnrolled) {
     return isCourseStarted ? TO_COURSEWARE_PAGE : VIEW_ON_DASHBOARD;
   }
+
+  if (userHasSubsidyRequestForCourse) { return HIDE_BUTTON; }
+
   if (!isEnrollable) { return ENROLL_DISABLED; }
   if (!enrollmentUrl) { return ENROLL_DISABLED; }
+
   if (isSubscriptionValid && hasLicenseSubsidy(userSubsidyApplicableToCourse)) {
     return TO_DATASHARING_CONSENT;
   }
@@ -38,7 +42,6 @@ export function determineEnrollmentType({
   }
 
   if (!isSubscriptionValid && courseHasOffer) { return TO_VOUCHER_REDEEM; }
-  if (subsidyRequestConfiguration?.subsidyRequestsEnabled) { return HIDE_BUTTON; }
   if (!isSubscriptionValid && !courseHasOffer) { return TO_ECOM_BASKET; }
   return ENROLL_DISABLED;
 }

--- a/src/components/course/tests/SubsidyRequestButton.test.jsx
+++ b/src/components/course/tests/SubsidyRequestButton.test.jsx
@@ -1,0 +1,200 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import {
+  screen, render, fireEvent, waitFor,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { ToastsContext } from '../../Toasts/ToastsProvider';
+import { SubsidyRequestsContext, SUBSIDY_REQUEST_STATE, SUBSIDY_TYPE } from '../../enterprise-subsidy-requests';
+import SubsidyRequestButton from '../SubsidyRequestButton';
+import { CourseContext } from '../CourseContextProvider';
+import * as entepriseAccessService from '../../enterprise-subsidy-requests/data/service';
+
+jest.mock('../../enterprise-subsidy-requests/data/service');
+
+const mockEnterpriseUUID = 'uuid';
+const mockEnterpriseSlug = 'sluggy';
+const mockCourseKey = 'edx+101';
+const mockCourseRunKey = `${mockCourseKey}+v1`;
+
+const mockAddToast = jest.fn();
+const mockRefreshSubsidyRequests = jest.fn();
+const initialToastsState = {
+  toasts: [],
+  addToast: mockAddToast,
+  removeToast: jest.fn(),
+};
+
+const initialSubsidyRequestsState = {
+  subsidyRequestConfiguration: {
+    subsidyRequestsEnabled: true,
+    enterpriseCustomerUuid: mockEnterpriseUUID,
+    subsidyType: SUBSIDY_TYPE.COUPON,
+  },
+  requestsBySubsidyType: {
+    [SUBSIDY_TYPE.LICENSE]: [],
+    [SUBSIDY_TYPE.COUPON]: [],
+  },
+  refreshSubsidyRequests: mockRefreshSubsidyRequests,
+};
+
+const initialCourseState = {
+  state: {
+    course: {
+      key: mockCourseKey,
+      courseRunKeys: [mockCourseRunKey],
+    },
+    catalog: { containsContentItems: true },
+    userEnrollments: [],
+    userSubsidyApplicableToCourse: undefined,
+  },
+};
+
+const SubsidyRequestButtonWrapper = ({
+  subsidyRequestsState = {},
+  courseState = {},
+}) => (
+  <ToastsContext.Provider value={initialToastsState}>
+    <SubsidyRequestsContext.Provider value={{ ...initialSubsidyRequestsState, ...subsidyRequestsState }}>
+      <CourseContext.Provider value={{ ...initialCourseState, ...courseState }}>
+        <SubsidyRequestButton enterpriseSlug={mockEnterpriseSlug} />
+      </CourseContext.Provider>
+    </SubsidyRequestsContext.Provider>
+  </ToastsContext.Provider>
+);
+
+describe('<SubsidyRequestButton />', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('should render button', () => {
+    render(<SubsidyRequestButtonWrapper />);
+    expect(screen.getByText('Request enrollment'));
+  });
+
+  it('should not render button if subsidy requests is not enabled', () => {
+    render(
+      <SubsidyRequestButtonWrapper
+        subsidyRequestsState={{
+          ...initialSubsidyRequestsState,
+          subsidyRequestConfiguration: {
+            subsidyRequestsEnabled: false,
+          },
+        }}
+      />,
+    );
+    expect(screen.queryByText('Request enrollment')).not.toBeInTheDocument();
+  });
+
+  it("should not render button if course is not in the enterprise's catalogs", () => {
+    render(
+      <SubsidyRequestButtonWrapper
+        courseState={{
+          state: {
+            ...initialCourseState.state,
+            catalog: { containsContentItems: false },
+          },
+        }}
+      />,
+    );
+    expect(screen.queryByText('Request enrollment')).not.toBeInTheDocument();
+  });
+
+  it('should not render button if the user is already enrolled in the course', () => {
+    render(
+      <SubsidyRequestButtonWrapper
+        courseState={{
+          state: {
+            ...initialCourseState.state,
+            userEnrollments: [
+              {
+                isEnrollmentActive: true,
+                isRevoked: false,
+                courseRunId: mockCourseRunKey,
+              },
+            ],
+          },
+        }}
+      />,
+    );
+    expect(screen.queryByText('Request enrollment')).not.toBeInTheDocument();
+  });
+
+  it('should not render button if the user has an applicable subsidy', () => {
+    render(
+      <SubsidyRequestButtonWrapper
+        courseState={{
+          state: {
+            ...initialCourseState.state,
+            userSubsidyApplicableToCourse: {
+              discount: 100,
+            },
+          },
+        }}
+      />,
+    );
+    expect(screen.queryByText('Request enrollment')).not.toBeInTheDocument();
+  });
+
+  it('should render button if the user has an applicable subsidy BUT also a subsidy request for the course', () => {
+    render(
+      <SubsidyRequestButtonWrapper
+        subsidyRequestsState={{
+          ...initialSubsidyRequestsState,
+          requestsBySubsidyType: {
+            [SUBSIDY_TYPE.COUPON]: [{
+              status: SUBSIDY_REQUEST_STATE.REQUESTED,
+              courseId: mockCourseKey,
+            }],
+          },
+        }}
+        courseState={{
+          state: {
+            ...initialCourseState.state,
+            userSubsidyApplicableToCourse: {
+              discount: 100,
+            },
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText('Awaiting approval'));
+  });
+
+  it.each(
+    [{
+      subsidyType: SUBSIDY_TYPE.LICENSE,
+      expectedCalledFn: entepriseAccessService.postLicenseRequest,
+    },
+    {
+      subsidyType: SUBSIDY_TYPE.COUPON,
+      expectedCalledFn: entepriseAccessService.postCouponCodeRequest,
+    },
+    ],
+  )('should call enterprise access to create a subsidy request when clicked', async (
+    {
+      subsidyType, expectedCalledFn,
+    },
+  ) => {
+    render(
+      <SubsidyRequestButtonWrapper
+        subsidyRequestsState={{
+          ...initialSubsidyRequestsState,
+          subsidyRequestConfiguration: {
+            ...initialSubsidyRequestsState.subsidyRequestConfiguration,
+            subsidyType,
+          },
+        }}
+      />,
+    );
+    const requestEnrollmentBtn = screen.getByText('Request enrollment');
+    fireEvent.click(requestEnrollmentBtn);
+
+    await waitFor(() => {
+      expect(
+        expectedCalledFn,
+      ).toHaveBeenCalledWith(mockEnterpriseUUID, mockCourseKey);
+      expect(mockAddToast).toHaveBeenCalledWith('Request for course submitted');
+      expect(mockRefreshSubsidyRequests).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/enterprise-invite/EnterpriseInvitePage.test.jsx
+++ b/src/components/enterprise-invite/EnterpriseInvitePage.test.jsx
@@ -4,14 +4,19 @@ import { getConfig } from '@edx/frontend-platform/config';
 import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import * as logging from '@edx/frontend-platform/logging';
 import EnterpriseInvitePage, {
   LOADING_MESSAGE,
   CTA_BUTTON_TEXT,
 } from './EnterpriseInvitePage';
 import { postLinkEnterpriseLearner } from './data/service';
+import * as utils from '../../utils/common';
 
 import { renderWithRouter } from '../../utils/tests';
 
+jest.mock('../../utils/common', () => ({
+  loginRefresh: jest.fn(),
+}));
 jest.mock('./data/service');
 jest.mock('@edx/frontend-platform/auth');
 jest.mock('@edx/frontend-platform/config');
@@ -40,11 +45,9 @@ const TEST_INVITE_KEY = '00000000-0000-0000-0000-000000000000';
 const TEST_ROUTE = `/invite/${TEST_INVITE_KEY}`;
 
 describe('EnterpriseInvitePage', () => {
-  beforeEach(() => {
-    postLinkEnterpriseLearner.mockReset();
-  });
+  afterEach(() => jest.clearAllMocks());
 
-  test('makes call to link user to enterprise and redirects to slug if successful', async () => {
+  test('makes call to link user to enterprise, refreshes login, and redirects to slug', async () => {
     postLinkEnterpriseLearner.mockResolvedValueOnce({
       data: {
         enterprise_customer_slug: TEST_ENTEPRRISE_SLUG,
@@ -58,12 +61,35 @@ describe('EnterpriseInvitePage', () => {
     expect(screen.getByText(LOADING_MESSAGE));
     await waitFor(() => expect(screen.queryAllByText(LOADING_MESSAGE)).toHaveLength(0));
 
+    expect(utils.loginRefresh).toHaveBeenCalledTimes(1);
+    // assert we got redirected to enterprise's slug
+    expect(history.location.pathname).toEqual(`/${TEST_ENTEPRRISE_SLUG}`);
+  });
+
+  test('redirects to slug if successful linked user even if login refresh fails', async () => {
+    postLinkEnterpriseLearner.mockResolvedValueOnce({
+      data: {
+        enterprise_customer_slug: TEST_ENTEPRRISE_SLUG,
+      },
+    });
+    const { history } = renderWithRouter(<EnterpriseInvitePage />, {
+      route: TEST_ROUTE,
+    });
+
+    const loginRefreshError = new Error('login refresh error');
+    utils.loginRefresh.mockRejectedValueOnce(loginRefreshError);
+    await waitFor(() => expect(utils.loginRefresh).toHaveBeenCalledTimes(1));
+
+    expect(logging.logError).toHaveBeenCalledWith(loginRefreshError);
+
     // assert we got redirected to enterprise's slug
     expect(history.location.pathname).toEqual(`/${TEST_ENTEPRRISE_SLUG}`);
   });
 
   test('handles error when linking user to enterprise', async () => {
-    postLinkEnterpriseLearner.mockResolvedValueOnce(new Error('oh noes'));
+    const error = new Error('oh noes');
+    postLinkEnterpriseLearner.mockRejectedValueOnce(error);
+
     const { history } = renderWithRouter(<EnterpriseInvitePage />, {
       route: TEST_ROUTE,
     });
@@ -71,6 +97,9 @@ describe('EnterpriseInvitePage', () => {
     // assert component is initially loading but then eventually resolves
     expect(screen.queryAllByText(LOADING_MESSAGE)).toHaveLength(1);
     await waitFor(() => expect(screen.queryAllByText(LOADING_MESSAGE)).toHaveLength(0));
+
+    expect(logging.logError).toHaveBeenCalledWith(error);
+    expect(utils.loginRefresh).not.toHaveBeenCalled();
 
     // assert we did NOT get redirected
     expect(history.location.pathname).toEqual(TEST_ROUTE);

--- a/src/components/enterprise-subsidy-requests/data/hooks.js
+++ b/src/components/enterprise-subsidy-requests/data/hooks.js
@@ -123,7 +123,7 @@ export function useUserHasSubsidyRequestForCourse(courseKey) {
   } = useContext(SubsidyRequestsContext);
 
   return useMemo(() => {
-    if (!subsidyRequestConfiguration) {
+    if (!subsidyRequestConfiguration?.subsidyRequestsEnabled) {
       return false;
     }
     switch (subsidyRequestConfiguration.subsidyType) {


### PR DESCRIPTION
- Handles the case when a user is already logged and links to a new enterprise using an invite key. We need to refresh login so that the new enterprise learner role gets populated in the jwt. 
- Fix subsidy request button behavior, add tests.


# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
