### PR TITLE
fix: add partner org names to requested course cards on dashboard

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/course-cards/RequestedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/RequestedCourseCard.jsx
@@ -18,7 +18,7 @@ RequestedCourseCard.propTypes = {
   courseRunId: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   linkToCertificate: PropTypes.string,
-  isRevoked: PropTypes.bool.isRequired,
+  isRevoked: PropTypes.bool,
   courseRunStatus: PropTypes.string.isRequired,
   endDate: PropTypes.string,
 };
@@ -26,6 +26,7 @@ RequestedCourseCard.propTypes = {
 RequestedCourseCard.defaultProps = {
   linkToCertificate: null,
   endDate: null,
+  isRevoked: false,
 };
 
 export default RequestedCourseCard;

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/utils.test.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/utils.test.js
@@ -1,3 +1,5 @@
+import { camelCaseObject } from '@edx/frontend-platform';
+
 import { COURSE_STATUSES } from '../constants';
 import { transformCourseEnrollment, groupCourseEnrollmentsByStatus, transformSubsidyRequest } from '../utils';
 import { createRawCourseEnrollment } from '../../tests/enrollment-testutils';
@@ -32,6 +34,7 @@ describe('transformSubsidyRequest', () => {
       email: 'edx@example.com',
       course_id: 'edx+101',
       course_title: 'edX 101',
+      course_partners: [{ name: 'edX' }, { name: 'Open edX' }],
       enterprise_customer_uuid: 'enterprise-uuid',
       state: 'requested',
       reviewed_at: null,
@@ -42,16 +45,19 @@ describe('transformSubsidyRequest', () => {
       coupon_id: null,
       coupon_code: null,
     };
+    const subsidyRequestCamelCased = camelCaseObject(subsidyRequest);
 
-    const transformedSubsidyRequest = {
-      courseRunId: subsidyRequest.courseId,
-      title: subsidyRequest.courseTitle,
+    const expectedTransformedSubsidyRequest = {
+      courseRunId: subsidyRequestCamelCased.courseId,
+      title: subsidyRequestCamelCased.courseTitle,
+      orgName: subsidyRequestCamelCased.coursePartners.map(partner => partner.name).join(', '),
       courseRunStatus: COURSE_STATUSES.requested,
-      linkToCourse: `${slug}/course/${subsidyRequest.courseId}`,
-      created: subsidyRequest.created,
+      linkToCourse: `${slug}/course/${subsidyRequestCamelCased.courseId}`,
+      created: subsidyRequestCamelCased.created,
+      notifications: [],
     };
-
-    expect(transformSubsidyRequest({ subsidyRequest, slug })).toEqual(transformedSubsidyRequest);
+    const actualTransformedSubsidyRequest = transformSubsidyRequest({ subsidyRequest: subsidyRequestCamelCased, slug });
+    expect(actualTransformedSubsidyRequest).toEqual(expectedTransformedSubsidyRequest);
   });
 });
 

--- a/src/components/dashboard/main-content/course-enrollments/data/utils.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/utils.js
@@ -56,7 +56,9 @@ export const transformSubsidyRequest = ({
 }) => ({
   courseRunId: subsidyRequest.courseId,
   title: subsidyRequest.courseTitle,
+  orgName: subsidyRequest.coursePartners.map(partner => partner.name).join(', '),
   courseRunStatus: COURSE_STATUSES.requested,
   linkToCourse: `${slug}/course/${subsidyRequest.courseId}`,
   created: subsidyRequest.created,
+  notifications: [], // required prop by CourseSection
 });

--- a/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
@@ -43,6 +43,8 @@ const transformedLicenseRequest = {
   courseRunId: 'edx+101',
   title: 'requested course',
   courseRunStatus: COURSE_STATUSES.requested,
+  linkToCourse: 'https://edx.org',
+  notifications: [],
 };
 
 hooks.useCourseEnrollments.mockReturnValue({


### PR DESCRIPTION
<img width="716" alt="image" src="https://user-images.githubusercontent.com/2828721/165302738-e149eeee-b371-44e4-942f-42f8c464ff42.png">

<img width="695" alt="image" src="https://user-images.githubusercontent.com/2828721/165303317-88154456-8e5d-4394-8bf4-42a938ee0e16.png">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
