### PR TITLE
fix: show only recent course run when multiple enrolled

### DIFF
--- a/src/components/program-progress/data/utils.jsx
+++ b/src/components/program-progress/data/utils.jsx
@@ -70,9 +70,20 @@ export function isCourseRunEnded(run) {
 }
 
 export function getEnrolledCourseRunDetails(courses) {
-  const enrolledCourseRunDetails = [];
-  courses.map((course) => (
-    course?.courseRuns.map((cRun) => (cRun.isEnrolled && (enrolledCourseRunDetails.push({
+  /**
+   * returns the list of course runs for courses that are enrolled by user with only one run for each course.
+   * if there are multiple enrolled course_runs then the most recent is selected.
+   *
+   * @param {Array} courses in progress or completed array of courses
+   * @return {Array} array of course runs selected from course runs of each course
+   */
+  return courses?.map((course) => {
+    const filteredRuns = course.courseRuns.filter(cRUn => cRUn.isEnrolled).sort(
+      (a, b) => new Date(b.start) - new Date(a.start),
+    );
+    // there will be at least one course run for each in_progress and completed courses
+    const cRun = filteredRuns[0];
+    return {
       start: cRun.start ? cRun.start : cRun.advertisedStart,
       title: cRun.title,
       key: course?.key,
@@ -82,10 +93,8 @@ export function getEnrolledCourseRunDetails(courses) {
       expired: cRun?.expired,
       seats: cRun.seats ? cRun?.seats : [],
       isEnded: isCourseRunEnded(cRun),
-    }))
-    ))
-  ));
-  return enrolledCourseRunDetails;
+    };
+  });
 }
 
 export function getNotStartedCourseDetails(courses) {

--- a/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
+++ b/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
@@ -132,6 +132,55 @@ describe('<EnrollModal />', () => {
     expect(screen.getByText(courseDataCompletedCourse.inProgress[0].courseRuns[0].title)).toBeInTheDocument();
     expect(screen.getByText('View Course').closest('a')).toHaveAttribute('href', courseLink);
   });
+
+  it('displays the only one in progress course when enrolled in multiple runs', () => {
+    const courseDataCompletedCourse = {
+      completed: [],
+      notStarted: [],
+      inProgress: [
+        {
+          key: 'HarvardX+CS50x',
+          title: 'Introduction to Computer Science',
+          courseRuns: [
+            {
+              key: 'HarvardX/CS50x/2012',
+              title: 'Introduction to Computer Science1',
+              start: '2015-10-15T00:00:00Z',
+              isEnrolled: true,
+              isEnrollmentOpen: false,
+              isCourseEnded: false,
+              status: 'published',
+              end: null,
+              pacingType: 'instructor_paced',
+              uuid: '982c3c80-6bc5-41c4-aa11-bd6e90c3f55d',
+              certificate_url: null,
+            },
+            {
+              key: 'HarvardX/CS50x/2012',
+              title: 'Introduction to Computer Science2',
+              start: '2019-10-15T00:00:00Z',
+              isEnrolled: true,
+              isEnrollmentOpen: true,
+              end: null,
+              pacingType: 'instructor_paced',
+              uuid: '982c3c80-6bc5-41c4-aa11-bd6e90c3f55d',
+              certificate_url: 'url',
+            },
+          ],
+        },
+      ],
+    };
+    render(<ProgramProgressCoursesWithContext
+      initialAppState={appState}
+      initialUserSubsidyState={userSubsidyState}
+      courseData={courseDataCompletedCourse}
+    />);
+
+    const courseLink = `/${appState.enterpriseConfig.slug}/course/${courseDataCompletedCourse.inProgress[0].key}`;
+    expect(screen.getByText(courseDataCompletedCourse.inProgress[0].courseRuns[1].title)).toBeInTheDocument();
+    expect(screen.getByText('View Course').closest('a')).toHaveAttribute('href', courseLink);
+  });
+
   it('displays the in progress course which can be upgrade to verified certificate with license', () => {
     const courseDataCompletedCourse = {
       completed: [],

--- a/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
+++ b/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
@@ -178,6 +178,7 @@ describe('<EnrollModal />', () => {
 
     const courseLink = `/${appState.enterpriseConfig.slug}/course/${courseDataCompletedCourse.inProgress[0].key}`;
     expect(screen.getByText(courseDataCompletedCourse.inProgress[0].courseRuns[1].title)).toBeInTheDocument();
+    expect(screen.queryByText(courseDataCompletedCourse.inProgress[0].courseRuns[0].title)).toBeNull();
     expect(screen.getByText('View Course').closest('a')).toHaveAttribute('href', courseLink);
   });
 


### PR DESCRIPTION
# For all changes

[ticket](https://2u-internal.atlassian.net/browse/ENT-5846)
Before:
<img width="896" alt="Screenshot 2022-06-06 at 11 15 37 PM" src="https://user-images.githubusercontent.com/49611774/172221467-928e217a-a0cd-4a64-b800-001a09e110f5.png">

After:
<img width="974" alt="Screenshot 2022-06-06 at 11 14 19 PM" src="https://user-images.githubusercontent.com/49611774/172221549-0fa5b71f-10c4-4510-b92b-60ac4962367b.png">


- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
