### PR TITLE
Experiment 1 | Add popular courses to dashboard

### DIFF
--- a/src/components/dashboard/main-content/DashboardMainContent.jsx
+++ b/src/components/dashboard/main-content/DashboardMainContent.jsx
@@ -1,12 +1,16 @@
 import React, { useContext, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
-import { Button, breakpoints, MediaQuery } from '@edx/paragon';
+import {
+  Button, breakpoints, MediaQuery,
+} from '@edx/paragon';
 
 import { CourseEnrollments } from './course-enrollments';
+import DashboardPopularCourses from './DashboardPopularCourses';
 
 import SupportInformation from '../sidebar/SupportInformation';
 import SubsidiesSummary from '../sidebar/SubsidiesSummary';
+import { isExperimentVariant } from '../../../utils/optimizely';
 
 const DashboardMainContent = () => {
   const {
@@ -51,6 +55,10 @@ const DashboardMainContent = () => {
               Find a course
             </Button>
           </>
+        )}
+
+        {isExperimentVariant(process.env.EXPERIMENT_1_ID, process.env.EXPERIMENT_1_VARIANT_1) && (
+          <DashboardPopularCourses />
         )}
       </CourseEnrollments>
 

--- a/src/components/dashboard/main-content/DashboardPopularCourses.jsx
+++ b/src/components/dashboard/main-content/DashboardPopularCourses.jsx
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react';
+import { InstantSearch } from 'react-instantsearch-dom';
+
+import { Container } from '@edx/paragon';
+import { AppContext } from '@edx/frontend-platform/react';
+import { getConfig } from '@edx/frontend-platform/config';
+import { SearchData } from '@edx/frontend-enterprise-catalog-search';
+
+import { PopularResults } from '../../search/popular-results';
+import { COURSE_TITLE, SEARCH_FACET_FILTERS } from '../../search/constants';
+
+import { NUM_POPULAR_COURSES_TO_DISPLAY } from './data/constants';
+
+const DashboardPopularCourses = () => {
+  const { algolia } = useContext(AppContext);
+  const config = getConfig();
+
+  return (
+    <SearchData searchFacetFilters={SEARCH_FACET_FILTERS}>
+      <InstantSearch
+        indexName={config.ALGOLIA_INDEX_NAME}
+        searchClient={algolia.client}
+      >
+        <Container size="lg" className="search-results pl-0 my-5">
+          <PopularResults
+            title={COURSE_TITLE}
+            numberResultsToDisplay={NUM_POPULAR_COURSES_TO_DISPLAY}
+          />
+        </Container>
+      </InstantSearch>
+    </SearchData>
+  );
+};
+
+export default DashboardPopularCourses;

--- a/src/components/dashboard/main-content/data/constants.js
+++ b/src/components/dashboard/main-content/data/constants.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const NUM_POPULAR_COURSES_TO_DISPLAY = 4;

--- a/src/components/layout/MainContent.jsx
+++ b/src/components/layout/MainContent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const MainContent = props => (
-  <article className="col-xs-12 col-lg-7">
+  <article className="col-xs-12 col-lg-8">
     {props.children}
   </article>
 );

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Sidebar = props => (
-  <aside className="col-12 col-lg-4 offset-lg-1" {...props}>
+  <aside className="col-12 col-lg-4 pl-5" {...props}>
     {props.children}
   </aside>
 );

--- a/src/components/search/popular-results/PopularResults.jsx
+++ b/src/components/search/popular-results/PopularResults.jsx
@@ -15,6 +15,7 @@ const PopularResults = ({
   isSearchStalled,
   error,
   title,
+  numberResultsToDisplay,
 }) => {
   const nbHits = useNbHitsFromSearchResults(searchResults);
 
@@ -27,7 +28,7 @@ const PopularResults = ({
       </h2>
       {isSearchStalled && (
         <div className="row">
-          {[...Array(NUM_RESULTS_TO_DISPLAY).keys()].map(resultNum => (
+          {[...Array(numberResultsToDisplay).keys()].map(resultNum => (
             <div key={resultNum} className="skeleton-course-card">
               {getSkeletonCardFromTitle(title)}
             </div>
@@ -54,12 +55,14 @@ PopularResults.propTypes = {
   isSearchStalled: PropTypes.bool,
   error: PropTypes.shape(),
   title: PropTypes.string.isRequired,
+  numberResultsToDisplay: PropTypes.number,
 };
 
 PopularResults.defaultProps = {
   searchResults: undefined,
   isSearchStalled: false,
   error: undefined,
+  numberResultsToDisplay: NUM_RESULTS_TO_DISPLAY,
 };
 
 export default connectStateResults(PopularResults);

--- a/src/components/search/popular-results/PopularResultsIndex.jsx
+++ b/src/components/search/popular-results/PopularResultsIndex.jsx
@@ -10,7 +10,7 @@ import { NUM_RESULTS_TO_DISPLAY } from './data/constants';
 import { getContentTypeFromTitle } from '../../utils/search';
 import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 
-const PopularResultsIndex = ({ title }) => {
+const PopularResultsIndex = ({ title, numberResultsToDisplay }) => {
   const { enterpriseConfig } = useContext(AppContext);
   const { subscriptionPlan, subscriptionLicense, offers: { offers } } = useContext(UserSubsidyContext);
   const offerCatalogs = offers.map((offer) => offer.catalog);
@@ -30,19 +30,24 @@ const PopularResultsIndex = ({ title }) => {
   const defaultFilter = `content_type:${contentType} AND ${filters}`;
   const searchConfig = {
     query: '',
-    hitsPerPage: NUM_RESULTS_TO_DISPLAY,
+    hitsPerPage: numberResultsToDisplay,
     filters: defaultFilter,
   };
   return (
     <Index indexName={config.ALGOLIA_INDEX_NAME} indexId={`popular-${title}`}>
       <Configure {...searchConfig} />
-      <PopularResults title={title} />
+      <PopularResults title={title} numberResultsToDisplay={numberResultsToDisplay} />
     </Index>
   );
 };
 
 PopularResultsIndex.propTypes = {
   title: PropTypes.string.isRequired,
+  numberResultsToDisplay: PropTypes.number,
+};
+
+PopularResultsIndex.defaultProps = {
+  numberResultsToDisplay: NUM_RESULTS_TO_DISPLAY,
 };
 
 export default PopularResultsIndex;


### PR DESCRIPTION
### Background
https://2u-internal.atlassian.net/browse/ENT-5759

https://2u-internal.atlassian.net/wiki/spaces/SOL/pages/15144464/Experiment+1+Do+static+popular+courses+on+dashboard+increase+enterprise+learner+engagement

This makes use of a very convenient, existing component called `PopularResults`, which is what's shown by default when a search in learner portal returns no results.  
* The "Popular Courses" will only render if the learner has 0 course enrollments.
* It's currently set to show the 4 most popular courses that are available to a learner in some customer/catalog/subsidy state.  We can change `4` to be any other number on the Dashboard.
* After consulting with UX, changed the number of columns on MainContent to 8, removing the offset from the Sidebar and gave it a `pl-5` - this is so the main content can use more of the available empty space that was previously there.

**Screenshots**
Without giving MainContent one more column of width:
<img width="1520" alt="image" src="https://user-images.githubusercontent.com/2307986/167708212-68610022-33ce-4fe1-9ecd-552c0dc3982e.png">

After giving it one more column of width, with popular courses and no subsidy:
![image](https://user-images.githubusercontent.com/2307986/167861882-5617580a-3925-48e4-8d5f-5ea2f54c7aa4.png)


And here's the layout change for a dashboard with no popular courses and a subsidy:
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/2307986/167861810-477d383d-7cd3-47a7-bc14-625f23e94f62.png">



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
