### PR TITLE
feat: update search catalogs with enterprise offers catalogs, refactor

### DIFF
--- a/src/components/app/AuthenticatedUserSubsidyPage.jsx
+++ b/src/components/app/AuthenticatedUserSubsidyPage.jsx
@@ -6,13 +6,16 @@ import {
   AutoActivateLicense,
   UserSubsidy,
 } from '../enterprise-user-subsidy';
+import { SubsidyRequestsContextProvider } from '../enterprise-subsidy-requests';
 
 export default function AuthenticatedUserSubsidyPage({ children }) {
   return (
     <AuthenticatedPage>
       <UserSubsidy>
-        <AutoActivateLicense />
-        {children}
+        <SubsidyRequestsContextProvider>
+          <AutoActivateLicense />
+          {children}
+        </SubsidyRequestsContextProvider>
       </UserSubsidy>
     </AuthenticatedPage>
   );

--- a/src/components/course/CourseContextProvider.jsx
+++ b/src/components/course/CourseContextProvider.jsx
@@ -26,7 +26,7 @@ export function CourseContextProvider({ children, initialState }) {
   const subsidyRequestCatalogsApplicableToCourse = useMemo(() => {
     const catalogsContainingCourse = new Set(catalog.catalogList);
     const subsidyRequestCatalogIntersection = new Set(
-      [...catalogsForSubsidyRequests].filter(el => catalogsContainingCourse.has(el)),
+      catalogsForSubsidyRequests.filter(el => catalogsContainingCourse.has(el)),
     );
     return subsidyRequestCatalogIntersection;
   }, [catalog, catalogsForSubsidyRequests]);

--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -16,7 +16,6 @@ import CourseSidebar from './CourseSidebar';
 import { useAllCourseData, useExtractAndRemoveSearchParamsFromURL } from './data/hooks';
 import { getActiveCourseRun, getAvailableCourseRuns } from './data/utils';
 import NotFoundPage from '../NotFoundPage';
-import { SubsidyRequestsContextProvider } from '../enterprise-subsidy-requests';
 import { CourseEnrollmentsContextProvider } from '../dashboard/main-content/course-enrollments';
 import CourseRecommendations from './CourseRecommendations';
 import { UserSubsidyContext } from '../enterprise-user-subsidy/UserSubsidy';
@@ -121,28 +120,26 @@ export default function CoursePage() {
   return (
     <>
       <Helmet title={PAGE_TITLE} />
-      <SubsidyRequestsContextProvider>
-        <CourseEnrollmentsContextProvider>
-          <CourseContextProvider initialState={initialState}>
-            <CourseHeader />
-            <Container size="lg" className="py-5">
-              <Row>
-                <MainContent>
-                  <CourseMainContent />
-                </MainContent>
-                <MediaQuery minWidth={breakpoints.large.minWidth}>
-                  {matches => matches && (
-                    <Sidebar>
-                      <CourseSidebar />
-                    </Sidebar>
-                  )}
-                </MediaQuery>
-                <CourseRecommendations />
-              </Row>
-            </Container>
-          </CourseContextProvider>
-        </CourseEnrollmentsContextProvider>
-      </SubsidyRequestsContextProvider>
+      <CourseEnrollmentsContextProvider>
+        <CourseContextProvider initialState={initialState}>
+          <CourseHeader />
+          <Container size="lg" className="py-5">
+            <Row>
+              <MainContent>
+                <CourseMainContent />
+              </MainContent>
+              <MediaQuery minWidth={breakpoints.large.minWidth}>
+                {matches => matches && (
+                  <Sidebar>
+                    <CourseSidebar />
+                  </Sidebar>
+                )}
+              </MediaQuery>
+              <CourseRecommendations />
+            </Row>
+          </Container>
+        </CourseContextProvider>
+      </CourseEnrollmentsContextProvider>
     </>
   );
 }

--- a/src/components/course/enrollment/tests/EnrollAction.test.jsx
+++ b/src/components/course/enrollment/tests/EnrollAction.test.jsx
@@ -68,10 +68,10 @@ const renderEnrollAction = ({
     },
   },
   initialSubsidyRequestsState = {
-    catalogsForSubsidyRequests: new Set(),
+    catalogsForSubsidyRequests: [],
   },
   initialCourseEnrollmentsRequestState = {
-    courseEnrollmentsByStatus: new Set(),
+    courseEnrollmentsByStatus: {},
   },
 }) => {
   // need to use router, to render component such as react-router's <Link>

--- a/src/components/course/enrollment/tests/hooks.test.jsx
+++ b/src/components/course/enrollment/tests/hooks.test.jsx
@@ -28,7 +28,7 @@ const LICENSE_UUID = 'test-license-uuid';
 const subscriptionLicense = { uuid: LICENSE_UUID };
 
 const baseSubsidyRequestContextValue = {
-  catalogsForSubsidyRequests: new Set(),
+  catalogsForSubsidyRequests: [],
 };
 
 const baseUserSubsidyState = {

--- a/src/components/course/tests/CourseAssociatedPrograms.test.jsx
+++ b/src/components/course/tests/CourseAssociatedPrograms.test.jsx
@@ -8,7 +8,7 @@ import CourseAssociatedPrograms from '../CourseAssociatedPrograms';
 import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 
 const baseSubsidyRequestContextValue = {
-  catalogsForSubsidyRequests: new Set(),
+  catalogsForSubsidyRequests: [],
 };
 
 const CourseAssociatedProgramsWithCourseContext = ({

--- a/src/components/course/tests/CourseContextProvider.test.jsx
+++ b/src/components/course/tests/CourseContextProvider.test.jsx
@@ -6,7 +6,7 @@ import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import { CourseContextProvider, CourseContext } from '../CourseContextProvider';
 
 const baseSubsidyRequestContextValue = {
-  catalogsForSubsidyRequests: new Set(),
+  catalogsForSubsidyRequests: [],
 };
 
 const baseInitialCourseState = {
@@ -63,7 +63,7 @@ describe('<CourseContextProvider>', () => {
     };
     const subsidyRequestContextValue = {
       ...baseSubsidyRequestContextValue,
-      catalogsForSubsidyRequests: new Set([testCatalogUUID]),
+      catalogsForSubsidyRequests: [testCatalogUUID],
     };
     render(
       <CourseContextProviderWrapper

--- a/src/components/course/tests/CourseHeader.test.jsx
+++ b/src/components/course/tests/CourseHeader.test.jsx
@@ -28,7 +28,7 @@ const baseSubsidyRequestsState = {
     [SUBSIDY_TYPE.LICENSE]: [],
     [SUBSIDY_TYPE.COUPON]: [],
   },
-  catalogsForSubsidyRequests: new Set(),
+  catalogsForSubsidyRequests: [],
 };
 
 /* eslint-disable react/prop-types */

--- a/src/components/course/tests/CourseRunCard.test.jsx
+++ b/src/components/course/tests/CourseRunCard.test.jsx
@@ -92,7 +92,7 @@ const renderCard = ({
       subsidyRequestsEnabled: true,
     },
     isLoading: false,
-    catalogsForSubsidyRequests: new Set(),
+    catalogsForSubsidyRequests: [],
   },
   subsidyRequestCatalogsApplicableToCourse = baseSubsidyRequestCatalogsApplicableToCourse,
 }) => {

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -84,7 +84,7 @@ const defaultSubsidyRequestsState = {
     [SUBSIDY_TYPE.LICENSE]: [],
     [SUBSIDY_TYPE.COUPON]: [],
   },
-  catalogsForSubsidyRequests: new Set(),
+  catalogsForSubsidyRequests: [],
 };
 
 /* eslint-disable react/prop-types */

--- a/src/components/course/tests/CourseSkills.test.jsx
+++ b/src/components/course/tests/CourseSkills.test.jsx
@@ -22,7 +22,7 @@ const baseCourseState = {
 };
 
 const baseSubsidyRequestContextValue = {
-  catalogsForSubsidyRequests: new Set(),
+  catalogsForSubsidyRequests: [],
 };
 
 const CourseSkillsWithContext = ({

--- a/src/components/course/tests/CreatedBy.test.jsx
+++ b/src/components/course/tests/CreatedBy.test.jsx
@@ -9,7 +9,7 @@ import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import { TEST_OWNER, TEST_STAFF } from './data/constants';
 
 const initialSubsidyRequestsState = {
-  catalogsForSubsidyRequests: new Set(),
+  catalogsForSubsidyRequests: [],
 };
 
 // eslint-disable-next-line react/prop-types

--- a/src/components/course/tests/EnrollModal.test.jsx
+++ b/src/components/course/tests/EnrollModal.test.jsx
@@ -26,11 +26,11 @@ const baseCourseInitialState = {
 };
 
 const baseSubsidyRequestContextValue = {
-  catalogsForSubsidyRequests: new Set(),
+  catalogsForSubsidyRequests: [],
 };
 
 const baseCourseEnrollmentsContextValue = {
-  courseEnrollmentsByStatus: new Set(),
+  courseEnrollmentsByStatus: {},
 };
 
 const EnrollModalWrapper = ({

--- a/src/components/course/tests/SubsidyRequestButton.test.jsx
+++ b/src/components/course/tests/SubsidyRequestButton.test.jsx
@@ -36,7 +36,7 @@ const initialSubsidyRequestsState = {
     [SUBSIDY_TYPE.COUPON]: [],
   },
   refreshSubsidyRequests: mockRefreshSubsidyRequests,
-  catalogsForSubsidyRequests: new Set(),
+  catalogsForSubsidyRequests: [],
 };
 
 const TEST_CATALOG_UUID = 'test-catalog-uuid';

--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -13,7 +13,6 @@ import { DashboardSidebar } from './sidebar';
 import SubscriptionExpirationModal from './SubscriptionExpirationModal';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import { CourseEnrollmentsContextProvider } from './main-content/course-enrollments';
-import { SubsidyRequestsContextProvider } from '../enterprise-subsidy-requests';
 
 export const LICENCE_ACTIVATION_MESSAGE = 'Your license was successfully activated.';
 
@@ -50,20 +49,18 @@ export default function DashboardPage() {
       </Container>
       <Container size="lg" className="py-5">
         <Row>
-          <SubsidyRequestsContextProvider>
-            <CourseEnrollmentsContextProvider>
-              <MainContent>
-                <DashboardMainContent />
-              </MainContent>
-              <MediaQuery minWidth={breakpoints.large.minWidth}>
-                {matches => (matches ? (
-                  <Sidebar data-testid="sidebar">
-                    <DashboardSidebar />
-                  </Sidebar>
-                ) : null)}
-              </MediaQuery>
-            </CourseEnrollmentsContextProvider>
-          </SubsidyRequestsContextProvider>
+          <CourseEnrollmentsContextProvider>
+            <MainContent>
+              <DashboardMainContent />
+            </MainContent>
+            <MediaQuery minWidth={breakpoints.large.minWidth}>
+              {matches => (matches ? (
+                <Sidebar data-testid="sidebar">
+                  <DashboardSidebar />
+                </Sidebar>
+              ) : null)}
+            </MediaQuery>
+          </CourseEnrollmentsContextProvider>
           <IntegrationWarningModal isOpen={enterpriseConfig.showIntegrationWarning} />
           {subscriptionPlan && showExpirationNotifications && <SubscriptionExpirationModal />}
         </Row>

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -87,7 +87,7 @@ const defaultSubsidyRequestState = {
     [SUBSIDY_TYPE.LICENSE]: [],
     [SUBSIDY_TYPE.COUPON]: [],
   },
-  catalogsForSubsidyRequests: new Set(),
+  catalogsForSubsidyRequests: [],
 };
 
 const mockWindowConfig = {

--- a/src/components/enterprise-subsidy-requests/data/hooks.js
+++ b/src/components/enterprise-subsidy-requests/data/hooks.js
@@ -124,7 +124,7 @@ export const useCatalogsForSubsidyRequests = ({
           );
           const { results } = camelCaseObject(response.data);
           const catalogsFromCoupons = results.map(coupon => coupon.enterpriseCatalogUuid);
-          setCatalogs(new Set(catalogsFromCoupons));
+          setCatalogs([...new Set(catalogsFromCoupons)]);
         } catch (error) {
           logError(error);
         }
@@ -134,7 +134,7 @@ export const useCatalogsForSubsidyRequests = ({
         const catalogsFromSubscriptions = customerAgreementConfig.subscriptions.map(
           subscription => subscription.enterpriseCatalogUuid,
         );
-        setCatalogs(new Set(catalogsFromSubscriptions));
+        setCatalogs([...new Set(catalogsFromSubscriptions)]);
       }
 
       setIsLoading(false);

--- a/src/components/program-progress/ProgramProgressPage.jsx
+++ b/src/components/program-progress/ProgramProgressPage.jsx
@@ -14,7 +14,6 @@ import ProgramProgressSideBar from './ProgramProgressSidebar';
 import ProgramProgressCourses from './ProgramProgressCourses';
 
 import { useLearnerProgramProgressData } from './data/hooks';
-import { SubsidyRequestsContextProvider } from '../enterprise-subsidy-requests';
 import { CourseEnrollmentsContextProvider } from '../dashboard/main-content/course-enrollments';
 import {
   getCoursesEnrolledInAuditMode,
@@ -78,45 +77,43 @@ const ProgramProgressPage = () => {
   return (
     <>
       <Helmet title={PROGRAM_TITLE} />
-      <SubsidyRequestsContextProvider>
-        <CourseEnrollmentsContextProvider>
-          <ProgramProgressContextProvider initialState={initialState}>
-            <Container fluid={false} size="lg">
-              <ProgramProgressHeader />
-              <Row>
-                <article className="col-8">
-                  {allCoursesCompleted
-                    ? (
-                      <>
-                        <h3>Congratulations!</h3>
-                        <p>You have successfully completed all the requirements for the {PROGRAM_TITLE}.</p>
-                      </>
-                    )
-                    : (
-                      <>
-                        <h3> Your Program Journey</h3>
-                        <p>Track and plan your progress through the {totalCoursesInProgram} courses in this program.</p>
-                        <p>To complete the program, you must earn a verified certificate for each course.</p>
-                      </>
-                    )}
-                  <SubsidiesSummary
-                    totalCoursesEligibleForCertificate={totalCoursesEligibleForCertificate}
-                    courseEndDate={courseEndDate}
-                    programProgressPage
-                  />
-                  <ProgramProgressCourses courseData={courseData} />
-                </article>
-
-                <MediaQuery minWidth={breakpoints.large.minWidth}>
-                  {matches => matches && (
-                    <ProgramProgressSideBar />
+      <CourseEnrollmentsContextProvider>
+        <ProgramProgressContextProvider initialState={initialState}>
+          <Container fluid={false} size="lg">
+            <ProgramProgressHeader />
+            <Row>
+              <article className="col-8">
+                {allCoursesCompleted
+                  ? (
+                    <>
+                      <h3>Congratulations!</h3>
+                      <p>You have successfully completed all the requirements for the {PROGRAM_TITLE}.</p>
+                    </>
+                  )
+                  : (
+                    <>
+                      <h3> Your Program Journey</h3>
+                      <p>Track and plan your progress through the {totalCoursesInProgram} courses in this program.</p>
+                      <p>To complete the program, you must earn a verified certificate for each course.</p>
+                    </>
                   )}
-                </MediaQuery>
-              </Row>
-            </Container>
-          </ProgramProgressContextProvider>
-        </CourseEnrollmentsContextProvider>
-      </SubsidyRequestsContextProvider>
+                <SubsidiesSummary
+                  totalCoursesEligibleForCertificate={totalCoursesEligibleForCertificate}
+                  courseEndDate={courseEndDate}
+                  programProgressPage
+                />
+                <ProgramProgressCourses courseData={courseData} />
+              </article>
+
+              <MediaQuery minWidth={breakpoints.large.minWidth}>
+                {matches => matches && (
+                  <ProgramProgressSideBar />
+                )}
+              </MediaQuery>
+            </Row>
+          </Container>
+        </ProgramProgressContextProvider>
+      </CourseEnrollmentsContextProvider>
     </>
   );
 };

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -10,7 +10,7 @@ import { SearchHeader, SearchContext } from '@edx/frontend-enterprise-catalog-se
 import { useToggle } from '@edx/paragon';
 
 import algoliasearch from 'algoliasearch/lite';
-import { useDefaultSearchFilters } from './data/hooks';
+import { useDefaultSearchFilters, useSearchCatalogs } from './data/hooks';
 import {
   NUM_RESULTS_PER_PAGE,
   CONTENT_TYPE_COURSE,
@@ -43,21 +43,28 @@ const Search = () => {
   const { enterpriseConfig, algolia } = useContext(AppContext);
   const {
     subscriptionPlan,
-    subscriptionLicense, couponCodes: { couponCodes },
+    subscriptionLicense,
+    couponCodes: { couponCodes },
+    enterpriseOffers,
     canEnrollWithEnterpriseOffers,
     hasLowEnterpriseOffersBalance,
   } = useContext(UserSubsidyContext);
-  const couponCodesCatalogs = couponCodes.map((couponCode) => couponCode.catalog);
-  const { subsidyRequestConfiguration, catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
+
+  const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
+
+  const searchCatalogs = useSearchCatalogs({
+    subscriptionPlan,
+    subscriptionLicense,
+    couponCodes,
+    enterpriseOffers,
+    catalogsForSubsidyRequests,
+  });
 
   const { filters } = useDefaultSearchFilters({
     enterpriseConfig,
-    subscriptionPlan,
-    subscriptionLicense,
-    couponCodesCatalogs,
-    subsidyRequestConfiguration,
-    catalogsForSubsidyRequests: [...catalogsForSubsidyRequests],
+    searchCatalogs,
   });
+
   useEffect(() => {
     if (pathwayUUID) {
       openLearnerPathwayModal();

--- a/src/components/search/SearchPage.jsx
+++ b/src/components/search/SearchPage.jsx
@@ -3,14 +3,11 @@ import { SearchData } from '@edx/frontend-enterprise-catalog-search';
 
 import Search from './Search';
 import { SEARCH_FACET_FILTERS } from './constants';
-import { SubsidyRequestsContextProvider } from '../enterprise-subsidy-requests';
 
 const SearchPage = () => (
-  <SubsidyRequestsContextProvider>
-    <SearchData searchFacetFilters={SEARCH_FACET_FILTERS}>
-      <Search />
-    </SearchData>
-  </SubsidyRequestsContextProvider>
+  <SearchData searchFacetFilters={SEARCH_FACET_FILTERS}>
+    <Search />
+  </SearchData>
 );
 
 export default SearchPage;

--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -1,70 +1,79 @@
-import { useContext, useMemo, useEffect } from 'react';
+import {
+  useContext, useMemo, useEffect,
+} from 'react';
 import {
   SearchContext, getCatalogString, SHOW_ALL_NAME, setRefinementAction,
 } from '@edx/frontend-enterprise-catalog-search';
 import { features } from '../../../config';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 
-export const useDefaultSearchFilters = ({
-  enterpriseConfig,
+export const useSearchCatalogs = ({
   subscriptionPlan,
   subscriptionLicense,
-  couponCodesCatalogs = [],
-  subsidyRequestConfiguration,
-  catalogsForSubsidyRequests = [],
+  couponCodes,
+  enterpriseOffers,
+  catalogsForSubsidyRequests,
 }) => {
-  // default to showing all catalogs
-  const { refinements, dispatch } = useContext(SearchContext);
+  const searchCatalogs = useMemo(() => {
+    const catalogs = [];
 
-  useEffect(() => {
-    // don't default to showing all catalogs if browse and request is turned on
-    // and there are catalogs associated with assignable subsidies
-    if (
-      features.FEATURE_BROWSE_AND_REQUEST
-      && subsidyRequestConfiguration?.subsidyRequestsEnabled
-      && catalogsForSubsidyRequests.length > 0
-    ) {
-      return;
+    // Scope to catalogs from coupons, enterprise offers, or subscription plan associated with learner's license
+    if (subscriptionPlan && subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED) {
+      catalogs.push(subscriptionPlan.enterpriseCatalogUuid);
+    }
+    if (features.ENROLL_WITH_CODES) {
+      catalogs.push(...couponCodes.map((couponCode) => couponCode.catalog));
+    }
+    if (features.FEATURE_ENROLL_WITH_ENTERPRISE_OFFERS) {
+      catalogs.push(...enterpriseOffers.map((offer) => offer.enterpriseCatalogUuid));
     }
 
-    // if the user has no subscriptions or coupon codes, we default to showing all catalogs
-    if (!(subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED) && couponCodesCatalogs.length < 1) {
+    // Scope to catalogs associated with assignable subsidies if browse and request is turned on
+    if (
+      features.FEATURE_BROWSE_AND_REQUEST
+      && catalogsForSubsidyRequests.length > 0
+    ) {
+      catalogs.push(...catalogsForSubsidyRequests);
+    }
+
+    return catalogs;
+  }, [
+    subscriptionPlan,
+    subscriptionLicense,
+    couponCodes,
+    enterpriseOffers,
+    catalogsForSubsidyRequests,
+  ]);
+
+  return searchCatalogs;
+};
+
+export const useDefaultSearchFilters = ({
+  enterpriseConfig,
+  searchCatalogs,
+}) => {
+  const { refinements, dispatch } = useContext(SearchContext);
+  const showAllRefinement = refinements[SHOW_ALL_NAME];
+
+  useEffect(() => {
+    // default to showing all catalogs if there are no confined search catalogs
+    if (searchCatalogs.length === 0 && !showAllRefinement) {
       dispatch(setRefinementAction(SHOW_ALL_NAME, 1));
     }
   }, [
-    subsidyRequestConfiguration?.subsidyRequestsEnabled,
-    catalogsForSubsidyRequests,
-    subscriptionLicense?.status,
-    couponCodesCatalogs.length,
+    searchCatalogs,
+    showAllRefinement,
   ]);
 
   const filters = useMemo(
     () => {
       // Show all enterprise catalogs
-      if (refinements[SHOW_ALL_NAME]) {
+      if (showAllRefinement) {
         return `enterprise_customer_uuids:${enterpriseConfig.uuid}`;
       }
 
-      // Scope to catalogs from coupons and/or the subscription plan associated with learner's license
-      const catalogs = [];
-      if (features.ENROLL_WITH_CODES) {
-        catalogs.push(...couponCodesCatalogs);
-      }
-      if (subscriptionPlan && subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED) {
-        catalogs.push(subscriptionPlan.enterpriseCatalogUuid);
-      }
-
-      // Scope to catalogs associated with assignable subsidies if browse and request is turned on
-      if (
-        features.FEATURE_BROWSE_AND_REQUEST
-        && subsidyRequestConfiguration?.subsidyRequestsEnabled
-        && catalogsForSubsidyRequests.length > 0
-      ) {
-        catalogs.push(...catalogsForSubsidyRequests);
-      }
-
-      if (catalogs.length > 0) {
-        return getCatalogString(catalogs);
+      if (searchCatalogs.length > 0) {
+        return getCatalogString(searchCatalogs);
       }
 
       // If the learner is not confined to certain catalogs, scope to all of the enterprise's catalogs
@@ -72,12 +81,8 @@ export const useDefaultSearchFilters = ({
     },
     [
       enterpriseConfig,
-      subscriptionPlan,
-      couponCodesCatalogs,
       JSON.stringify(refinements),
-      subscriptionLicense?.status,
-      subsidyRequestConfiguration?.subsidyRequestsEnabled,
-      catalogsForSubsidyRequests,
+      searchCatalogs,
     ],
   );
 

--- a/src/components/search/popular-results/PopularResultsIndex.jsx
+++ b/src/components/search/popular-results/PopularResultsIndex.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Index, Configure } from 'react-instantsearch-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform/';
-import { useDefaultSearchFilters } from '../data/hooks';
+import { useDefaultSearchFilters, useSearchCatalogs } from '../data/hooks';
 import PopularResults from './PopularResults';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { NUM_RESULTS_TO_DISPLAY } from './data/constants';
@@ -12,19 +12,23 @@ import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 
 const PopularResultsIndex = ({ title, numberResultsToDisplay }) => {
   const { enterpriseConfig } = useContext(AppContext);
-  const { subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes } } = useContext(UserSubsidyContext);
-  const couponCodesCatalogs = couponCodes.map((couponCode) => couponCode.catalog);
+  const {
+    subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes }, enterpriseOffers,
+  } = useContext(UserSubsidyContext);
 
-  const { subsidyRequestConfiguration, catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
-  const { filters } = useDefaultSearchFilters({
-    enterpriseConfig,
+  const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
+  const searchCatalogs = useSearchCatalogs({
     subscriptionPlan,
     subscriptionLicense,
-    couponCodesCatalogs,
-    subsidyRequestConfiguration,
-    catalogsForSubsidyRequests: [...catalogsForSubsidyRequests],
+    couponCodes,
+    enterpriseOffers,
+    catalogsForSubsidyRequests,
   });
 
+  const { filters } = useDefaultSearchFilters({
+    enterpriseConfig,
+    searchCatalogs,
+  });
   const config = getConfig();
   const contentType = getContentTypeFromTitle(title);
   const defaultFilter = `content_type:${contentType} AND ${filters}`;

--- a/src/components/skills-quiz/SearchCourseCard.jsx
+++ b/src/components/skills-quiz/SearchCourseCard.jsx
@@ -12,9 +12,10 @@ import { SkillsContext } from './SkillsContextProvider';
 
 import { NO_COURSES_ALERT_MESSAGE } from './constants';
 import { useSelectedSkillsAndJobSkills } from './data/hooks';
-import { useDefaultSearchFilters } from '../search/data/hooks';
+import { useDefaultSearchFilters, useSearchCatalogs } from '../search/data/hooks';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import CourseCard from './CourseCard';
+import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 
 const renderDialog = () => (
   <div className="lead d-flex align-items-center py-3">
@@ -29,13 +30,22 @@ const renderDialog = () => (
 
 const SearchCourseCard = ({ index }) => {
   const { enterpriseConfig } = useContext(AppContext);
-  const { subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes } } = useContext(UserSubsidyContext);
-  const couponCodesCatalogs = couponCodes.map((couponCode) => couponCode.catalog);
-  const { filters } = useDefaultSearchFilters({
-    enterpriseConfig,
+  const {
+    subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes }, enterpriseOffers,
+  } = useContext(UserSubsidyContext);
+  const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
+
+  const searchCatalogs = useSearchCatalogs({
     subscriptionPlan,
     subscriptionLicense,
-    couponCodesCatalogs,
+    couponCodes,
+    enterpriseOffers,
+    catalogsForSubsidyRequests,
+  });
+
+  const { filters } = useDefaultSearchFilters({
+    enterpriseConfig,
+    searchCatalogs,
   });
 
   const { state } = useContext(SkillsContext);

--- a/src/components/skills-quiz/SearchPathways.jsx
+++ b/src/components/skills-quiz/SearchPathways.jsx
@@ -8,19 +8,29 @@ import { camelCaseObject } from '@edx/frontend-platform/utils';
 
 import { SkillsContext } from './SkillsContextProvider';
 import { useSelectedSkillsAndJobSkills } from './data/hooks';
-import { useDefaultSearchFilters } from '../search/data/hooks';
+import { useDefaultSearchFilters, useSearchCatalogs } from '../search/data/hooks';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import SearchPathwayCard from '../pathway/SearchPathwayCard';
+import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 
 const SearchPathways = ({ index }) => {
   const { enterpriseConfig } = useContext(AppContext);
-  const { subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes } } = useContext(UserSubsidyContext);
-  const couponCodesCatalogs = couponCodes.map((couponCode) => couponCode.catalog);
-  const { filters } = useDefaultSearchFilters({
-    enterpriseConfig,
+  const {
+    subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes }, enterpriseOffers,
+  } = useContext(UserSubsidyContext);
+  const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
+
+  const searchCatalogs = useSearchCatalogs({
     subscriptionPlan,
     subscriptionLicense,
-    couponCodesCatalogs,
+    couponCodes,
+    enterpriseOffers,
+    catalogsForSubsidyRequests,
+  });
+
+  const { filters } = useDefaultSearchFilters({
+    enterpriseConfig,
+    searchCatalogs,
   });
 
   const { state } = useContext(SkillsContext);

--- a/src/components/skills-quiz/SearchProgramCard.jsx
+++ b/src/components/skills-quiz/SearchProgramCard.jsx
@@ -23,9 +23,10 @@ import { shortenString } from '../course/data/utils';
 import { SKILL_NAME_CUTOFF_LIMIT, MAX_VISIBLE_SKILLS_PROGRAM, NO_PROGRAMS_ALERT_MESSAGE } from './constants';
 import getCommonSkills from './data/utils';
 import { useSelectedSkillsAndJobSkills } from './data/hooks';
-import { useDefaultSearchFilters } from '../search/data/hooks';
+import { useDefaultSearchFilters, useSearchCatalogs } from '../search/data/hooks';
 import { ProgramType } from '../search/SearchProgramCard';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
+import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 
 const linkToProgram = (program, slug, enterpriseUUID, programUuid) => {
   if (!Object.keys(program).length) {
@@ -57,13 +58,22 @@ const renderDialog = () => (
 const SearchProgramCard = ({ index }) => {
   const { enterpriseConfig } = useContext(AppContext);
   const { slug, uuid } = enterpriseConfig;
-  const { subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes } } = useContext(UserSubsidyContext);
-  const couponCodesCatalogs = couponCodes.map((couponCode) => couponCode.catalog);
-  const { filters } = useDefaultSearchFilters({
-    enterpriseConfig,
+  const {
+    subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes }, enterpriseOffers,
+  } = useContext(UserSubsidyContext);
+  const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
+
+  const searchCatalogs = useSearchCatalogs({
     subscriptionPlan,
     subscriptionLicense,
-    couponCodesCatalogs,
+    couponCodes,
+    enterpriseOffers,
+    catalogsForSubsidyRequests,
+  });
+
+  const { filters } = useDefaultSearchFilters({
+    enterpriseConfig,
+    searchCatalogs,
   });
 
   const { state } = useContext(SkillsContext);

--- a/src/components/skills-quiz/SkillsCourses.jsx
+++ b/src/components/skills-quiz/SkillsCourses.jsx
@@ -17,12 +17,13 @@ import { useSelectedSkillsAndJobSkills } from './data/hooks';
 import { sortSkillsCoursesWithCourseCount } from './data/utils';
 import { SkillsContext } from './SkillsContextProvider';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
-import { useDefaultSearchFilters } from '../search/data/hooks';
+import { useDefaultSearchFilters, useSearchCatalogs } from '../search/data/hooks';
 import {
   NO_COURSES_ALERT_MESSAGE_AGAINST_SKILLS,
 } from './constants';
 import CardLoadingSkeleton from './CardLoadingSkeleton';
 import CourseCard from './CourseCard';
+import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 
 const renderDialog = () => (
   <div className="lead d-flex align-items-center py-3">
@@ -46,15 +47,24 @@ const SkillsCourses = ({ index }) => {
   const { selectedJob } = state;
   const allSkills = useSelectedSkillsAndJobSkills({ getAllSkills: true });
 
-  const { subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes } } = useContext(UserSubsidyContext);
-  const couponCodesCatalogs = couponCodes.map((couponCode) => couponCode.catalog);
+  const {
+    subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes }, enterpriseOffers,
+  } = useContext(UserSubsidyContext);
+  const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
+
+  const searchCatalogs = useSearchCatalogs({
+    subscriptionPlan,
+    subscriptionLicense,
+    couponCodes,
+    enterpriseOffers,
+    catalogsForSubsidyRequests,
+  });
 
   const { filters } = useDefaultSearchFilters({
     enterpriseConfig,
-    subscriptionPlan,
-    subscriptionLicense,
-    couponCodesCatalogs,
+    searchCatalogs,
   });
+
   const skillsFacetFilter = useMemo(
     () => {
       if (allSkills) {

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -26,7 +26,7 @@ import SelectJobCard from './SelectJobCard';
 import TagCloud from '../TagCloud';
 import SkillsCourses from './SkillsCourses';
 
-import { useDefaultSearchFilters } from '../search/data/hooks';
+import { useDefaultSearchFilters, useSearchCatalogs } from '../search/data/hooks';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import {
   DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE, STEP1, STEP2, STEP3, SKILLS_QUIZ_SEARCH_PAGE_MESSAGE,
@@ -38,6 +38,7 @@ import SelectedJobSkills from './SelectedJobSkills';
 import SkillsQuizHeader from './SkillsQuizHeader';
 
 import headerImage from './images/headerImage.png';
+import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 
 const SkillsQuizStepper = () => {
   const config = getConfig();
@@ -64,13 +65,24 @@ const SkillsQuizStepper = () => {
   const { refinements, dispatch } = useContext(SearchContext);
   const { skill_names: skills, name: jobs, current_job: currentJob } = refinements;
   const { enterpriseConfig } = useContext(AppContext);
-  const { subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes } } = useContext(UserSubsidyContext);
-  const couponCodesCatalogs = couponCodes.map((couponCode) => couponCode.catalog);
-  const { filters } = useDefaultSearchFilters({
-    enterpriseConfig,
+  const {
     subscriptionPlan,
     subscriptionLicense,
-    couponCodesCatalogs,
+    couponCodes: { couponCodes },
+    enterpriseOffers,
+  } = useContext(UserSubsidyContext);
+  const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
+  const searchCatalogs = useSearchCatalogs({
+    subscriptionPlan,
+    subscriptionLicense,
+    couponCodes,
+    enterpriseOffers,
+    catalogsForSubsidyRequests,
+  });
+
+  const { filters } = useDefaultSearchFilters({
+    enterpriseConfig,
+    searchCatalogs,
   });
   const history = useHistory();
 

--- a/src/components/skills-quiz/tests/SearchCourseCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchCourseCard.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import '@testing-library/jest-dom';
 import { screen, act } from '@testing-library/react';
@@ -11,6 +12,7 @@ import { renderWithRouter } from '../../../utils/tests';
 import { TEST_IMAGE_URL, TEST_ENTERPRISE_SLUG } from '../../search/tests/constants';
 import { NO_COURSES_ALERT_MESSAGE } from '../constants';
 import { SkillsContext } from '../SkillsContextProvider';
+import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 
 jest.mock('@edx/frontend-platform/auth', () => ({
   ...jest.requireActual('@edx/frontend-platform/auth'),
@@ -29,29 +31,8 @@ jest.mock('react-truncate', () => ({
 
 jest.mock('react-loading-skeleton', () => ({
   __esModule: true,
-  // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
-
-/* eslint-disable react/prop-types */
-const SearchCourseCardWithContext = ({
-  initialAppState,
-  initialSkillsState,
-  initialUserSubsidyState,
-  searchContext,
-  index,
-}) => (
-  <AppContext.Provider value={initialAppState}>
-    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-      <SearchContext.Provider value={searchContext}>
-        <SkillsContext.Provider value={initialSkillsState}>
-          <SearchCourseCard index={index} />
-        </SkillsContext.Provider>
-      </SearchContext.Provider>
-    </UserSubsidyContext.Provider>
-  </AppContext.Provider>
-);
-/* eslint-enable react/prop-types */
 
 const TEST_COURSE_KEY = 'test-course-key';
 const TEST_TITLE = 'Test Title';
@@ -79,18 +60,18 @@ const testIndex = {
   search: jest.fn().mockImplementation(() => Promise.resolve(courses)),
 };
 
-const initialAppState = {
+const defaultAppState = {
   enterpriseConfig: {
     slug: 'test-enterprise-slug',
   },
 };
 
-const searchContext = {
+const defaultSearchContext = {
   refinements: { skill_names: ['test-skill-1', 'test-skill-2'] },
   dispatch: () => null,
 };
 
-const initialSkillsState = {
+const defaultSkillsState = {
   state: {
     goal: 'Goal',
     selectedJob: 'job-1',
@@ -116,9 +97,34 @@ const defaultCouponCodesState = {
   couponCodesCount: 0,
 };
 
-const initialUserSubsidyState = {
+const defaultUserSubsidyState = {
   couponCodes: defaultCouponCodesState,
 };
+
+const defaultSubsidyRequestState = {
+  catalogsForSubsidyRequests: [],
+};
+
+const SearchCourseCardWithContext = ({
+  initialAppState = defaultAppState,
+  initialSkillsState = defaultSkillsState,
+  initialUserSubsidyState = defaultUserSubsidyState,
+  initialSubsidyRequestState = defaultSubsidyRequestState,
+  searchContext = defaultSearchContext,
+  index,
+}) => (
+  <AppContext.Provider value={initialAppState}>
+    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+      <SubsidyRequestsContext.Provider value={initialSubsidyRequestState}>
+        <SearchContext.Provider value={searchContext}>
+          <SkillsContext.Provider value={initialSkillsState}>
+            <SearchCourseCard index={index} />
+          </SkillsContext.Provider>
+        </SearchContext.Provider>
+      </SubsidyRequestsContext.Provider>
+    </UserSubsidyContext.Provider>
+  </AppContext.Provider>
+);
 
 describe('<SearchCourseCard />', () => {
   test('renders the correct data', async () => {
@@ -126,11 +132,7 @@ describe('<SearchCourseCard />', () => {
     await act(async () => {
       const { container } = renderWithRouter(
         <SearchCourseCardWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={testIndex}
-          searchContext={searchContext}
         />,
       );
       containerDOM = container;
@@ -168,11 +170,7 @@ describe('<SearchCourseCard />', () => {
     await act(async () => {
       renderWithRouter(
         <SearchCourseCardWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={courseIndex}
-          searchContext={searchContext}
         />,
       );
     });
@@ -203,11 +201,7 @@ describe('<SearchCourseCard />', () => {
     await act(async () => {
       renderWithRouter(
         <SearchCourseCardWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={courseIndex}
-          searchContext={searchContext}
         />,
       );
     });
@@ -228,11 +222,7 @@ describe('<SearchCourseCard />', () => {
     await act(async () => {
       renderWithRouter(
         <SearchCourseCardWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={courseIndex}
-          searchContext={searchContext}
         />,
       );
     });

--- a/src/components/skills-quiz/tests/SearchFilters.test.jsx
+++ b/src/components/skills-quiz/tests/SearchFilters.test.jsx
@@ -16,6 +16,7 @@ import {
 
 import '../__mocks__/react-instantsearch-dom';
 import SkillsQuizStepper from '../SkillsQuizStepper';
+import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 
 jest.mock('@edx/frontend-platform/auth', () => ({
   ...jest.requireActual('@edx/frontend-platform/auth'),
@@ -29,7 +30,7 @@ jest.mock('@edx/frontend-enterprise-utils', () => ({
 
 const facetsToTest = [DESIRED_JOB_FACET, SKILLS_FACET, CURRENT_JOB_FACET];
 describe('<SkillsQuizStepper />', () => {
-  const initialAppState = {
+  const defaultAppState = {
     enterpriseConfig: {
       slug: 'test-enterprise-slug',
     },
@@ -40,18 +41,25 @@ describe('<SkillsQuizStepper />', () => {
     couponCodesCount: 0,
   };
 
-  const initialUserSubsidyState = {
+  const defaultUserSubsidyState = {
     couponCodes: defaultCouponCodesState,
   };
+
+  const defaultSubsidyRequestState = {
+    catalogsForSubsidyRequests: [],
+  };
+
   test('renders skills and jobs dropdown with a label', async () => {
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchData>
-            <SkillsContextProvider>
-              <SkillsQuizStepper />
-            </SkillsContextProvider>
-          </SearchData>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchData>
+              <SkillsContextProvider>
+                <SkillsQuizStepper />
+              </SkillsContextProvider>
+            </SearchData>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/?skill_names=123' },

--- a/src/components/skills-quiz/tests/SearchPathways.test.jsx
+++ b/src/components/skills-quiz/tests/SearchPathways.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import '@testing-library/jest-dom';
 import { screen, act } from '@testing-library/react';
@@ -10,6 +11,7 @@ import SearchPathways from '../SearchPathways';
 import { renderWithRouter } from '../../../utils/tests';
 import { TEST_ENTERPRISE_SLUG } from '../../search/tests/constants';
 import { SkillsContext } from '../SkillsContextProvider';
+import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 
 jest.mock('@edx/frontend-platform/auth', () => ({
   ...jest.requireActual('@edx/frontend-platform/auth'),
@@ -32,26 +34,6 @@ jest.mock('react-loading-skeleton', () => ({
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
 
-/* eslint-disable react/prop-types */
-const SearchPathwaysWithContext = ({
-  initialAppState,
-  initialSkillsState,
-  initialUserSubsidyState,
-  searchContext,
-  index,
-}) => (
-  <AppContext.Provider value={initialAppState}>
-    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-      <SearchContext.Provider value={searchContext}>
-        <SkillsContext.Provider value={initialSkillsState}>
-          <SearchPathways index={index} />
-        </SkillsContext.Provider>
-      </SearchContext.Provider>
-    </UserSubsidyContext.Provider>
-  </AppContext.Provider>
-);
-/* eslint-enable react/prop-types */
-
 const TEST_PATHWAY_UUID = 'test-pathway-uuid';
 const TEST_TITLE = 'Test Title';
 const TEST_CARD_IMAGE_URL = 'http://fake.image';
@@ -72,19 +54,19 @@ const testIndex = {
   search: jest.fn().mockImplementation(() => Promise.resolve(pathways)),
 };
 
-const initialAppState = {
+const defaultAppState = {
   enterpriseConfig: {
     slug: TEST_ENTERPRISE_SLUG,
     uuid: '5d3v5ee2-761b-49b4-8f47-f6f51589d815',
   },
 };
 
-const searchContext = {
+const defaultSearchContext = {
   refinements: { skill_names: ['test-skill-1', 'test-skill-2'] },
   dispatch: () => null,
 };
 
-const initialSkillsState = {
+const defaultSkillsState = {
   state: {
     goal: 'Goal',
     selectedJob: 'job-1',
@@ -110,9 +92,34 @@ const defaultCouponCodesState = {
   couponCodesCount: 0,
 };
 
-const initialUserSubsidyState = {
+const defaultUserSubsidyState = {
   couponCodes: defaultCouponCodesState,
 };
+
+const defaultSubsidyRequestState = {
+  catalogsForSubsidyRequests: [],
+};
+
+const SearchPathwaysWithContext = ({
+  initialAppState = defaultAppState,
+  initialSkillsState = defaultSkillsState,
+  initialUserSubsidyState = defaultUserSubsidyState,
+  initialSubsidyRequestState = defaultSubsidyRequestState,
+  initialSearchContext = defaultSearchContext,
+  index,
+}) => (
+  <AppContext.Provider value={initialAppState}>
+    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+      <SubsidyRequestsContext.Provider value={initialSubsidyRequestState}>
+        <SearchContext.Provider value={initialSearchContext}>
+          <SkillsContext.Provider value={initialSkillsState}>
+            <SearchPathways index={index} />
+          </SkillsContext.Provider>
+        </SearchContext.Provider>
+      </SubsidyRequestsContext.Provider>
+    </UserSubsidyContext.Provider>
+  </AppContext.Provider>
+);
 
 describe('<SearchPathways />', () => {
   test('renders the correct data', async () => {
@@ -120,11 +127,7 @@ describe('<SearchPathways />', () => {
     await act(async () => {
       const { container } = renderWithRouter(
         <SearchPathwaysWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={testIndex}
-          searchContext={searchContext}
         />,
       );
       containerDOM = container;
@@ -149,11 +152,7 @@ describe('<SearchPathways />', () => {
     await act(async () => {
       renderWithRouter(
         <SearchPathwaysWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={pathwayIndex}
-          searchContext={searchContext}
         />,
       );
     });
@@ -174,11 +173,7 @@ describe('<SearchPathways />', () => {
     await act(async () => {
       const { container } = renderWithRouter(
         <SearchPathwaysWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={pathwayIndex}
-          searchContext={searchContext}
         />,
       );
       containerDOM = container;

--- a/src/components/skills-quiz/tests/SearchProgramCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchProgramCard.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import '@testing-library/jest-dom';
 import { screen, act } from '@testing-library/react';
@@ -11,6 +12,7 @@ import { renderWithRouter } from '../../../utils/tests';
 import { TEST_ENTERPRISE_SLUG } from '../../search/tests/constants';
 import { NO_PROGRAMS_ALERT_MESSAGE } from '../constants';
 import { SkillsContext } from '../SkillsContextProvider';
+import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 
 const userId = 'batman';
 
@@ -34,26 +36,6 @@ jest.mock('react-loading-skeleton', () => ({
   // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
-
-/* eslint-disable react/prop-types */
-const SearchProgramCardWithContext = ({
-  initialAppState,
-  initialSkillsState,
-  initialUserSubsidyState,
-  searchContext,
-  index,
-}) => (
-  <AppContext.Provider value={initialAppState}>
-    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-      <SearchContext.Provider value={searchContext}>
-        <SkillsContext.Provider value={initialSkillsState}>
-          <SearchProgramCard index={index} />
-        </SkillsContext.Provider>
-      </SearchContext.Provider>
-    </UserSubsidyContext.Provider>
-  </AppContext.Provider>
-);
-/* eslint-enable react/prop-types */
 
 const PROGRAM_UUID = 'a9cbdeb6-5fc0-44ef-97f7-9ed605a149db';
 const PROGRAM_TITLE = 'Intro to BatVerse';
@@ -90,19 +72,19 @@ const testIndex = {
   search: jest.fn().mockImplementation(() => Promise.resolve(programs)),
 };
 
-const initialAppState = {
+const defaultAppState = {
   enterpriseConfig: {
     slug: TEST_ENTERPRISE_SLUG,
     uuid: '5d3v5ee2-761b-49b4-8f47-f6f51589d815',
   },
 };
 
-const searchContext = {
+const defaultSearchContext = {
   refinements: { skill_names: ['test-skill-1', 'test-skill-2'] },
   dispatch: () => null,
 };
 
-const initialSkillsState = {
+const defaultSkillsState = {
   state: {
     goal: 'Goal',
     selectedJob: 'job-1',
@@ -128,9 +110,33 @@ const defaultCouponCodesState = {
   couponCodesCount: 0,
 };
 
-const initialUserSubsidyState = {
+const defaultUserSubsidyState = {
   couponCodes: defaultCouponCodesState,
 };
+
+const defaultSubsidyRequestState = {
+  catalogsForSubsidyRequests: [],
+};
+
+const SearchProgramCardWithContext = ({
+  initialAppState = defaultAppState,
+  initialSkillsState = defaultSkillsState,
+  initialUserSubsidyState = defaultUserSubsidyState,
+  initialSearchContext = defaultSearchContext,
+  index,
+}) => (
+  <AppContext.Provider value={initialAppState}>
+    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+      <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+        <SearchContext.Provider value={initialSearchContext}>
+          <SkillsContext.Provider value={initialSkillsState}>
+            <SearchProgramCard index={index} />
+          </SkillsContext.Provider>
+        </SearchContext.Provider>
+      </SubsidyRequestsContext.Provider>
+    </UserSubsidyContext.Provider>
+  </AppContext.Provider>
+);
 
 describe('<SearchProgramCard />', () => {
   test('renders the correct data', async () => {
@@ -138,11 +144,7 @@ describe('<SearchProgramCard />', () => {
     await act(async () => {
       const { container } = renderWithRouter(
         <SearchProgramCardWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={testIndex}
-          searchContext={searchContext}
         />,
       );
       containerDOM = container;
@@ -187,11 +189,7 @@ describe('<SearchProgramCard />', () => {
     await act(async () => {
       renderWithRouter(
         <SearchProgramCardWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={index}
-          searchContext={searchContext}
         />,
       );
     });
@@ -226,11 +224,7 @@ describe('<SearchProgramCard />', () => {
     await act(async () => {
       renderWithRouter(
         <SearchProgramCardWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={index}
-          searchContext={searchContext}
         />,
       );
     });
@@ -251,11 +245,7 @@ describe('<SearchProgramCard />', () => {
     await act(async () => {
       renderWithRouter(
         <SearchProgramCardWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={index}
-          searchContext={searchContext}
         />,
       );
     });

--- a/src/components/skills-quiz/tests/SkillsCourses.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsCourses.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import '@testing-library/jest-dom';
 import { screen, act } from '@testing-library/react';
@@ -11,6 +12,7 @@ import { renderWithRouter } from '../../../utils/tests';
 import { TEST_IMAGE_URL, TEST_ENTERPRISE_SLUG } from '../../search/tests/constants';
 import { NO_COURSES_ALERT_MESSAGE_AGAINST_SKILLS } from '../constants';
 import { SkillsContext } from '../SkillsContextProvider';
+import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 
 jest.mock('@edx/frontend-platform/auth', () => ({
   ...jest.requireActual('@edx/frontend-platform/auth'),
@@ -32,26 +34,6 @@ jest.mock('react-loading-skeleton', () => ({
   // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
-
-/* eslint-disable react/prop-types */
-const SkillsCoursesWithContext = ({
-  initialAppState,
-  initialSkillsState,
-  initialUserSubsidyState,
-  searchContext,
-  index,
-}) => (
-  <AppContext.Provider value={initialAppState}>
-    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-      <SearchContext.Provider value={searchContext}>
-        <SkillsContext.Provider value={initialSkillsState}>
-          <SkillsCourses index={index} />
-        </SkillsContext.Provider>
-      </SearchContext.Provider>
-    </UserSubsidyContext.Provider>
-  </AppContext.Provider>
-);
-/* eslint-enable react/prop-types */
 
 const TEST_COURSE_KEY = 'test-course-key';
 const SKILLS_HEADING = 'Skills';
@@ -80,18 +62,18 @@ const testIndex = {
   search: jest.fn().mockImplementation(() => Promise.resolve(courses)),
 };
 
-const initialAppState = {
+const defaultAppState = {
   enterpriseConfig: {
     slug: 'test-enterprise-slug',
   },
 };
 
-const searchContext = {
+const defaultSearchContext = {
   refinements: { skill_names: ['test-skill-3'] },
   dispatch: () => null,
 };
 
-const initialSkillsState = {
+const defaultSkillsState = {
   state: {
     goal: 'Goal',
     selectedJob: 'job-1',
@@ -117,9 +99,34 @@ const defaultCouponCodesState = {
   couponCodesCount: 0,
 };
 
-const initialUserSubsidyState = {
+const defaultUserSubsidyState = {
   couponCodes: defaultCouponCodesState,
 };
+
+const defaultSubsidyRequestState = {
+  catalogsForSubsidyRequests: [],
+};
+
+const SkillsCoursesWithContext = ({
+  initialAppState = defaultAppState,
+  initialSkillsState = defaultSkillsState,
+  initialUserSubsidyState = defaultUserSubsidyState,
+  initialSubsidyRequestState = defaultSubsidyRequestState,
+  searchContext = defaultSearchContext,
+  index,
+}) => (
+  <AppContext.Provider value={initialAppState}>
+    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+      <SubsidyRequestsContext.Provider value={initialSubsidyRequestState}>
+        <SearchContext.Provider value={searchContext}>
+          <SkillsContext.Provider value={initialSkillsState}>
+            <SkillsCourses index={index} />
+          </SkillsContext.Provider>
+        </SearchContext.Provider>
+      </SubsidyRequestsContext.Provider>
+    </UserSubsidyContext.Provider>
+  </AppContext.Provider>
+);
 
 describe('<SkillsCourses />', () => {
   test('renders the correct data', async () => {
@@ -127,11 +134,7 @@ describe('<SkillsCourses />', () => {
     await act(async () => {
       const { container } = renderWithRouter(
         <SkillsCoursesWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={testIndex}
-          searchContext={searchContext}
         />,
       );
       containerDOM = container;
@@ -160,11 +163,7 @@ describe('<SkillsCourses />', () => {
     await act(async () => {
       renderWithRouter(
         <SkillsCoursesWithContext
-          initialAppState={initialAppState}
-          initialSkillsState={initialSkillsState}
-          initialUserSubsidyState={initialUserSubsidyState}
           index={courseIndex}
-          searchContext={searchContext}
         />,
       );
     });

--- a/src/components/skills-quiz/tests/SkillsQuiz.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsQuiz.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen } from '@testing-library/react';
@@ -11,19 +12,7 @@ import {
 } from '../../../utils/tests';
 import SkillsQuiz from '../SkillsQuiz';
 import { SkillsContextProvider } from '../SkillsContextProvider';
-
-/* eslint-disable react/prop-types */
-const SkillsQuizWithContext = ({
-  initialAppState = {},
-  initialUserSubsidyState = {},
-}) => (
-  <AppContext.Provider value={initialAppState}>
-    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-      <SkillsQuiz />
-    </UserSubsidyContext.Provider>
-  </AppContext.Provider>
-);
-/* eslint-enable react/prop-types */
+import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 
 const mockLocation = {
   pathname: '/welcome',
@@ -47,24 +36,44 @@ jest.mock('@edx/frontend-enterprise-utils', () => ({
   sendEnterpriseTrackEvent: jest.fn(),
 }));
 
-describe('<SkillsQuiz />', () => {
-  const defaultCouponCodesState = {
-    couponCodes: [],
-    loading: false,
-    couponCodesCount: 0,
-  };
-  const initialAppState = {
-    enterpriseConfig: {
-      name: 'BearsRUs',
-    },
-    config: {
-      LMS_BASE_URL: process.env.LMS_BASE_URL,
-    },
-  };
-  const initialUserSubsidyState = {
-    couponCodes: defaultCouponCodesState,
-  };
+const defaultCouponCodesState = {
+  couponCodes: [],
+  loading: false,
+  couponCodesCount: 0,
+};
 
+const defaultAppState = {
+  enterpriseConfig: {
+    name: 'BearsRUs',
+  },
+  config: {
+    LMS_BASE_URL: process.env.LMS_BASE_URL,
+  },
+};
+
+const defaultUserSubsidyState = {
+  couponCodes: defaultCouponCodesState,
+};
+
+const defaultSubsidyRequestState = {
+  catalogsForSubsidyRequests: [],
+};
+
+const SkillsQuizWithContext = ({
+  initialAppState = defaultAppState,
+  initialUserSubsidyState = defaultUserSubsidyState,
+  initialSubsidyRequestState = defaultSubsidyRequestState,
+}) => (
+  <AppContext.Provider value={initialAppState}>
+    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+      <SubsidyRequestsContext.Provider value={initialSubsidyRequestState}>
+        <SkillsQuiz />
+      </SubsidyRequestsContext.Provider>
+    </UserSubsidyContext.Provider>
+  </AppContext.Provider>
+);
+
+describe('<SkillsQuiz />', () => {
   afterAll(() => {
     jest.restoreAllMocks();
   });
@@ -73,7 +82,7 @@ describe('<SkillsQuiz />', () => {
     renderWithRouter(
       <SearchData>
         <SkillsContextProvider>
-          <SkillsQuizWithContext initialAppState={initialAppState} initialUserSubsidyState={initialUserSubsidyState} />
+          <SkillsQuizWithContext />
         </SkillsContextProvider>
       </SearchData>,
       { route: '/test/skills-quiz/' },

--- a/src/components/skills-quiz/tests/SkillsQuizStepper.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsQuizStepper.test.jsx
@@ -22,6 +22,7 @@ import {
 } from '../constants';
 
 import edxLogo from '../images/edx-logo.svg';
+import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 
 jest.mock('@edx/frontend-platform/auth', () => ({
   ...jest.requireActual('@edx/frontend-platform/auth'),
@@ -41,27 +42,31 @@ jest.mock('@edx/frontend-enterprise-catalog-search', () => ({
   removeFromRefinementArray: jest.fn(),
 }));
 
+const defaultAppState = {
+  enterpriseConfig: {
+    name: 'BearsRUs',
+    slug: 'BearsRYou',
+  },
+  config: {
+    LMS_BASE_URL: process.env.LMS_BASE_URL,
+  },
+};
+
+const defaultCouponCodesState = {
+  couponCodes: [],
+  loading: false,
+  couponCodesCount: 0,
+};
+
+const defaultUserSubsidyState = {
+  couponCodes: defaultCouponCodesState,
+};
+
+const defaultSubsidyRequestState = {
+  catalogsForSubsidyRequests: [],
+};
+
 describe('<SkillsQuizStepper />', () => {
-  const initialAppState = {
-    enterpriseConfig: {
-      name: 'BearsRUs',
-      slug: 'BearsRYou',
-    },
-    config: {
-      LMS_BASE_URL: process.env.LMS_BASE_URL,
-    },
-  };
-
-  const defaultCouponCodesState = {
-    couponCodes: [],
-    loading: false,
-    couponCodesCount: 0,
-  };
-
-  const initialUserSubsidyState = {
-    couponCodes: defaultCouponCodesState,
-  };
-
   afterAll(() => {
     jest.restoreAllMocks();
   });
@@ -73,13 +78,15 @@ describe('<SkillsQuizStepper />', () => {
     };
 
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchContext.Provider value={{ ...searchContext }}>
-            <SkillsContextProvider>
-              <SkillsQuizStepper />
-            </SkillsContextProvider>
-          </SearchContext.Provider>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchContext.Provider value={{ ...searchContext }}>
+              <SkillsContextProvider>
+                <SkillsQuizStepper />
+              </SkillsContextProvider>
+            </SearchContext.Provider>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/' },
@@ -103,13 +110,15 @@ describe('<SkillsQuizStepper />', () => {
     };
 
     const { getByAltText } = renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchContext.Provider value={{ ...searchContext }}>
-            <SkillsContextProvider>
-              <SkillsQuizStepper />
-            </SkillsContextProvider>
-          </SearchContext.Provider>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchContext.Provider value={{ ...searchContext }}>
+              <SkillsContextProvider>
+                <SkillsQuizStepper />
+              </SkillsContextProvider>
+            </SearchContext.Provider>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/' },
@@ -127,13 +136,15 @@ describe('<SkillsQuizStepper />', () => {
     };
 
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchContext.Provider value={{ ...searchContext }}>
-            <SkillsContextProvider>
-              <SkillsQuizStepper />
-            </SkillsContextProvider>
-          </SearchContext.Provider>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchContext.Provider value={{ ...searchContext }}>
+              <SkillsContextProvider>
+                <SkillsQuizStepper />
+              </SkillsContextProvider>
+            </SearchContext.Provider>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/' },
@@ -148,13 +159,15 @@ describe('<SkillsQuizStepper />', () => {
     };
 
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchContext.Provider value={{ ...searchContext }}>
-            <SkillsContextProvider>
-              <SkillsQuizStepper />
-            </SkillsContextProvider>
-          </SearchContext.Provider>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchContext.Provider value={{ ...searchContext }}>
+              <SkillsContextProvider>
+                <SkillsQuizStepper />
+              </SkillsContextProvider>
+            </SearchContext.Provider>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/' },
@@ -172,13 +185,15 @@ describe('<SkillsQuizStepper />', () => {
     };
 
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchContext.Provider value={{ ...searchContext }}>
-            <SkillsContext.Provider value={skillsQuizContextInitialState}>
-              <SkillsQuizStepper />
-            </SkillsContext.Provider>
-          </SearchContext.Provider>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchContext.Provider value={{ ...searchContext }}>
+              <SkillsContext.Provider value={skillsQuizContextInitialState}>
+                <SkillsQuizStepper />
+              </SkillsContext.Provider>
+            </SearchContext.Provider>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/' },
@@ -197,13 +212,15 @@ describe('<SkillsQuizStepper />', () => {
     };
 
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchContext.Provider value={{ ...searchContext }}>
-            <SkillsContext.Provider value={skillsQuizContextInitialState}>
-              <SkillsQuizStepper />
-            </SkillsContext.Provider>
-          </SearchContext.Provider>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchContext.Provider value={{ ...searchContext }}>
+              <SkillsContext.Provider value={skillsQuizContextInitialState}>
+                <SkillsQuizStepper />
+              </SkillsContext.Provider>
+            </SearchContext.Provider>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/' },
@@ -222,13 +239,15 @@ describe('<SkillsQuizStepper />', () => {
     };
 
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchContext.Provider value={{ ...searchContext }}>
-            <SkillsContext.Provider value={skillsQuizContextInitialState}>
-              <SkillsQuizStepper />
-            </SkillsContext.Provider>
-          </SearchContext.Provider>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchContext.Provider value={{ ...searchContext }}>
+              <SkillsContext.Provider value={skillsQuizContextInitialState}>
+                <SkillsQuizStepper />
+              </SkillsContext.Provider>
+            </SearchContext.Provider>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/' },
@@ -246,13 +265,15 @@ describe('<SkillsQuizStepper />', () => {
     };
 
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchContext.Provider value={{ ...searchContext }}>
-            <SkillsContextProvider>
-              <SkillsQuizStepper />
-            </SkillsContextProvider>
-          </SearchContext.Provider>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchContext.Provider value={{ ...searchContext }}>
+              <SkillsContextProvider>
+                <SkillsQuizStepper />
+              </SkillsContextProvider>
+            </SearchContext.Provider>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/' },
@@ -270,13 +291,15 @@ describe('<SkillsQuizStepper />', () => {
 
   it('checks all dropdowns are shown when we have goal and skills', async () => {
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchData>
-            <SkillsContextProvider>
-              <SkillsQuizStepper />
-            </SkillsContextProvider>
-          </SearchData>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchData>
+              <SkillsContextProvider>
+                <SkillsQuizStepper />
+              </SkillsContextProvider>
+            </SearchData>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/?skill_names=xyz' },
@@ -299,13 +322,15 @@ describe('<SkillsQuizStepper />', () => {
     };
 
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchContext.Provider value={{ ...searchContext }}>
-            <SkillsContextProvider>
-              <SkillsQuizStepper />
-            </SkillsContextProvider>
-          </SearchContext.Provider>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchContext.Provider value={{ ...searchContext }}>
+              <SkillsContextProvider>
+                <SkillsQuizStepper />
+              </SkillsContextProvider>
+            </SearchContext.Provider>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/' },
@@ -327,13 +352,15 @@ describe('<SkillsQuizStepper />', () => {
       state: { goal: GOAL_DROPDOWN_DEFAULT_OPTION },
     };
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchData>
-            <SkillsContextProvider value={{ ...skillsQuizContextInitialState }}>
-              <SkillsQuizStepper />
-            </SkillsContextProvider>
-          </SearchData>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchData>
+              <SkillsContextProvider value={{ ...skillsQuizContextInitialState }}>
+                <SkillsQuizStepper />
+              </SkillsContextProvider>
+            </SearchData>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/?skill_names=xyz' },
@@ -351,13 +378,15 @@ describe('<SkillsQuizStepper />', () => {
     };
 
     renderWithRouter(
-      <AppContext.Provider value={initialAppState}>
-        <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <SearchData>
-            <SkillsContext.Provider value={skillsQuizContextInitialState}>
-              <SkillsQuizStepper />
-            </SkillsContext.Provider>
-          </SearchData>
+      <AppContext.Provider value={defaultAppState}>
+        <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
+          <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
+            <SearchData>
+              <SkillsContext.Provider value={skillsQuizContextInitialState}>
+                <SkillsQuizStepper />
+              </SkillsContext.Provider>
+            </SearchData>
+          </SubsidyRequestsContext.Provider>
         </UserSubsidyContext.Provider>
       </AppContext.Provider>,
       { route: '/test/skills-quiz/?skill_names=xyz' },


### PR DESCRIPTION
- Move `SubsidyRequestsContextProvider` up the component tree
- Refactor useDefaultSearchFilters hook
- Add enterprise offers catalogs

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
