### PR TITLE
fix: handle edge case with admin role but no learner role

### DIFF
--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -122,9 +122,11 @@ export const useUpdateActiveEnterpriseForUser = ({
     }
 
     const { roles } = user;
-    if (roles.length > 0) {
-      // The first item in roles corresponds to the currently active enterprise for the user
-      const currentActiveEnterpriseId = roles[0].split(':')[1];
+    // The first learner role corresponds to the currently active enterprise for the user
+    const activeLearnerRole = roles.find(role => role.split(':')[0] === 'enterprise_learner');
+
+    if (activeLearnerRole) {
+      const currentActiveEnterpriseId = activeLearnerRole.split(':')[1];
       if (currentActiveEnterpriseId !== '*' && currentActiveEnterpriseId !== enterpriseId) {
         updateActiveEnterpriseAndRefreshJWT();
       }

--- a/src/components/enterprise-page/data/tests/hooks.test.js
+++ b/src/components/enterprise-page/data/tests/hooks.test.js
@@ -8,7 +8,11 @@ describe('useUpdateActiveEnterpriseForUser', () => {
   const mockEnterpriseId = 'enterprise-uuid';
   const mockCurrentActiveEnterpriseId = 'current-active-enterprise-uuid';
   const mockUser = {
-    roles: [`enterprise_learner:${mockCurrentActiveEnterpriseId}`],
+    roles: [
+      'enterprise_admin:random-enterprise-uuid',
+      `enterprise_learner:${mockCurrentActiveEnterpriseId}`,
+      `enterprise_learner:${mockEnterpriseId}`,
+    ],
   };
 
   afterEach(() => jest.clearAllMocks());
@@ -39,7 +43,6 @@ describe('useUpdateActiveEnterpriseForUser', () => {
       enterpriseId: mockEnterpriseId,
       user: {
         roles: [`enterprise_learner:${mockEnterpriseId}`],
-
       },
     },
   ])('should do nothing if missing enterpriseId or user, or active enterprise is the same as current enterprise', async (


### PR DESCRIPTION
There could technically be a case where a user is an admin but not a learner in enterprise A (Roles were created manually). Since the jwt roles are ordered in a way that admin roles come first, the first role does not necessarily correspond to the active enterprise. This change handles that edge case.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
