### PR TITLE
fix: fix course run card status display

### DIFF
--- a/src/components/course/CourseRunCard.jsx
+++ b/src/components/course/CourseRunCard.jsx
@@ -171,12 +171,10 @@ const CourseRunCard = ({
       : 'Be the first to enroll!';
 
     let tempHeading = `${isCourseStarted ? 'Started' : 'Starts'} ${moment(start).format(DATE_FORMAT)}`;
+
     if (isCourseSelfPaced(pacingType)) {
-      if (isCourseStarted && hasTimeToComplete(courseRun)) {
-        // Course is self paced and has time to complete
-        tempHeading = `Starts ${moment().format(DATE_FORMAT)}`;
-      } else {
-        tempHeading = 'Course started';
+      if (isCourseStarted) {
+        tempHeading = hasTimeToComplete(courseRun) ? `Starts ${moment().format(DATE_FORMAT)}` : 'Course started';
       }
     }
     return [

--- a/src/components/course/tests/CourseRunCard.test.jsx
+++ b/src/components/course/tests/CourseRunCard.test.jsx
@@ -120,15 +120,15 @@ const renderCard = ({
 describe('<CourseRunCard/>', () => {
   test('Course archived card', () => {
     renderCard({ courseRun: generateCourseRun({ availability: COURSE_AVAILABILITY_MAP.ARCHIVED }) });
-    expect(screen.getByText('Course archived')).toBeTruthy();
-    expect(screen.getByText('Future dates to be announced')).toBeTruthy();
-    expect(screen.queryByText('Enroll')).toBeFalsy();
+    expect(screen.getByText('Course archived')).toBeInTheDocument();
+    expect(screen.getByText('Future dates to be announced')).toBeInTheDocument();
+    expect(screen.queryByText('Enroll')).not.toBeInTheDocument();
   });
 
   test('Course not enrollable, coming soon', () => {
     renderCard({ courseRun: generateCourseRun({ isEnrollable: false }) });
-    expect(screen.getByText('Coming soon')).toBeTruthy();
-    expect(screen.queryByText('Enroll')).toBeTruthy();
+    expect(screen.getByText('Coming soon')).toBeInTheDocument();
+    expect(screen.queryByText('Enroll')).toBeInTheDocument();
   });
 
   test('Course not enrollable and no availability', () => {
@@ -137,8 +137,8 @@ describe('<CourseRunCard/>', () => {
       availability: '',
     });
     renderCard({ courseRun });
-    expect(screen.getByText('Enrollment closed')).toBeTruthy();
-    expect(screen.queryByText('Enroll')).toBeTruthy();
+    expect(screen.getByText('Enrollment closed')).toBeInTheDocument();
+    expect(screen.queryByText('Enroll')).toBeInTheDocument();
   });
 
   test('User has entitlement', () => {
@@ -147,8 +147,8 @@ describe('<CourseRunCard/>', () => {
       courseRun,
       userEntitlements: [{ courseUuid: COURSE_UUID }],
     });
-    expect(screen.getByText('Entitlement found')).toBeTruthy();
-    expect(screen.getByText('View on dashboard')).toBeTruthy();
+    expect(screen.getByText('Entitlement found')).toBeInTheDocument();
+    expect(screen.getByText('View on dashboard')).toBeInTheDocument();
   });
 
   test('Course is self paced and has started', () => {
@@ -159,9 +159,9 @@ describe('<CourseRunCard/>', () => {
       courseRun,
     });
     const startDate = moment(COURSE_RUN_START).format(DATE_FORMAT);
-    expect(screen.getByText(`Starts ${startDate}`)).toBeTruthy();
-    expect(screen.getByText('Be the first to enroll!')).toBeTruthy();
-    expect(screen.queryByText('Enroll')).toBeTruthy();
+    expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
+    expect(screen.getByText('Be the first to enroll!')).toBeInTheDocument();
+    expect(screen.queryByText('Enroll')).toBeInTheDocument();
   });
 
   test('Course self is paced, has not started, and enrollment count', () => {
@@ -176,9 +176,10 @@ describe('<CourseRunCard/>', () => {
     renderCard({
       courseRun,
     });
-    expect(screen.getByText('Course started')).toBeTruthy();
-    expect(screen.getByText('1,000 recently enrolled!')).toBeTruthy();
-    expect(screen.queryByText('Enroll')).toBeTruthy();
+    const startDate = moment(courseRunStart).format(DATE_FORMAT);
+    expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
+    expect(screen.getByText('1,000 recently enrolled!')).toBeInTheDocument();
+    expect(screen.queryByText('Enroll')).toBeInTheDocument();
   });
 
   test('User has a subsidy request for the course', () => {
@@ -189,9 +190,9 @@ describe('<CourseRunCard/>', () => {
       courseRun,
     });
     const startDate = moment(COURSE_RUN_START).format(DATE_FORMAT);
-    expect(screen.getByText(`Starts ${startDate}`)).toBeTruthy();
-    expect(screen.getByText('Be the first to enroll!')).toBeTruthy();
-    expect(screen.getByText(enrollButtonTypes.HIDE_BUTTON)).toBeTruthy();
+    expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
+    expect(screen.getByText('Be the first to enroll!')).toBeInTheDocument();
+    expect(screen.getByText(enrollButtonTypes.HIDE_BUTTON)).toBeInTheDocument();
   });
 
   test('User must request enrollment', () => {
@@ -213,9 +214,9 @@ describe('<CourseRunCard/>', () => {
       subsidyRequestCatalogsApplicableToCourse: new Set(['test-catalog-uuid']),
     });
     const startDate = moment(COURSE_RUN_START).format(DATE_FORMAT);
-    expect(screen.getByText(`Starts ${startDate}`)).toBeTruthy();
-    expect(screen.getByText('Be the first to enroll!')).toBeTruthy();
-    expect(screen.getByText(enrollButtonTypes.HIDE_BUTTON)).toBeTruthy();
+    expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
+    expect(screen.getByText('Be the first to enroll!')).toBeInTheDocument();
+    expect(screen.getByText(enrollButtonTypes.HIDE_BUTTON)).toBeInTheDocument();
   });
 
   test('User must request enrollment, but course is not applicable to catalogs for configured subsidy type', () => {
@@ -239,9 +240,9 @@ describe('<CourseRunCard/>', () => {
       subsidyRequestCatalogsApplicableToCourse: new Set(),
     });
     const startDate = moment(COURSE_RUN_START).format(DATE_FORMAT);
-    expect(screen.getByText(`Starts ${startDate}`)).toBeTruthy();
-    expect(screen.getByText('Be the first to enroll!')).toBeTruthy();
-    expect(screen.getByText(enrollButtonTypes.TO_ECOM_BASKET)).toBeTruthy();
+    expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
+    expect(screen.getByText('Be the first to enroll!')).toBeInTheDocument();
+    expect(screen.getByText(enrollButtonTypes.TO_ECOM_BASKET)).toBeInTheDocument();
   });
 
   test('User is enrolled, and course not started', () => {
@@ -259,8 +260,8 @@ describe('<CourseRunCard/>', () => {
         mode: 'audit',
       }],
     });
-    expect(screen.getByText(`Starts ${startDate}`)).toBeTruthy();
-    expect(screen.getByText('You are enrolled')).toBeTruthy();
-    expect(screen.getByText('View course')).toBeTruthy();
+    expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
+    expect(screen.getByText('You are enrolled')).toBeInTheDocument();
+    expect(screen.getByText('View course')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# For all changes

https://openedx.atlassian.net/browse/ENT-5789

Fix showing 'Course started' when the course run hasn't started yet.

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
