### PR TITLE
fix: handle null subsidyRequest.coursePartners

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/data/utils.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/utils.js
@@ -56,7 +56,7 @@ export const transformSubsidyRequest = ({
 }) => ({
   courseRunId: subsidyRequest.courseId,
   title: subsidyRequest.courseTitle,
-  orgName: subsidyRequest.coursePartners.map(partner => partner.name).join(', '),
+  orgName: subsidyRequest.coursePartners?.map(partner => partner.name).join(', '),
   courseRunStatus: COURSE_STATUSES.requested,
   linkToCourse: `${slug}/course/${subsidyRequest.courseId}`,
   created: subsidyRequest.created,


### PR DESCRIPTION
Seeing the following JS error on production, where the request object doesn't have the `course_partners` field backfilled, so it comes back as `null`.

<img width="546" alt="image" src="https://user-images.githubusercontent.com/2828721/165981613-108b10cc-2264-4d90-95f8-439b84dcdf6b.png">

We will no longer iterate over `coursePartners` when it's not defined.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
