### PR TITLE
fix: add failure url to ecommerce url query params

### DIFF
--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -377,7 +377,7 @@ export const useCourseEnrollmentUrl = ({
       const queryParams = new URLSearchParams({
         ...baseEnrollmentOptions,
         sku,
-        consent_url_param_string: encodeURI('left_sidebar_text_override='), // Deliberately doubly encoded since it will get parsed on the redirect.
+        consent_url_param_string: `failure_url=${encodeURIComponent(global.location.href)}?${baseQueryParams.toString()}&left_sidebar_text_override=`,
       });
 
       if (features.ENROLL_WITH_CODES && userSubsidyApplicableToCourse?.subsidyType === COUPON_CODE_SUBSIDY_TYPE) {

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -229,6 +229,7 @@ describe('useCourseEnrollmentUrl', () => {
       expect(result.current).toContain(withLicenseRnrollmentInputs.key);
       expect(result.current).not.toContain('code');
     });
+
     test('with no coupon codes passed, treats it as empty and does not fail', () => {
       const { result } = renderHook(() => useCourseEnrollmentUrl({
         ...noCouponCodesEnrollmentInputs,
@@ -245,6 +246,13 @@ describe('useCourseEnrollmentUrl', () => {
         sku: undefined,
       }));
       expect(result.current).toBeNull();
+    });
+
+    test('includes failure url in query params', () => {
+      const { result } = renderHook(() => useCourseEnrollmentUrl({
+        ...noCouponCodesEnrollmentInputs,
+      }));
+      expect(result.current.includes('failure_url'));
     });
   });
 });


### PR DESCRIPTION
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
