### PR TITLE
feat: don't cache subsidy request configuration for launch

### DIFF
--- a/src/components/enterprise-subsidy-requests/data/service.js
+++ b/src/components/enterprise-subsidy-requests/data/service.js
@@ -2,12 +2,10 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 import { SUBSIDY_REQUEST_STATE } from '../constants';
 
-export function fetchSubsidyRequestConfiguration(enterpriseUUID, useCache = true) {
+export function fetchSubsidyRequestConfiguration(enterpriseUUID) {
   const config = getConfig();
   const url = `${config.ENTERPRISE_ACCESS_BASE_URL}/api/v1/customer-configurations/${enterpriseUUID}/`;
-  return getAuthenticatedHttpClient({
-    useCache: useCache && config.USE_API_CACHE,
-  }).get(url);
+  return getAuthenticatedHttpClient().get(url);
 }
 
 export function fetchLicenseRequests({


### PR DESCRIPTION
To avoid any potential problems/confusion during launch, lets not cache the subsidy request configuration.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
