### PR TITLE
fix: fix pathway search card height

### DIFF
--- a/src/components/pathway/SearchPathwayCard.jsx
+++ b/src/components/pathway/SearchPathwayCard.jsx
@@ -69,6 +69,7 @@ const SearchPathwayCard = ({ hit, isLoading, isSkillQuizResult }) => {
   const searchPathwayCard = () => (
     <Card
       isClickable
+      className="h-100"
     >
       <Card.ImageCap
         src={pathway?.cardImageUrl || ''}

--- a/src/components/search/styles/_SearchResults.scss
+++ b/src/components/search/styles/_SearchResults.scss
@@ -12,7 +12,7 @@
     @extend .col-md-4;
     @extend .col-lg-3;
     @extend .mb-4;
-    height: 372px;
+    height: 405px;
   }
 
   ul.pagination {


### PR DESCRIPTION
Extends the fixed height of search result cards just a touch and throws an `h-100` onto the pathway `Card`.

<img width="990" alt="image" src="https://user-images.githubusercontent.com/2307986/171526344-2221e679-4769-41fe-8bac-f2c0f18684f1.png">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
