### PR TITLE
fix: upgrade catalog-search to 3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
         "@edx/frontend-component-footer": "^10.2.4",
-        "@edx/frontend-enterprise-catalog-search": "3.0.2",
+        "@edx/frontend-enterprise-catalog-search": "3.0.3",
         "@edx/frontend-enterprise-logistration": "^2.0.0",
         "@edx/frontend-enterprise-utils": "^2.0.0",
         "@edx/frontend-platform": "^1.15.6",
@@ -2837,11 +2837,11 @@
       }
     },
     "node_modules/@edx/frontend-enterprise-catalog-search": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-3.0.2.tgz",
-      "integrity": "sha512-CL4H7IotJzAyR+hc/mxbN7od/riVqzG+nGirY7QDbDU/EepdVe7BH69jtr8rx2GwJjrQvaZUx9v1NV/vLcQFkA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-3.0.3.tgz",
+      "integrity": "sha512-713YvIZeupRvvO4Q/6e2/7laob1GO+da1lctRVvwswWI4KQOlXRRXBVCjRO43gVagHmDN2HG5/50CgMLUKRF9g==",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^2.0.1",
+        "@edx/frontend-enterprise-utils": "^2.0.2",
         "classnames": "2.2.5",
         "lodash.debounce": "4.0.8",
         "prop-types": "15.7.2"
@@ -2878,9 +2878,9 @@
       }
     },
     "node_modules/@edx/frontend-enterprise-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-utils/-/frontend-enterprise-utils-2.0.1.tgz",
-      "integrity": "sha512-DavEibBjwPzBqAwClefOXscQUgBpjQJ/8vl14nz403+ldH1ckjvebwAxwrJTbivw3D+nwHH0vAU+8Qs504JXfw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-utils/-/frontend-enterprise-utils-2.0.3.tgz",
+      "integrity": "sha512-71yB6wEciHU9B57mEgZKT7PFjpwRQwlCjB048N2z9PIzKHrux8g5WIT3C/dtXC0+xGvz1z8aOf+tHahgHLWkkQ==",
       "dependencies": {
         "@testing-library/react": "11.2.6",
         "history": "4.10.1"
@@ -26982,11 +26982,11 @@
       }
     },
     "@edx/frontend-enterprise-catalog-search": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-3.0.2.tgz",
-      "integrity": "sha512-CL4H7IotJzAyR+hc/mxbN7od/riVqzG+nGirY7QDbDU/EepdVe7BH69jtr8rx2GwJjrQvaZUx9v1NV/vLcQFkA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-3.0.3.tgz",
+      "integrity": "sha512-713YvIZeupRvvO4Q/6e2/7laob1GO+da1lctRVvwswWI4KQOlXRRXBVCjRO43gVagHmDN2HG5/50CgMLUKRF9g==",
       "requires": {
-        "@edx/frontend-enterprise-utils": "^2.0.1",
+        "@edx/frontend-enterprise-utils": "^2.0.2",
         "classnames": "2.2.5",
         "lodash.debounce": "4.0.8",
         "prop-types": "15.7.2"
@@ -27009,9 +27009,9 @@
       }
     },
     "@edx/frontend-enterprise-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-utils/-/frontend-enterprise-utils-2.0.1.tgz",
-      "integrity": "sha512-DavEibBjwPzBqAwClefOXscQUgBpjQJ/8vl14nz403+ldH1ckjvebwAxwrJTbivw3D+nwHH0vAU+8Qs504JXfw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-utils/-/frontend-enterprise-utils-2.0.3.tgz",
+      "integrity": "sha512-71yB6wEciHU9B57mEgZKT7PFjpwRQwlCjB048N2z9PIzKHrux8g5WIT3C/dtXC0+xGvz1z8aOf+tHahgHLWkkQ==",
       "requires": {
         "@testing-library/react": "11.2.6",
         "history": "4.10.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "^10.2.4",
-    "@edx/frontend-enterprise-catalog-search": "3.0.2",
+    "@edx/frontend-enterprise-catalog-search": "3.0.3",
     "@edx/frontend-enterprise-logistration": "^2.0.0",
     "@edx/frontend-enterprise-utils": "^2.0.0",
     "@edx/frontend-platform": "^1.15.6",


### PR DESCRIPTION
ENT-5800 - this brings in a change to use a MediaQuery to toggle the mobile view for SearchFilter.

The interesting change: https://github.com/openedx/frontend-enterprise/pull/259

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
