### PR TITLE
style: fix style issues with program progress page

### DIFF
--- a/src/components/program-progress/ProgramListingCard.jsx
+++ b/src/components/program-progress/ProgramListingCard.jsx
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router-dom';
 
 import { AppContext } from '@edx/frontend-platform/react';
 
+import Truncate from 'react-truncate';
 import { getProgramIcon } from '../course/data/utils';
 
 const ProgramListingCard = ({ program }) => {
@@ -58,23 +59,27 @@ const ProgramListingCard = ({ program }) => {
           />
         </div>
       )}
-      <Card.Body>
-        <div className="font-weight-light d-flex justify-content-between">
-          <div>
-            {program.authoringOrganizations?.length > 0 && program.authoringOrganizations.map(org => org.key).join(' ')}
+      <Card.Body className="program-card-body">
+        <div>
+          <div className="font-weight-light d-flex justify-content-between">
+            <div>
+              {program.authoringOrganizations?.length > 0 && program.authoringOrganizations.map(org => org.key).join(' ')}
+            </div>
+            <div className="program-type">
+              <img
+                src={getProgramIcon(program.type)}
+                alt="Program Type Logo"
+                className="program-type-icon mr-2"
+              />
+              {program.type}
+            </div>
           </div>
-          <div className="program-type">
-            <img
-              src={getProgramIcon(program.type)}
-              alt="Program Type Logo"
-              className="program-type-icon mr-2"
-            />
-            {program.type}
-          </div>
+          <h3 className="program-title">
+            <Truncate lines={2} trimWhitespace>
+              {program.title}
+            </Truncate>
+          </h3>
         </div>
-        <h3 className="program-title">
-          {program.title}
-        </h3>
         <div className="program-progress mt-4">
           <div className="progress-item">
             <div className="remaining-courses">

--- a/src/components/program-progress/ProgramProgressPage.jsx
+++ b/src/components/program-progress/ProgramProgressPage.jsx
@@ -65,7 +65,7 @@ const ProgramProgressPage = () => {
       <SubsidyRequestsContextProvider>
         <CourseEnrollmentsContextProvider>
           <ProgramProgressContextProvider initialState={initialState}>
-            <Container fluid={false}>
+            <Container fluid={false} size="lg">
               <ProgramProgressHeader />
               <Row>
                 <article className="col-8">

--- a/src/components/program-progress/styles/_ProgramListingCard.scss
+++ b/src/components/program-progress/styles/_ProgramListingCard.scss
@@ -1,8 +1,14 @@
 .program-listing-card{
   width: 100%;
-  max-width: 500px;
+  max-width: 450px;
   cursor: pointer;
 
+  .program-card-body{
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding-bottom: 0px;
+  }
   .program-progress{
   display: flex;
   width: 100%;
@@ -24,7 +30,7 @@
 
   .program-banner-image{
     height :165px;
-    object-fit: contain;
+    object-fit: cover;
     background: white;
   }
 


### PR DESCRIPTION
# For all changes
### Before
![image](https://user-images.githubusercontent.com/49611774/167092474-68d2c146-b638-435f-a921-2365cdb7182a.png)
### After
![image](https://user-images.githubusercontent.com/49611774/167092006-0f391134-c7e1-4a80-a1be-6927a647cf2e.png)
### change

- Title of the card is truncated if it increases from 2 lines to avoid ugly card row on large text
- Bottom margins of the cards is short now
- Progress details of card are stick to bottom
- Cards have shorter width

-------------------------------------


### Before
![image](https://user-images.githubusercontent.com/49611774/167092996-32080906-8b04-4d0e-8540-1cf8d9004689.png)
### After
![image (1)](https://user-images.githubusercontent.com/49611774/167093021-a83e4021-d374-4dee-affe-7c4a59566353.png)
### Change
- Everything in the page is centred and it looks better

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
