### PR TITLE
chore: override react/prop-types rule for test files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,4 +12,13 @@ config.rules['indent'] = ['error', 2, { 'ignoredNodes': ['TemplateLiteral', 'Swi
 config.rules['template-curly-spacing'] = 'off';
 config.rules['import/prefer-default-export'] = 'off';
 
+// Disable react/prop-types for test files
+config.overrides = [
+    {
+        'files': ['*.test.js', '*.test.jsx'],
+        'rules': {
+            'react/prop-types': 'off'
+        }
+    }
+]
 module.exports = config;

--- a/src/components/app/LoginRefresh.test.jsx
+++ b/src/components/app/LoginRefresh.test.jsx
@@ -8,7 +8,6 @@ import * as utils from '../../utils/common';
 
 jest.mock('../../utils/common');
 
-// eslint-disable-next-line react/prop-types
 const LoginRefreshWithContext = ({ roles = [] }) => (
   <AppContext.Provider value={{
     authenticatedUser: {
@@ -21,7 +20,7 @@ const LoginRefreshWithContext = ({ roles = [] }) => (
       <div>Hello!</div>
     </LoginRefresh>
   </AppContext.Provider>
-); /* eslint-enable react/prop-types */
+);
 
 describe('<LoginRefresh />', () => {
   it('should call loginRefresh if the user has no roles', async () => {

--- a/src/components/course/enrollment/tests/EnrollAction.test.jsx
+++ b/src/components/course/enrollment/tests/EnrollAction.test.jsx
@@ -53,7 +53,6 @@ const subscriptionLicense = { uuid: 'a-license' };
    * @param {string} args.enrollAction
    */
 const EnrollLabel = (props) => (
-  // eslint-disable-next-line react/prop-types
   <div>{props.enrollLabelText}</div>
 );
 const renderEnrollAction = ({

--- a/src/components/course/enrollment/tests/hooks.test.jsx
+++ b/src/components/course/enrollment/tests/hooks.test.jsx
@@ -99,7 +99,6 @@ describe('useEnrollData', () => {
     };
 
     // Needed to render our hook with context initialized
-    // eslint-disable-next-line react/prop-types
     const wrapper = ({ children }) => (
       <ContextWrapper initialCourseState={courseState}>
         {children}
@@ -149,7 +148,6 @@ describe('useSubsidyDataForCourse', () => {
       catalog: { catalogList: ['catalog-1', 'catalog-2'] },
     };
     // Needed to render our hook with context initialized
-    // eslint-disable-next-line react/prop-types
     const wrapper = ({ children }) => (
       <ContextWrapper
         initialCourseState={courseState}

--- a/src/components/course/tests/CreatedBy.test.jsx
+++ b/src/components/course/tests/CreatedBy.test.jsx
@@ -12,7 +12,6 @@ const initialSubsidyRequestsState = {
   catalogsForSubsidyRequests: [],
 };
 
-// eslint-disable-next-line react/prop-types
 const CreatedByWithCourseContext = ({ initialState = {} }) => (
   <SubsidyRequestsContext.Provider value={initialSubsidyRequestsState}>
     <CourseContextProvider initialState={initialState}>

--- a/src/components/enterprise-invite/EnterpriseInvitePage.test.jsx
+++ b/src/components/enterprise-invite/EnterpriseInvitePage.test.jsx
@@ -24,7 +24,6 @@ jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
 }));
 jest.mock('../error-page', () => ({
-  // eslint-disable-next-line react/prop-types
   ErrorPage: ({ children }) => <div data-testid="error-page-message">{children}</div>,
 }));
 

--- a/src/components/enterprise-user-subsidy/tests/AutoActivateLicense.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/AutoActivateLicense.test.jsx
@@ -11,7 +11,6 @@ import { renderWithRouter } from '../../../utils/tests';
 const TEST_ENTERPRISE_SLUG = 'test-slug';
 const initialPathname = `/${TEST_ENTERPRISE_SLUG}`;
 
-// eslint-disable-next-line react/prop-types
 const AutoActivateLicenseWrapper = ({ subscriptionLicense }) => (
   <Route path={initialPathname} exact>
     <AppContext.Provider value={{ enterpriseConfig: { slug: TEST_ENTERPRISE_SLUG } }}>

--- a/src/components/pathway/tests/PathwayModal.test.jsx
+++ b/src/components/pathway/tests/PathwayModal.test.jsx
@@ -22,7 +22,6 @@ jest.mock('../data/hooks', () => ({
 
 jest.mock('react-loading-skeleton', () => ({
   __esModule: true,
-  // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
 

--- a/src/components/pathway/tests/SearchPathwayCard.test.jsx
+++ b/src/components/pathway/tests/SearchPathwayCard.test.jsx
@@ -16,7 +16,6 @@ jest.mock('react-truncate', () => ({
 
 jest.mock('react-loading-skeleton', () => ({
   __esModule: true,
-  // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
 

--- a/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
+++ b/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
@@ -44,7 +44,6 @@ const subsidyRequestsState = {
 };
 
 const ProgramProgressCoursesWithContext = ({
-  // eslint-disable-next-line react/prop-types
   initialAppState, initialUserSubsidyState, courseData, initialSubsidyRequestsState,
 }) => (
   <AppContext.Provider value={initialAppState}>

--- a/src/components/program/tests/ProgramInstructors.test.jsx
+++ b/src/components/program/tests/ProgramInstructors.test.jsx
@@ -5,7 +5,6 @@ import '@testing-library/jest-dom/extend-expect';
 import { ProgramContextProvider } from '../ProgramContextProvider';
 import ProgramInstructors from '../ProgramInstructors';
 
-// eslint-disable-next-line react/prop-types
 const ProgramInstructorsWithContext = ({ initialState = {} }) => (
   <ProgramContextProvider initialState={initialState}>
     <ProgramInstructors />

--- a/src/components/search/tests/SearchCourseCard.test.jsx
+++ b/src/components/search/tests/SearchCourseCard.test.jsx
@@ -15,7 +15,6 @@ jest.mock('react-truncate', () => ({
 
 jest.mock('react-loading-skeleton', () => ({
   __esModule: true,
-  // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
 

--- a/src/components/search/tests/SearchProgramCard.test.jsx
+++ b/src/components/search/tests/SearchProgramCard.test.jsx
@@ -17,7 +17,6 @@ jest.mock('react-truncate', () => ({
 
 jest.mock('react-loading-skeleton', () => ({
   __esModule: true,
-  // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
 

--- a/src/components/search/tests/SearchResults.test.jsx
+++ b/src/components/search/tests/SearchResults.test.jsx
@@ -32,7 +32,6 @@ jest.mock('../../../config', () => ({
 
 jest.mock('react-loading-skeleton', () => ({
   __esModule: true,
-  // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
 

--- a/src/components/skills-quiz/tests/SearchCurrentJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchCurrentJobCard.test.jsx
@@ -14,7 +14,6 @@ jest.mock('react-truncate', () => ({
 
 jest.mock('react-loading-skeleton', () => ({
   __esModule: true,
-  // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
 

--- a/src/components/skills-quiz/tests/SearchJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchJobCard.test.jsx
@@ -14,7 +14,6 @@ jest.mock('react-truncate', () => ({
 
 jest.mock('react-loading-skeleton', () => ({
   __esModule: true,
-  // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
 

--- a/src/components/skills-quiz/tests/SearchPathways.test.jsx
+++ b/src/components/skills-quiz/tests/SearchPathways.test.jsx
@@ -30,7 +30,6 @@ jest.mock('react-truncate', () => ({
 
 jest.mock('react-loading-skeleton', () => ({
   __esModule: true,
-  // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
 

--- a/src/components/skills-quiz/tests/SearchProgramCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchProgramCard.test.jsx
@@ -33,7 +33,6 @@ jest.mock('react-truncate', () => ({
 
 jest.mock('react-loading-skeleton', () => ({
   __esModule: true,
-  // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
 

--- a/src/components/skills-quiz/tests/SkillsCourses.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsCourses.test.jsx
@@ -31,7 +31,6 @@ jest.mock('react-truncate', () => ({
 
 jest.mock('react-loading-skeleton', () => ({
   __esModule: true,
-  // eslint-disable-next-line react/prop-types
   default: (props = {}) => <div data-testid={props['data-testid']} />,
 }));
 


### PR DESCRIPTION
Override rule for test files so we don't have to disable it manually. Should consider moving this to base confg in `@edx/frontend-build`

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
