### PR TITLE
fix: untangle dependency cycle in subsidy request contexts/hooks.

### DIFF
--- a/src/components/course/CourseRunCard.jsx
+++ b/src/components/course/CourseRunCard.jsx
@@ -24,11 +24,8 @@ import {
 import { formatStringAsNumber } from '../../utils/common';
 
 import { useSubsidyDataForCourse } from './enrollment/hooks';
-import { useCourseEnrollmentUrl } from './data/hooks';
+import { useCourseEnrollmentUrl, useUserHasSubsidyRequestForCourse } from './data/hooks';
 import { determineEnrollmentType } from './enrollment/utils';
-import {
-  useUserHasSubsidyRequestForCourse,
-} from '../enterprise-subsidy-requests/data/hooks';
 import { SubsidyRequestsContext } from '../enterprise-subsidy-requests/SubsidyRequestsContextProvider';
 
 const DATE_FORMAT = 'MMM D';

--- a/src/components/course/SubsidyRequestButton.jsx
+++ b/src/components/course/SubsidyRequestButton.jsx
@@ -8,9 +8,9 @@ import { useHistory } from 'react-router-dom';
 
 import { SubsidyRequestsContext, SUBSIDY_TYPE } from '../enterprise-subsidy-requests';
 import { CourseContext } from './CourseContextProvider';
+import { useUserHasSubsidyRequestForCourse } from './data/hooks';
 import { findUserEnrollmentForCourseRun } from './data/utils';
 import { ToastsContext } from '../Toasts';
-import { useUserHasSubsidyRequestForCourse } from '../enterprise-subsidy-requests/data/hooks';
 import { postLicenseRequest, postCouponCodeRequest } from '../enterprise-subsidy-requests/data/service';
 
 const props = {

--- a/src/components/course/tests/CourseRunCard.test.jsx
+++ b/src/components/course/tests/CourseRunCard.test.jsx
@@ -19,7 +19,7 @@ import CourseRunCard from '../CourseRunCard';
 import { CourseContextProvider } from '../CourseContextProvider';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests/SubsidyRequestsContextProvider';
-import * as subsidyRequestsHooks from '../../enterprise-subsidy-requests/data/hooks';
+import * as subsidyRequestsHooks from '../data/hooks';
 import { enrollButtonTypes } from '../enrollment/constants';
 
 const COURSE_UUID = 'foo';
@@ -35,8 +35,9 @@ jest.mock('../enrollment/EnrollAction', () => ({ enrollLabel, enrollmentType }) 
     <span>{enrollmentType}</span>
   </>
 ));
-jest.mock('../../enterprise-subsidy-requests/data/hooks', () => ({
+jest.mock('../data/hooks', () => ({
   useUserHasSubsidyRequestForCourse: jest.fn(() => false),
+  useCourseEnrollmentUrl: jest.fn(() => false),
 }));
 
 const INITIAL_APP_STATE = initialAppState({});

--- a/src/components/enterprise-subsidy-requests/data/hooks.js
+++ b/src/components/enterprise-subsidy-requests/data/hooks.js
@@ -1,12 +1,11 @@
 import {
-  useState, useEffect, useContext, useMemo,
+  useState, useEffect,
 } from 'react';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { fetchSubsidyRequestConfiguration, fetchLicenseRequests, fetchCouponCodeRequests } from './service';
 import { SUBSIDY_TYPE, SUBSIDY_REQUEST_STATE } from '../constants';
-import { SubsidyRequestsContext } from '../SubsidyRequestsContextProvider';
 
 export function useSubsidyRequestConfiguration(enterpriseUUID) {
   const [subsidyRequestConfiguration, setSubsidyRequestConfiguration] = useState();
@@ -101,47 +100,4 @@ export function useSubsidyRequests(subsidyRequestConfiguration) {
     isLoading,
     refreshSubsidyRequests: loadSubsidyRequests,
   };
-}
-
-/**
- * Returns `true` if user has made a subsidy request.
- *
- * Returns `false` if:
- *  - Subsidy request has not been configured
- *  - No requests are found under the configured `SUBSIDY_TYPE`
- *
- * If the `SUBSIDY_TYPE` is `COUPON`, optional parameter courseKey can be passed
- * to only return true if courseKey is in one of the requests
- *
- * @param {string} [courseKey] - optional filter for specific course
- * @returns {boolean}
- */
-export function useUserHasSubsidyRequestForCourse(courseKey) {
-  const {
-    subsidyRequestConfiguration,
-    requestsBySubsidyType,
-  } = useContext(SubsidyRequestsContext);
-
-  return useMemo(() => {
-    if (!subsidyRequestConfiguration?.subsidyRequestsEnabled) {
-      return false;
-    }
-    switch (subsidyRequestConfiguration.subsidyType) {
-      case SUBSIDY_TYPE.LICENSE: {
-        return requestsBySubsidyType[SUBSIDY_TYPE.LICENSE].length > 0;
-      }
-      case SUBSIDY_TYPE.COUPON: {
-        const foundCouponRequest = requestsBySubsidyType[SUBSIDY_TYPE.COUPON].find(
-          request => (!courseKey || request.courseId === courseKey),
-        );
-        return !!foundCouponRequest;
-      }
-      default:
-        return false;
-    }
-  }, [
-    courseKey,
-    subsidyRequestConfiguration,
-    requestsBySubsidyType,
-  ]);
 }

--- a/src/components/enterprise-subsidy-requests/data/tests/hooks.test.jsx
+++ b/src/components/enterprise-subsidy-requests/data/tests/hooks.test.jsx
@@ -5,9 +5,7 @@ import { SUBSIDY_TYPE, SUBSIDY_REQUEST_STATE } from '../../constants';
 import {
   useSubsidyRequestConfiguration,
   useSubsidyRequests,
-  useUserHasSubsidyRequestForCourse,
 } from '../hooks';
-import { SubsidyRequestsContext } from '../../SubsidyRequestsContextProvider';
 import * as service from '../service';
 
 const mockEmail = 'edx@example.com';
@@ -181,90 +179,5 @@ describe('useSubsidyRequests', () => {
     );
 
     expect(result.current.couponCodeRequests).toEqual([]);
-  });
-});
-
-describe('useUserHasSubsidyRequestForCourse', () => {
-  afterEach(() => jest.clearAllMocks());
-
-  it('returns false when `subsidyRequestConfiguration` are not set', () => {
-    const context = {
-      subsidyRequestConfiguration: null,
-    };
-    const wrapper = ({ children }) => (
-      <SubsidyRequestsContext.Provider value={context}>{children}</SubsidyRequestsContext.Provider>
-    );
-    const { result } = renderHook(() => useUserHasSubsidyRequestForCourse(), { wrapper });
-    expect(result.current).toBe(false);
-  });
-
-  it('returns false when `subsidyType` is undefined', () => {
-    const context = {
-      subsidyRequestConfiguration: { subsidyType: undefined },
-      requestsBySubsidyType: {
-        [SUBSIDY_TYPE.LICENSE]: [],
-        [SUBSIDY_TYPE.COUPON]: [],
-      },
-    };
-    const wrapper = ({ children }) => (
-      <SubsidyRequestsContext.Provider value={context}>{children}</SubsidyRequestsContext.Provider>
-    );
-    const { result } = renderHook(() => useUserHasSubsidyRequestForCourse(), { wrapper });
-    expect(result.current).toBe(false);
-  });
-
-  it('returns true when `subsidyType` is LICENSE && 1 license request is found', () => {
-    const context = {
-      subsidyRequestConfiguration: {
-        subsidyRequestsEnabled: true,
-        subsidyType: SUBSIDY_TYPE.LICENSE,
-      },
-      requestsBySubsidyType: {
-        [SUBSIDY_TYPE.LICENSE]: [{ state: SUBSIDY_REQUEST_STATE.REQUESTED }],
-        [SUBSIDY_TYPE.COUPON]: [],
-      },
-    };
-    const wrapper = ({ children }) => (
-      <SubsidyRequestsContext.Provider value={context}>{children}</SubsidyRequestsContext.Provider>
-    );
-    const { result } = renderHook(() => useUserHasSubsidyRequestForCourse(), { wrapper });
-    expect(result.current).toBe(true);
-  });
-
-  it('returns true when `subsidyType` is COUPON && 1 coupon request is found', () => {
-    const courseId = '123';
-    const context = {
-      subsidyRequestConfiguration: {
-        subsidyRequestsEnabled: true,
-        subsidyType: SUBSIDY_TYPE.COUPON,
-      },
-      requestsBySubsidyType: {
-        [SUBSIDY_TYPE.LICENSE]: [],
-        [SUBSIDY_TYPE.COUPON]: [{ state: SUBSIDY_REQUEST_STATE.REQUESTED, courseId }],
-      },
-    };
-    const wrapper = ({ children }) => (
-      <SubsidyRequestsContext.Provider value={context}>{children}</SubsidyRequestsContext.Provider>
-    );
-    const { result } = renderHook(() => useUserHasSubsidyRequestForCourse(courseId), { wrapper });
-    expect(result.current).toBe(true);
-  });
-
-  it('returns false when `subsidyType` is COUPON && no matching courseId', () => {
-    const context = {
-      subsidyRequestConfiguration: {
-        subsidyRequestsEnabled: true,
-        subsidyType: SUBSIDY_TYPE.COUPON,
-      },
-      requestsBySubsidyType: {
-        [SUBSIDY_TYPE.LICENSE]: [],
-        [SUBSIDY_TYPE.COUPON]: [{ state: SUBSIDY_REQUEST_STATE.REQUESTED, courseId: 'lorem' }],
-      },
-    };
-    const wrapper = ({ children }) => (
-      <SubsidyRequestsContext.Provider value={context}>{children}</SubsidyRequestsContext.Provider>
-    );
-    const { result } = renderHook(() => useUserHasSubsidyRequestForCourse('ipsum'), { wrapper });
-    expect(result.current).toBe(false);
   });
 });


### PR DESCRIPTION
In a [PR that upgrades to frontend-build 9.2.0](https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/508), I've got a couple of new eslint dependency cycle errors:
```
/Users/adusenbery/code/frontend-app-learner-portal-enterprise/src/components/enterprise-subsidy-requests/SubsidyRequestsContextProvider.jsx
  5:1  error  Dependency cycle detected  import/no-cycle

/Users/adusenbery/code/frontend-app-learner-portal-enterprise/src/components/enterprise-subsidy-requests/data/hooks.js
  9:1  error  Dependency cycle detected  import/no-cycle
```

This PR just moves the `useUserHasSubsidyRequestForCourse` hook from the `enterprise-subsidy-requests` component over to the `course` component, because it's only used by the `course` component.
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
