### PR TITLE
fix: only check for active coupons, offers, and subs for offers usage

### DIFF
--- a/src/components/enterprise-user-subsidy/coupons/data/service.js
+++ b/src/components/enterprise-user-subsidy/coupons/data/service.js
@@ -13,6 +13,7 @@ const fetchCouponsOverview = ({ enterpriseId, options = {} }) => {
     page: 1,
     page_size: 50,
     filter: 'active',
+    is_current: true,
     ...options,
   });
   const config = getConfig();

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/hooks.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/hooks.js
@@ -8,6 +8,7 @@ import { fetchCouponsOverview } from '../../coupons/data/service';
 import { features } from '../../../../config';
 import * as enterpriseOffersService from './service';
 import { ENTERPRISE_OFFER_LOW_BALANCE_THRESHOLD } from './constants';
+import { hasValidStartExpirationDates } from '../../../../utils/common';
 
 export function useEnterpriseOffers({
   enterpriseId,
@@ -75,13 +76,19 @@ export function useEnterpriseOffers({
       return;
     }
 
-    const enterpriseHasCoupons = enterpriseCoupons.length > 0;
-    const enterpriseHasSubscriptions = (customerAgreementConfig?.subscriptions?.length || 0) > 0;
+    const enterpriseHasActiveCoupons = enterpriseCoupons.length > 0;
+    const enterpriseHasActiveSubscription = !!(customerAgreementConfig?.subscriptions ?? []).find(({
+      startDate,
+      expirationDate,
+    }) => hasValidStartExpirationDates({
+      startDate,
+      expirationDate,
+    }));
 
     // For MVP we will only support enterprises with one active offer
     const enterpriseHasOneOffer = enterpriseOffers.length === 1;
 
-    if (enterpriseHasCoupons || enterpriseHasSubscriptions || !enterpriseHasOneOffer) {
+    if (enterpriseHasActiveCoupons || enterpriseHasActiveSubscription || !enterpriseHasOneOffer) {
       return;
     }
 

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/service.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/service.js
@@ -6,6 +6,7 @@ export function fetchEnterpriseOffers(enterpriseId, options = {
   usage_type: ENTERPRISE_OFFER_USAGE_TYPE.PERCENTAGE,
   discount_value: 100,
   status: ENTERPRISE_OFFER_STATUS.OPEN,
+  is_current: true,
 }) {
   const queryParams = new URLSearchParams({
     ...options,

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/hooks.test.jsx
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/hooks.test.jsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { renderHook } from '@testing-library/react-hooks';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
@@ -99,7 +100,7 @@ describe('useEnterpriseOffers', () => {
     expect(isLoading).toEqual(false);
   });
 
-  it('returns canEnrollWithEnterpriseOffers = false if the enterprise has subs', async () => {
+  it('returns canEnrollWithEnterpriseOffers = false if the enterprise has an active sub', async () => {
     couponService.fetchCouponsOverview.mockResolvedValueOnce({
       data: {
         results: [],
@@ -109,7 +110,11 @@ describe('useEnterpriseOffers', () => {
     const { result, waitForNextUpdate } = renderHook(() => useEnterpriseOffers({
       ...defaultProps,
       customerAgreementConfig: {
-        subscriptions: [{ uuid: 'sub-uuid' }],
+        subscriptions: [{
+          uuid: 'sub-uuid',
+          startDate: moment().subtract(1, 'd').toISOString(),
+          expirationDate: moment().add(1, 'd').toISOString(),
+        }],
       },
     }));
 
@@ -126,7 +131,7 @@ describe('useEnterpriseOffers', () => {
     expect(isLoading).toEqual(false);
   });
 
-  it('returns canEnrollWithEnterpriseOffers = false if the enterprise has no coupons or subs, but has > 1 active enterprise offer', async () => {
+  it('returns canEnrollWithEnterpriseOffers = false if the enterprise has no active coupons or sub, but has > 1 active enterprise offer', async () => {
     couponService.fetchCouponsOverview.mockResolvedValueOnce({
       data: {
         results: [],
@@ -146,7 +151,7 @@ describe('useEnterpriseOffers', () => {
     expect(result.current.canEnrollWithEnterpriseOffers).toEqual(false);
   });
 
-  it('returns canEnrollWithEnterpriseOffers = true if the enterprise has no coupons or subs, and has 1 active enterprise offer', async () => {
+  it('returns canEnrollWithEnterpriseOffers = true if the enterprise has no active coupons or sub, and has 1 active enterprise offer', async () => {
     couponService.fetchCouponsOverview.mockResolvedValueOnce({
       data: {
         results: [],

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/service.test.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/service.test.js
@@ -22,6 +22,7 @@ describe('fetchEnterpriseOffers', () => {
       usage_type: ENTERPRISE_OFFER_USAGE_TYPE.PERCENTAGE,
       discount_value: 100,
       status: ENTERPRISE_OFFER_STATUS.OPEN,
+      is_current: true,
     });
     const url = `${config.ECOMMERCE_BASE_URL}/api/v2/enterprise/${TEST_ENTERPRISE_UUID}/enterprise-learner-offers/?${queryParams.toString()}`;
     fetchEnterpriseOffers(TEST_ENTERPRISE_UUID);


### PR DESCRIPTION
- query only for current coupons & offers
- check for active subscriptions specifically when determining if an enterprise can use offers

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
