### PR TITLE
fix: conditionally add skill quiz search result styling to pathway ca…

### DIFF
--- a/src/components/pathway/SearchPathwayCard.jsx
+++ b/src/components/pathway/SearchPathwayCard.jsx
@@ -108,11 +108,18 @@ const SearchPathwayCard = ({ hit, isLoading, isSkillQuizResult }) => {
   /*
     Including both search-pathway-card and search-result-card
     in the wrapper div is important so that pathway cards have a layout
-    that's identical to the program and course search result cards.
+    that's identical to the program and course search result cards
+    in the skills quiz page.
   */
+  const wrapperClassNames = classNames(
+    {
+      'search-result-card': isSkillQuizResult,
+    },
+    'search-pathway-card mb-4 h-100',
+  );
   return (
     <div
-      className="search-pathway-card search-result-card mb-4 h-100"
+      className={wrapperClassNames}
       role="group"
       aria-label={pathway.title}
     >


### PR DESCRIPTION
…rd wrapper

without this change, the pathway search result card wrappers are forced to be a static width, which makes them appear to be jammed too close together.
<img width="1097" alt="image" src="https://user-images.githubusercontent.com/2307986/171522378-669ecd4c-e6f6-47a8-81cb-2efec39759ed.png">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
