### PR TITLE
Llin/ent 5701

### DIFF
--- a/src/components/course/Course.jsx
+++ b/src/components/course/Course.jsx
@@ -18,6 +18,7 @@ import { getActiveCourseRun, getAvailableCourseRuns } from './data/utils';
 import NotFoundPage from '../NotFoundPage';
 import { SubsidyRequestsContextProvider } from '../enterprise-subsidy-requests';
 import CourseRecommendations from './CourseRecommendations';
+import { UserSubsidyContext } from '../enterprise-user-subsidy/UserSubsidy';
 
 export default function Course() {
   const { courseKey } = useParams();
@@ -31,6 +32,7 @@ export default function Course() {
     },
     [search],
   );
+  const { subscriptionLicense, offers: { offers } } = useContext(UserSubsidyContext);
 
   // extract search queryId and objectId that led to this course page view from
   // the URL query parameters and then remove it to keep the URLs clean.
@@ -42,6 +44,8 @@ export default function Course() {
     courseKey,
     enterpriseConfig,
     courseRunKey,
+    subscriptionLicense,
+    offers,
   });
 
   const initialState = useMemo(

--- a/src/components/course/data/service.js
+++ b/src/components/course/data/service.js
@@ -2,9 +2,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { getConfig } from '@edx/frontend-platform/config';
 
-import { hasValidStartExpirationDates } from '../../../utils/common';
-import { LICENSE_SUBSIDY_TYPE, OFFER_SUBSIDY_TYPE, PROMISE_FULFILLED } from './constants';
-import { getActiveCourseRun, getAvailableCourseRuns, findOfferForCourse } from './utils';
+import { getActiveCourseRun, getAvailableCourseRuns } from './utils';
 
 export default class CourseService {
   constructor(options = {}) {
@@ -27,24 +25,18 @@ export default class CourseService {
     this.activeCourseRun = activeCourseRun;
   }
 
-  async fetchAllCourseData({ offers }) {
+  async fetchAllCourseData() {
     const courseDataRaw = await Promise.all([
       this.fetchCourseDetails(),
       this.fetchUserEnrollments(),
       this.fetchUserEntitlements(),
       this.fetchEnterpriseCustomerContainsContent(),
-    ])
-      .then((responses) => responses.map(res => res.data));
+    ]).then((responses) => responses.map(res => res.data));
 
     const courseData = camelCaseObject(courseDataRaw);
     const courseDetails = courseData[0];
     // Get the user subsidy (by license, codes, or any other means) that the user may have for the active course run
     this.activeCourseRun = this.activeCourseRun || getActiveCourseRun(courseDetails);
-
-    const { catalogList } = courseData[3];
-    const userSubsidyApplicableToCourse = await this.fetchEnterpriseUserSubsidy({
-      offers, catalogList,
-    });
 
     // Check for the course_run_key URL param and remove all other course run data
     // if the given course run key is for an available course run.
@@ -61,7 +53,6 @@ export default class CourseService {
 
     return {
       courseDetails,
-      userSubsidyApplicableToCourse,
       userEnrollments: courseData[1],
       userEntitlements: courseData[2].results,
       catalog: courseData[3],
@@ -121,49 +112,6 @@ export default class CourseService {
     return this.cachedAuthenticatedHttpClient.get(url);
   }
 
-  async fetchEnterpriseUserSubsidy({ offers, catalogList }) {
-    // TODO: the license subsidy is fetched from backend, but the offer subsidy currently is being
-    //   used from the passed in arguments (fetched already by UserSubsidy.jsx).
-    //  Need to reconcile api to make it consistent for all subsidy types: offers, subscriptions
-    //
-    // Note: these API calls should be ordered by priority. Example: if a user has
-    // a license subsidy, we use that as the user's final subsidy. if not, we check
-    // if the user has a code subsidy, and so on.
-    const SUBSIDY_TYPES = [
-      {
-        type: LICENSE_SUBSIDY_TYPE,
-        fetchFn: this.fetchUserLicenseSubsidy(),
-      },
-      {
-        type: OFFER_SUBSIDY_TYPE,
-        fetchFn: this.fetchUserOfferSubsidy({ offers, catalogList }),
-      },
-    ];
-    const promises = SUBSIDY_TYPES.map(subsidy => subsidy.fetchFn);
-    // Promise.allSettled() waits until all promises are resolved, whether successful
-    // or not. in contrast, Promise.all() immediately rejects when any promise errors
-    // which is not ideal since if a user doesn't have a subsidy, the APIs may return
-    // a non-200 status code.
-    const data = await Promise.allSettled(promises);
-
-    let userSubsidyApplicableToCourse = null;
-    for (let i = 0; i < data.length; i++) {
-      if (data[i]?.status === PROMISE_FULFILLED) {
-        const result = data[i].value.data;
-        const subsidyData = camelCaseObject(result);
-
-        if (hasValidStartExpirationDates(subsidyData)) {
-          userSubsidyApplicableToCourse = { ...subsidyData, subsidyType: SUBSIDY_TYPES[i].type };
-          // if a non-expired user subsidy is found, break early since the promises
-          // are priority ordered
-          break;
-        }
-      }
-    }
-
-    return userSubsidyApplicableToCourse;
-  }
-
   fetchUserLicenseSubsidy() {
     const queryParams = new URLSearchParams({
       enterprise_customer_uuid: this.enterpriseUuid,
@@ -171,43 +119,5 @@ export default class CourseService {
     });
     const url = `${this.config.LICENSE_MANAGER_URL}/api/v1/license-subsidy/?${queryParams.toString()}`;
     return this.cachedAuthenticatedHttpClient.get(url);
-  }
-
-  /**
-   * @typedef {Object} Offer An offer for a course
-   * @property {string} usageType
-   * @property {number} benefitValue
-   * @property {string} couponStartDate utc formatted
-   * @property {string} couponEndDate utc formatted
-   * @property {number} redemptionsRemaining
-   * @property {string} code
-   * @property {string} catalog uuid of catalog
-   */
-
-  /**
-   * Returns an offer whose catalog uuid matches one of the provided catalogs.
-   * TODO: This method currently cannot discover if the offer applies specifically
-   * to a course, just that there is an offer that matches one in the list of catalogs.
-   * @param {Object} args Arguments
-   * @param {Array<Offer>} args.offers All offers for this user for an enterprise
-   *
-   * @returns {Promise} a promise that resolves to an object matching userSubsidyApplicableToCourse
-   */
-  fetchUserOfferSubsidy({ offers, catalogList }) {
-    const offerForCourse = findOfferForCourse(offers, catalogList);
-    if (!offerForCourse) {
-      return Promise.reject(new Error('No offer found'));
-    }
-    const {
-      usageType, benefitValue, couponStartDate, couponEndDate,
-    } = offerForCourse;
-    return Promise.resolve({
-      data: {
-        discountType: usageType,
-        discountValue: benefitValue,
-        startDate: couponStartDate,
-        endDate: couponEndDate,
-      },
-    });
   }
 }

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -1,13 +1,151 @@
 import { renderHook } from '@testing-library/react-hooks';
 
-import { useCourseEnrollmentUrl, useUserHasSubsidyRequestForCourse } from '../hooks';
+import moment from 'moment';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { useCourseEnrollmentUrl, useUserHasSubsidyRequestForCourse, useAllCourseData } from '../hooks';
 import { SubsidyRequestsContext } from '../../../enterprise-subsidy-requests/SubsidyRequestsContextProvider';
 import { SUBSIDY_TYPE, SUBSIDY_REQUEST_STATE } from '../../../enterprise-subsidy-requests/constants';
-import { LICENSE_SUBSIDY_TYPE } from '../constants';
+import { LICENSE_SUBSIDY_TYPE, OFFER_SUBSIDY_TYPE } from '../constants';
 
 jest.mock('../../../../config', () => ({
   features: { ENROLL_WITH_CODES: true },
 }));
+
+const mockCourseData = {
+  catalog: {
+    containsContentItems: true,
+    catalogList: ['catalog-1'],
+  },
+};
+
+const mockLicenseForCourse = {
+  uuid: 'license-uuid',
+  start_date: moment().subtract(1, 'w').toISOString(),
+  expiration_date: moment().add(8, 'w').toISOString(),
+};
+
+const mockOffersForCourse = [{
+  catalog: 'catalog-1',
+  couponStartDate: moment().subtract(1, 'w').toISOString(),
+  couponEndDate: moment().add(8, 'w').toISOString(),
+}];
+
+const mockCourseRecommendataions = {
+  allRecommendations: [],
+};
+
+const mockCourseService = {
+  fetchAllCourseData: jest.fn(() => mockCourseData),
+  fetchUserLicenseSubsidy: jest.fn(() => ({ data: mockLicenseForCourse })),
+  fetchAllCourseRecommendations: jest.fn(() => mockCourseRecommendataions),
+};
+
+jest.mock('../service', () => ({
+  __esModule: true,
+  default: () => mockCourseService,
+}));
+
+describe('useAllCourseData', () => {
+  const basicProps = {
+    courseKey: 'courseKey',
+    enterpriseConfig: {
+      uuid: 'uuid',
+    },
+    courseRunKey: 'courseRunKey',
+    subscriptionLicense: null,
+    offers: [],
+  };
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns course data and course recommendations', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useAllCourseData(basicProps));
+
+    await waitForNextUpdate();
+    expect(result.current.courseData).toEqual({
+      ...mockCourseData,
+      userSubsidyApplicableToCourse: null,
+    });
+
+    expect(mockCourseService.fetchAllCourseData).toHaveBeenCalled();
+    expect(mockCourseService.fetchAllCourseRecommendations).toHaveBeenCalled();
+
+    expect(result.current.courseRecommendations).toEqual(mockCourseRecommendataions);
+  });
+
+  it('returns license subsidy if there is an applicable license for the course', async () => {
+    const subscriptionLicense = {
+      uuid: 'license-uuid',
+    };
+    const { result, waitForNextUpdate } = renderHook(() => useAllCourseData({
+      ...basicProps,
+      subscriptionLicense,
+    }));
+    await waitForNextUpdate();
+
+    expect(mockCourseService.fetchUserLicenseSubsidy).toHaveBeenCalled();
+    expect(result.current.courseData).toEqual({
+      ...mockCourseData,
+      userSubsidyApplicableToCourse: {
+        ...camelCaseObject(mockLicenseForCourse),
+        subsidyType: LICENSE_SUBSIDY_TYPE,
+      },
+    });
+  });
+
+  it('handles non 404 errors fetching user license subsidy', async () => {
+    const mockError = new Error('error');
+    mockCourseService.fetchUserLicenseSubsidy.mockRejectedValueOnce(mockError);
+    const subscriptionLicense = {
+      uuid: 'license-uuid',
+    };
+    const { result, waitForNextUpdate } = renderHook(() => useAllCourseData({
+      ...basicProps,
+      subscriptionLicense,
+    }));
+    await waitForNextUpdate();
+
+    expect(mockCourseService.fetchUserLicenseSubsidy).toHaveBeenCalled();
+    expect(result.current.fetchError).toEqual(mockError);
+  });
+
+  it('returns coupon subsidy if there is an applicable coupon for the course', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useAllCourseData({
+      ...basicProps,
+      offers: mockOffersForCourse,
+    }));
+    await waitForNextUpdate();
+
+    expect(result.current.courseData).toEqual({
+      ...mockCourseData,
+      userSubsidyApplicableToCourse: {
+        discountType: mockOffersForCourse[0].usageType,
+        discountValue: mockOffersForCourse[0].benefitValue,
+        startDate: mockOffersForCourse[0].couponStartDate,
+        endDate: mockOffersForCourse[0].couponEndDate,
+        subsidyType: OFFER_SUBSIDY_TYPE,
+      },
+    });
+  });
+
+  it('returns license subsidy if there is both an applicable license and coupon for the course', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useAllCourseData({
+      ...basicProps,
+      subscriptionLicense: mockLicenseForCourse,
+      offers: mockOffersForCourse,
+    }));
+    await waitForNextUpdate();
+
+    expect(mockCourseService.fetchUserLicenseSubsidy).toHaveBeenCalled();
+    expect(result.current.courseData).toEqual({
+      ...mockCourseData,
+      userSubsidyApplicableToCourse: {
+        ...camelCaseObject(mockLicenseForCourse),
+        subsidyType: LICENSE_SUBSIDY_TYPE,
+      },
+    });
+  });
+});
 
 describe('useCourseEnrollmentUrl', () => {
   const noSubscriptionEnrollmentInputs = {
@@ -15,7 +153,12 @@ describe('useCourseEnrollmentUrl', () => {
       uuid: 'foo',
     },
     key: 'bar',
-    offers: [{ code: 'bearsRus', catalog: 'bears' }],
+    offers: [{
+      code: 'bearsRus',
+      catalog: 'bears',
+      couponStartDate: moment().subtract(1, 'w').toISOString(),
+      couponEndDate: moment().add(8, 'w').toISOString(),
+    }],
     sku: 'xkcd',
     catalogList: ['bears'],
     location: { search: 'foo' },

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -1,14 +1,20 @@
+import moment from 'moment';
 import { findOfferForCourse } from '../utils';
 
 describe('findOfferForCourse', () => {
-  const offers = [{ code: 'bearsRus', catalog: 'bears' }];
+  const offers = [{
+    code: 'bearsRus',
+    catalog: 'bears',
+    couponStartDate: moment().subtract(1, 'w').toISOString(),
+    couponEndDate: moment().add(8, 'w').toISOString(),
+  }];
 
   test('returns valid offer index if offer catalog is in catalog list', () => {
     const catalogList = ['cats', 'bears'];
     expect(findOfferForCourse(offers, catalogList)).toEqual(offers[0]);
   });
 
-  test('returns null if catalog list is empty', () => {
-    expect(findOfferForCourse(offers)).toBeNull();
+  test('returns undefined if catalog list is empty', () => {
+    expect(findOfferForCourse(offers)).toBeUndefined();
   });
 });

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -15,6 +15,7 @@ import XSeriesSvgIcon from '../../../assets/icons/xseries.svg';
 import CreditSvgIcon from '../../../assets/icons/credit.svg';
 import { PROGRAM_TYPE_MAP } from '../../program/data/constants';
 import { programIsMicroMasters, programIsProfessionalCertificate } from '../../program/data/utils';
+import { hasValidStartExpirationDates } from '../../../utils/common';
 
 export function hasCourseStarted(start) {
   const today = new Date();
@@ -131,11 +132,10 @@ export function getAvailableCourseRuns(course) {
 }
 
 export function findOfferForCourse(offers, catalogList = []) {
-  const offerIndex = offers.findIndex((offer) => catalogList?.includes(offer.catalog));
-  if (offerIndex !== -1) {
-    return offers[offerIndex];
-  }
-  return null;
+  return offers.find((offer) => catalogList?.includes(offer.catalog) && hasValidStartExpirationDates({
+    startDate: offer.couponStartDate,
+    endDate: offer.couponEndDate,
+  }));
 }
 
 const getBestCourseMode = (courseModes) => {
@@ -197,3 +197,27 @@ export function shortenString(str, maxLength, suffix, separator = ' ') {
   if (str.length <= maxLength) { return str; }
   return `${str.substr(0, str.lastIndexOf(separator, maxLength))}${suffix}`;
 }
+
+export const getSubsidyToApplyForCourse = ({
+  applicableSubscriptionLicense = undefined,
+  applicableOffer = undefined,
+}) => {
+  if (applicableSubscriptionLicense) {
+    return {
+      ...applicableSubscriptionLicense,
+      subsidyType: LICENSE_SUBSIDY_TYPE,
+    };
+  }
+
+  if (applicableOffer) {
+    return {
+      discountType: applicableOffer.usageType,
+      discountValue: applicableOffer.benefitValue,
+      startDate: applicableOffer.couponStartDate,
+      endDate: applicableOffer.couponEndDate,
+      subsidyType: OFFER_SUBSIDY_TYPE,
+    };
+  }
+
+  return null;
+};

--- a/src/components/course/enrollment/tests/hooks.test.jsx
+++ b/src/components/course/enrollment/tests/hooks.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { renderHook } from '@testing-library/react-hooks';
 
+import moment from 'moment';
 import { CourseContextProvider } from '../../CourseContextProvider';
 import { UserSubsidyContext } from '../../../enterprise-user-subsidy';
 import { SubsidyRequestsContext } from '../../../enterprise-subsidy-requests';
@@ -123,17 +124,24 @@ describe('useSubsidyDataForCourse', () => {
     expect(result.current).toStrictEqual(expected);
   });
   test('correctly extracts subsidy fields from UserSubsidyContext, with offers', () => {
+    const offers = [{
+      catalog: 'catalog-1',
+      discountValue: 10,
+      couponStartDate: moment().subtract(1, 'w').toISOString(),
+      couponEndDate: moment().add(8, 'w').toISOString(),
+    }];
+
     const expected = {
       courseHasOffer: true,
       offersCount: 1,
       subscriptionLicense,
-      offers: [{ catalog: 'catalog-1', discountValue: 10 }],
+      offers,
       userSubsidyApplicableToCourse: BASE_COURSE_STATE.userSubsidyApplicableToCourse,
     };
     const initialUserSubsidyState = {
       subscriptionLicense,
       offers: {
-        offers: [{ catalog: 'catalog-1', discountValue: 10 }],
+        offers,
         offersCount: 1,
       },
     };

--- a/src/components/enterprise-user-subsidy/data/hooks.js
+++ b/src/components/enterprise-user-subsidy/data/hooks.js
@@ -18,7 +18,7 @@ import { features } from '../../../config';
 /**
  * Attempts to fetch any existing licenses associated with the authenticated user and the
  * specified enterprise customer. Priority is given to activated licenses, then assigned
- * licenses, then revoked licenses.
+ * licenses.
  *
  * @param {string} enterpriseId The UUID of the enterprise customer
  * @returns An object representing a user's subscription license or null if no license was found.
@@ -38,7 +38,6 @@ const fetchExistingUserLicense = async (enterpriseId) => {
     const licensesByStatus = {
       [LICENSE_STATUS.ACTIVATED]: [],
       [LICENSE_STATUS.ASSIGNED]: [],
-      [LICENSE_STATUS.REVOKED]: [],
     };
     results.forEach((item) => {
       licensesByStatus[item.status].push(item);
@@ -121,10 +120,14 @@ export function useSubscriptionLicense({
           subscription => subscription.uuid === userLicense?.subscriptionPlanUuid,
         );
 
-        setLicense({
-          ...userLicense,
-          subscriptionPlan,
-        });
+        if (userLicense) {
+          setLicense({
+            ...userLicense,
+            subscriptionPlan,
+          });
+        } else {
+          setLicense(null);
+        }
 
         setIsLoading(false);
       });

--- a/src/utils/tests.jsx
+++ b/src/utils/tests.jsx
@@ -73,5 +73,9 @@ export const initialCourseState = ({
 });
 
 export const A_100_PERCENT_OFFER = {
-  catalog: 'a-catalog', discountValue: 100, discountType: 'Percentage',
+  catalog: 'a-catalog',
+  discountValue: 100,
+  discountType: 'Percentage',
+  couponStartDate: moment().subtract(1, 'w').toISOString(),
+  couponEndDate: moment().add(8, 'w').toISOString(),
 };


### PR DESCRIPTION
Only make to license-manager for license-subsidy information if the user has a license. This call was being made previously, even for users without a license, causing new relic errors.

Minor clean ups included.

[ENT-5608](https://openedx.atlassian.net/browse/ENT-5608)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
------------