### PR TITLE
fix: Do not render an enrollment button in course card if user must request enrollment

### DIFF
--- a/src/components/course/CourseRunCard.jsx
+++ b/src/components/course/CourseRunCard.jsx
@@ -1,5 +1,6 @@
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import moment from 'moment';
 import {
   Card,
@@ -7,6 +8,7 @@ import {
 
 import { AppContext } from '@edx/frontend-platform/react';
 import EnrollAction from './enrollment/EnrollAction';
+import { enrollButtonTypes } from './enrollment/constants';
 import {
   COURSE_AVAILABILITY_MAP,
 } from './data/constants';
@@ -24,7 +26,10 @@ import { formatStringAsNumber } from '../../utils/common';
 import { useSubsidyDataForCourse } from './enrollment/hooks';
 import { useCourseEnrollmentUrl } from './data/hooks';
 import { determineEnrollmentType } from './enrollment/utils';
-import { useUserHasSubsidyRequestForCourse } from '../enterprise-subsidy-requests/data/hooks';
+import {
+  useSubsidyRequestConfiguration,
+  useUserHasSubsidyRequestForCourse,
+} from '../enterprise-subsidy-requests/data/hooks';
 
 const DATE_FORMAT = 'MMM D';
 const DEFAULT_BUTTON_LABEL = 'Enroll';
@@ -59,6 +64,7 @@ const CourseRunCard = ({
     [userEnrollments, key],
   );
 
+  const { subsidyRequestConfiguration } = useSubsidyRequestConfiguration(enterpriseConfig.uuid);
   const userHasSubsidyRequestForCourse = useUserHasSubsidyRequestForCourse(courseKey);
 
   const isUserEnrolled = !!userEnrollment;
@@ -91,6 +97,7 @@ const CourseRunCard = ({
       userSubsidyApplicableToCourse,
       enrollmentUrl,
       courseHasOffer,
+      subsidyRequestConfiguration,
     },
     userHasSubsidyRequestForCourse,
     isUserEnrolled,
@@ -193,7 +200,13 @@ const CourseRunCard = ({
   return (
     <Card className="w-100">
       <Card.Body className="d-flex flex-column align-items-center justify-content-between">
-        <div className="text-center mb-3.5">
+        <div className={classNames(
+          'text-center',
+          {
+            'mb-3.5': enrollmentType !== enrollButtonTypes.HIDE_BUTTON,
+          },
+        )}
+        >
           <div className="h4 mb-0">{heading}</div>
           <div className="small">{subHeading}</div>
         </div>

--- a/src/components/course/enrollment/utils.js
+++ b/src/components/course/enrollment/utils.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import { enrollButtonTypes } from './constants';
+import { features } from '../../../config';
 import { hasLicenseSubsidy } from '../data/utils';
 
 const {
@@ -17,7 +18,11 @@ const {
  */
 export function determineEnrollmentType({
   subsidyData: {
-    subscriptionLicense, userSubsidyApplicableToCourse, enrollmentUrl, courseHasOffer,
+    subscriptionLicense,
+    userSubsidyApplicableToCourse,
+    enrollmentUrl,
+    courseHasOffer,
+    subsidyRequestConfiguration,
   } = {},
   isUserEnrolled,
   isEnrollable,
@@ -30,6 +35,13 @@ export function determineEnrollmentType({
   }
 
   if (userHasSubsidyRequestForCourse) { return HIDE_BUTTON; }
+
+  if (features.FEATURE_BROWSE_AND_REQUEST
+      && subsidyRequestConfiguration?.subsidyRequestsEnabled
+      && !hasLicenseSubsidy(userSubsidyApplicableToCourse)
+      && !courseHasOffer) {
+    return HIDE_BUTTON;
+  }
 
   if (!isEnrollable) { return ENROLL_DISABLED; }
   if (!enrollmentUrl) { return ENROLL_DISABLED; }


### PR DESCRIPTION
This is to prevent having "competing" calls-to-action on the course page; 1 to enroll, and
another to request enrollment.  We insist that the user must request enrollment if the browse
and request feature is enabled, on for the customer, and the user has no available subsidy applicable to the course.

### Test cases

## Browse/Request enabled and on for the customers, no assigned coupon codes or licenses:

![image](https://user-images.githubusercontent.com/2307986/161095556-b702d104-faf6-4b9b-a9b6-18140fb0bfdc.png)


## Browse and request enabled, code assigned:
Admin-portal:
![image](https://user-images.githubusercontent.com/2307986/161085747-b76adb78-a98e-4938-8c68-f5616de2757a.png)
Learner-portal:
![image](https://user-images.githubusercontent.com/2307986/161085806-13d66940-7cd4-4835-887c-54b8d92d8e38.png)

## BR enabled, license assigned, no code assigned:
Admin-portal:
![image](https://user-images.githubusercontent.com/2307986/161087290-1067d511-972a-4a29-a16c-09c54443a29a.png)
Learner-portal:
![image](https://user-images.githubusercontent.com/2307986/161087469-11d8d951-08ba-4cbc-bf83-d5a1dab70279.png)

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
