### PR TITLE
feat: initial changes to support per user bookings limit offers

### DIFF
--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -200,16 +200,15 @@ describe('<CourseSidebarPrice/> ', () => {
     });
 
     describe('Does not display insufficient enterprise offer balance message', () => {
-      test.each([
-        ENTERPRISE_OFFER_TYPE.NO_LIMIT,
-        ENTERPRISE_OFFER_TYPE.ENROLLMENTS_LIMIT,
-      ])('When offer has no bookings limit', (offerType) => {
+      test('When offer has no bookings limit', () => {
         const mockEnterpriseOffer = {
           discountValue: 100,
           discountType: SUBSIDY_DISCOUNT_TYPE_MAP.PERCENTAGE.toUpperCase(),
           enterpriseCatalogUuid: 'test-catalog-uuid',
+          maxDiscount: null,
+          maxUserDiscount: null,
           remainingBalance: null,
-          offerType,
+          offerType: ENTERPRISE_OFFER_TYPE.NO_LIMIT,
         };
         const mockEnterpriseOfferSubsidy = {
           ...mockEnterpriseOffer,
@@ -237,6 +236,8 @@ describe('<CourseSidebarPrice/> ', () => {
           discountValue: 100,
           discountType: SUBSIDY_DISCOUNT_TYPE_MAP.PERCENTAGE.toUpperCase(),
           enterpriseCatalogUuid: 'test-catalog-uuid',
+          maxDiscount: 1000,
+          maxUserDiscount: null,
           remainingBalance: 0,
           offerType: ENTERPRISE_OFFER_TYPE.BOOKINGS_LIMIT,
         };
@@ -264,6 +265,8 @@ describe('<CourseSidebarPrice/> ', () => {
           discountType: SUBSIDY_DISCOUNT_TYPE_MAP.PERCENTAGE.toUpperCase(),
           enterpriseCatalogUuid: 'wrong-catalog-uuid',
           remainingBalance: 0,
+          maxDiscount: 1000,
+          maxUserDiscount: null,
           offerType: ENTERPRISE_OFFER_TYPE.BOOKINGS_LIMIT,
         };
 

--- a/src/components/dashboard/sidebar/EnterpriseOffersSummaryCard.jsx
+++ b/src/components/dashboard/sidebar/EnterpriseOffersSummaryCard.jsx
@@ -5,15 +5,15 @@ import {
   Row,
   Col,
 } from '@edx/paragon';
+import moment from 'moment';
 import {
   ENTERPRISE_OFFER_SUMMARY_CARD_TITLE,
   ENTERPRISE_OFFER_ACTIVE_BADGE_LABEL,
   ENTERPRISE_OFFER_ACTIVE_BADGE_VARIANT,
-  ENTERPRISE_OFFER_SUMMARY_CARD_SUMMARY,
 } from './data/constants';
 import SidebarCard from './SidebarCard';
 
-const EnterpriseOffersSummaryCard = ({ className, searchCoursesCta }) => (
+const EnterpriseOffersSummaryCard = ({ className, offer, searchCoursesCta }) => (
   <SidebarCard
     title={
       (
@@ -31,7 +31,26 @@ const EnterpriseOffersSummaryCard = ({ className, searchCoursesCta }) => (
     }
     cardClassNames={className}
   >
-    {ENTERPRISE_OFFER_SUMMARY_CARD_SUMMARY}
+    {offer.remainingBalanceForUser
+      ? (
+        <p data-testid="offer-summary-text-detailed">
+          Apply your <b>${offer.remainingBalanceForUser}</b>{' '}
+          learner credit balance to enroll into courses with no out of pocket cost.
+        </p>
+      )
+      : (
+        <p data-testid="offer-summary-text">
+          Apply your organization&apos;s learner credit balance to enroll into courses with no out of pocket cost.
+        </p>
+      ) }
+
+    {offer.endDatetime
+      && (
+        <p data-testid="offer-summary-end-date-text">
+          Available until <b>{moment(offer.endDatetime).format('MMM D, YYYY')}</b>
+        </p>
+      )}
+
     {searchCoursesCta && (
       <Row className="mt-3 d-flex justify-content-end">
         <Col xl={7}>{searchCoursesCta}</Col>
@@ -41,6 +60,10 @@ const EnterpriseOffersSummaryCard = ({ className, searchCoursesCta }) => (
 );
 
 EnterpriseOffersSummaryCard.propTypes = {
+  offer: PropTypes.shape({
+    endDatetime: PropTypes.string,
+    remainingBalanceForUser: PropTypes.number,
+  }).isRequired,
   className: PropTypes.string,
   searchCoursesCta: PropTypes.node,
 };

--- a/src/components/dashboard/sidebar/SubsidiesSummary.jsx
+++ b/src/components/dashboard/sidebar/SubsidiesSummary.jsx
@@ -57,9 +57,8 @@ const SubsidiesSummary = ({
   const hasAssignedSubsidyOrRequests = hasActiveLicenseOrLicenseRequest || hasAssignedCodesOrCodeRequests;
 
   // We will not allow enterprises to use enterprise offers together with license/coupon codes for now
-  const hasRedeemableEnterpriseOffers = enterpriseOffers.length > 0 && canEnrollWithEnterpriseOffers;
 
-  if (!(hasAssignedSubsidyOrRequests || hasRedeemableEnterpriseOffers)) {
+  if (!(hasAssignedSubsidyOrRequests || canEnrollWithEnterpriseOffers)) {
     return null;
   }
 
@@ -112,7 +111,14 @@ const SubsidiesSummary = ({
           </div>
         </SidebarCard>
       )}
-      {hasRedeemableEnterpriseOffers && <EnterpriseOffersSummaryCard className="mb-5" searchCoursesCta={searchCoursesCta} />}
+      {canEnrollWithEnterpriseOffers
+        && (
+          <EnterpriseOffersSummaryCard
+            className="mb-5"
+            offer={enterpriseOffers[0]}
+            searchCoursesCta={searchCoursesCta}
+          />
+        )}
     </>
   );
 };

--- a/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
+++ b/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
@@ -12,7 +12,7 @@ import {
   NEED_HELP_BLOCK_TITLE,
   LICENSE_REQUESTED_NOTICE,
   COUPON_CODES_SUMMARY_NOTICE,
-  ENTERPRISE_OFFER_SUMMARY_CARD_SUMMARY,
+  ENTERPRISE_OFFER_SUMMARY_CARD_TITLE,
 } from '../data/constants';
 import { LICENSE_STATUS } from '../../../enterprise-user-subsidy/data/constants';
 import CourseEnrollmentsContextProvider from '../../main-content/course-enrollments/CourseEnrollmentsContextProvider';
@@ -183,7 +183,7 @@ describe('<DashboardSidebar />', () => {
         }}
       />,
     );
-    expect(screen.getByText(ENTERPRISE_OFFER_SUMMARY_CARD_SUMMARY)).toBeInTheDocument();
+    expect(screen.getByText(ENTERPRISE_OFFER_SUMMARY_CARD_TITLE)).toBeInTheDocument();
   });
   test('Enterprise offers summary card is not displayed when enterprise has active offers and but has subscriptions or coupons', () => {
     renderWithRouter(
@@ -199,7 +199,7 @@ describe('<DashboardSidebar />', () => {
         }}
       />,
     );
-    expect(screen.queryByText(ENTERPRISE_OFFER_SUMMARY_CARD_SUMMARY)).not.toBeInTheDocument();
+    expect(screen.queryByText(ENTERPRISE_OFFER_SUMMARY_CARD_TITLE)).not.toBeInTheDocument();
   });
   test('Find a course button is not rendered when user has no coupon codes or license subsidy', () => {
     renderWithRouter(

--- a/src/components/dashboard/sidebar/tests/EnterpriseOffersSummaryCard.test.jsx
+++ b/src/components/dashboard/sidebar/tests/EnterpriseOffersSummaryCard.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen, render } from '@testing-library/react';
+import moment from 'moment';
 import EnterpriseOffersSummaryCard from '../EnterpriseOffersSummaryCard';
 import { ENTERPRISE_OFFER_SUMMARY_CARD_TITLE } from '../data/constants';
 
@@ -9,6 +10,7 @@ describe('<EnterpriseOffersSummaryCard />', () => {
     const cta = 'Search Courses';
     render(
       <EnterpriseOffersSummaryCard
+        offer={{}}
         searchCoursesCta={
           <button type="button">{cta}</button>
         }
@@ -17,5 +19,41 @@ describe('<EnterpriseOffersSummaryCard />', () => {
 
     expect(screen.getByText(ENTERPRISE_OFFER_SUMMARY_CARD_TITLE)).toBeInTheDocument();
     expect(screen.getByText(cta)).toBeInTheDocument();
+  });
+
+  it('should render default summary text if remainingBalanceForUser is null', () => {
+    render(
+      <EnterpriseOffersSummaryCard
+        offer={{}}
+      />,
+    );
+
+    expect(screen.getByTestId('offer-summary-text')).toBeInTheDocument();
+  });
+
+  it('should render detailed summary text if remainingBalanceForUser is not null', () => {
+    const offer = {
+      remainingBalanceForUser: 100,
+    };
+    render(
+      <EnterpriseOffersSummaryCard
+        offer={offer}
+      />,
+    );
+    expect(screen.getByTestId('offer-summary-text-detailed')).toBeInTheDocument();
+  });
+
+  it('should render offer end date if applicable', () => {
+    const now = moment().toISOString();
+    const offer = {
+      endDatetime: now,
+    };
+    render(
+      <EnterpriseOffersSummaryCard
+        offer={offer}
+      />,
+    );
+
+    expect(screen.getByTestId('offer-summary-end-date-text')).toBeInTheDocument();
   });
 });

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
@@ -1,5 +1,5 @@
 export const ENTERPRISE_OFFER_TYPE = {
-  BOOKINGS_LIMIT: 'Bookings limit', // Offer has a global limit on the amount of spend
+  BOOKINGS_LIMIT: 'Bookings limit', // Offer has a global/user limit on the amount of spend
   ENROLLMENTS_LIMIT: 'Enrollments limit', // Offer has a global limit on number of enrollments
   BOOKINGS_AND_ENROLLMENTS_LIMIT: 'Bookings and enrollments limit', // Offer has a global limit on both the amount of spend and number of enrollments
   NO_LIMIT: 'No limit',

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/service.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/service.js
@@ -8,7 +8,7 @@ export function fetchEnterpriseOffers(enterpriseId, options = {
   status: ENTERPRISE_OFFER_STATUS.OPEN,
   is_current: true,
   max_user_applications__isnull: true, // We won't handle offers with per user limits for MVP
-  max_user_discount__isnull: true,
+  max_user_discount__isnull: true, // Remove filter when we're ready to support per user limit
 }) {
   const queryParams = new URLSearchParams({
     ...options,

--- a/src/components/program/ProgramCourses.jsx
+++ b/src/components/program/ProgramCourses.jsx
@@ -15,7 +15,7 @@ import { ProgramContext } from './ProgramContextProvider';
 
 import { PROGRAM_PACING_MAP } from './data/constants';
 
-const DATE_FORMAT = 'MMM D, YYYY';
+export const DATE_FORMAT = 'MMM D, YYYY';
 
 const getCourseRun = course => (
   // Get the latest course run.

--- a/src/components/program/tests/ProgramCourses.test.jsx
+++ b/src/components/program/tests/ProgramCourses.test.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { screen, render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import moment from 'moment';
 
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { ProgramContextProvider } from '../ProgramContextProvider';
-import ProgramCourses from '../ProgramCourses';
+import ProgramCourses, { DATE_FORMAT } from '../ProgramCourses';
 
 const programUuid = '00000000-0000-0000-0000-000000000000';
 const enterpriseUuid = '11111111-1111-1111-1111-111111111111';
@@ -154,12 +155,14 @@ describe('<ProgramCourses />', () => {
     );
 
     fireEvent.click(screen.getByText('Test Course Title'));
-    expect(screen.queryByText('Starts Feb 5, 2013')).toBeInTheDocument();
+    const courseRun = initialProgramState.program.courses[0].courseRuns[0];
+    expect(screen.queryByText(`Starts ${moment(courseRun.start).format(DATE_FORMAT)}`)).toBeInTheDocument();
   });
 
   test('does not renders start date when courses are self paced', () => {
     const newInitialProgramState = { ...initialProgramState };
-    newInitialProgramState.program.courses[0].courseRuns[0].pacingType = 'self_paced';
+    const courseRun = newInitialProgramState.program.courses[0].courseRuns[0];
+    courseRun.pacingType = 'self_paced';
     render(
       <ProgramCoursestWithContext
         initialAppState={initialAppState}
@@ -169,11 +172,12 @@ describe('<ProgramCourses />', () => {
     );
 
     fireEvent.click(screen.getByText('Test Course Title'));
-    expect(screen.queryByText('Starts Feb 5, 2013')).not.toBeInTheDocument();
+    expect(screen.queryByText(`Starts ${moment(courseRun.start).format(DATE_FORMAT)}`)).not.toBeInTheDocument();
   });
 
   test('renders latest course run', () => {
     const newInitialProgramState = { ...initialProgramState };
+    const firstCourseRun = newInitialProgramState.program.courses[0].courseRuns[0];
     const secondCourseRun = {
       title: 'Test Course Run Title',
       start: '2014-02-05T05:00:00Z',
@@ -189,7 +193,7 @@ describe('<ProgramCourses />', () => {
       />,
     );
     fireEvent.click(screen.getByText('Test Course Title'));
-    expect(screen.queryByText('Starts Feb 5, 2013')).not.toBeInTheDocument();
-    expect(screen.queryByText('Starts Feb 5, 2014')).toBeInTheDocument();
+    expect(screen.queryByText(`Starts ${moment(firstCourseRun.start).format(DATE_FORMAT)}`)).not.toBeInTheDocument();
+    expect(screen.queryByText(`Starts ${moment(secondCourseRun.start).format(DATE_FORMAT)}`)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-5973

- initial changes to start support offers with per user bookings limit
- only change affecting current users is the addition of the offer end date

<img width="370" alt="Screen Shot 2022-07-08 at 10 18 51 AM" src="https://user-images.githubusercontent.com/17792243/178040154-9717721a-c6c1-43e3-a73e-de6a6298bdaf.png">

<img width="418" alt="Screen Shot 2022-07-08 at 10 20 12 AM" src="https://user-images.githubusercontent.com/17792243/178040191-74beee2f-f1d4-48a7-8469-f85202841083.png">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
