### PR TITLE
fix: make pathway card heights consistent.

### DIFF
--- a/src/components/pathway/SearchPathwayCard.jsx
+++ b/src/components/pathway/SearchPathwayCard.jsx
@@ -69,7 +69,7 @@ const SearchPathwayCard = ({ hit, isLoading, isSkillQuizResult }) => {
   const searchPathwayCard = () => (
     <Card
       isClickable
-      className="h-100"
+      className={classNames({ 'h-100': !isSkillQuizResult })}
     >
       <Card.ImageCap
         src={pathway?.cardImageUrl || ''}
@@ -84,7 +84,7 @@ const SearchPathwayCard = ({ hit, isLoading, isSkillQuizResult }) => {
         )}
       />
 
-      <Card.Section classNames="py-3">
+      <Card.Section className="py-1">
         <div className="flex-wrap pathway-skill-names">
           {pathway.skillNames
            && filterSkillNames(pathway.skillNames).slice(0, MAX_VISIBLE_SKILLS_PATHWAY).map(

--- a/src/components/skills-quiz/styles/_SearchContentCard.scss
+++ b/src/components/skills-quiz/styles/_SearchContentCard.scss
@@ -24,6 +24,7 @@
 
   .pgn__card-image-cap {
     width: 100%;
+    height: 100%;
     height: 72px;
     object-fit: cover;
     border: none;


### PR DESCRIPTION
Fixes the following problems:
* Card heights for pathway cards in the search page, with long titles and 4 long skills names, overran their allocated height.  We fixed this be removing some extraneous padding from the card section.
* Pathway cards in skills builder were too short and not taking up allocated space.  Fixed this by removing (?!) `h-100` when the pathway card is for the skills quiz (and relatedly setting the card image cap height to 100% so there's no dead space before the header)

![search-pathway-card](https://user-images.githubusercontent.com/2307986/171890254-e51d6988-020d-44d5-9312-9dded8d32601.png)

![skills-quiz-pathway-cards](https://user-images.githubusercontent.com/2307986/171890352-5b91dbb7-ee66-4506-aa3d-42241c0541ae.png)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
