### PR TITLE
feat: fetch course title on Exec Ed (2U) enrollment info page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "react-helmet": "5.2.1",
         "react-instantsearch-dom": "^6.8.2",
         "react-intl": "^5.21.1",
-        "react-loading-skeleton": "2.1.1",
+        "react-loading-skeleton": "^3.1.0",
         "react-parallax": "^3.3.0",
         "react-redux": "7.2.2",
         "react-router": "4.3.1",
@@ -58,7 +58,7 @@
         "universal-cookie": "4.0.4"
       },
       "devDependencies": {
-        "@edx/frontend-build": "^11.0.2",
+        "@edx/frontend-build": "11.0.2",
         "@testing-library/jest-dom": "5.11.9",
         "@testing-library/react": "11.2.7",
         "@testing-library/react-hooks": "3.7.0",
@@ -701,6 +701,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
       "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.14.5"
       },
@@ -2616,6 +2617,7 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
       "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
@@ -3094,95 +3096,6 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
-    },
-    "node_modules/@emotion/cache": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
-      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
-      "dependencies": {
-        "@emotion/sheet": "0.9.4",
-        "@emotion/stylis": "0.8.5",
-        "@emotion/utils": "0.11.3",
-        "@emotion/weak-memoize": "0.2.5"
-      }
-    },
-    "node_modules/@emotion/core": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
-      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/cache": "^10.0.27",
-        "@emotion/css": "^10.0.27",
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/sheet": "0.9.4",
-        "@emotion/utils": "0.11.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@emotion/css": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
-      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-      "dependencies": {
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/utils": "0.11.3",
-        "babel-plugin-emotion": "^10.0.27"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
-    },
-    "node_modules/@emotion/serialize": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-      "dependencies": {
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/unitless": "0.7.5",
-        "@emotion/utils": "0.11.3",
-        "csstype": "^2.5.7"
-      }
-    },
-    "node_modules/@emotion/serialize/node_modules/csstype": {
-      "version": "2.6.17",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
-    },
-    "node_modules/@emotion/sheet": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
-    },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-    },
-    "node_modules/@emotion/utils": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "1.5.0",
@@ -5215,7 +5128,8 @@
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
     },
     "node_modules/@types/prettier": {
       "version": "2.6.0",
@@ -6565,23 +6479,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "node_modules/babel-plugin-emotion": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
-      "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/serialize": "^0.11.16",
-        "babel-plugin-macros": "^2.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^1.0.5",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7"
-      }
-    },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -6611,31 +6508,6 @@
       },
       "engines": {
         "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/babel-plugin-macros": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "cosmiconfig": "^6.0.0",
-        "resolve": "^1.12.0"
-      }
-    },
-    "node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -6722,11 +6594,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "node_modules/babel-plugin-transform-imports": {
       "version": "2.0.0",
@@ -7689,6 +7556,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -8310,6 +8178,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
@@ -9855,6 +9724,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -11390,11 +11260,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -13355,6 +13220,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -13370,6 +13236,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -13701,7 +13568,8 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
@@ -13791,6 +13659,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
       "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -16665,7 +16534,8 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-schema": {
       "version": "0.2.3",
@@ -16845,7 +16715,8 @@
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
     },
     "node_modules/load-json-file": {
       "version": "2.0.0",
@@ -18264,6 +18135,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -18275,6 +18147,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -18366,7 +18239,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-to-regexp": {
       "version": "1.8.0",
@@ -18380,6 +18254,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -20185,14 +20060,11 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-loading-skeleton": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-2.1.1.tgz",
-      "integrity": "sha512-+fGvgG9ieUw4D5QVgpqJkJ75jhzUdz96GRsA0HjTlR0Mpj9DJUEFc0AKELs7ZkqWVH8/DiroaaufSrOPld1kGA==",
-      "dependencies": {
-        "@emotion/core": "^10.0.22"
-      },
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.1.0.tgz",
+      "integrity": "sha512-j1U1CWWs68nBPOg7tkQqnlFcAMFF6oEK6MgqAo15f8A5p7mjH6xyKn2gHbkcimpwfO0VQXqxAswnSYVr8lWzjw==",
       "peerDependencies": {
-        "react": "^15.6.1 || ^16.0.0"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-overlays": {
@@ -20994,6 +20866,7 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -21211,7 +21084,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -22126,6 +22000,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23101,6 +22976,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -24743,6 +24619,7 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -25310,6 +25187,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
       "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
       }
@@ -26664,6 +26542,7 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
       "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
@@ -27032,94 +26911,6 @@
           }
         }
       }
-    },
-    "@emotion/cache": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
-      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
-      "requires": {
-        "@emotion/sheet": "0.9.4",
-        "@emotion/stylis": "0.8.5",
-        "@emotion/utils": "0.11.3",
-        "@emotion/weak-memoize": "0.2.5"
-      }
-    },
-    "@emotion/core": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
-      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/cache": "^10.0.27",
-        "@emotion/css": "^10.0.27",
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/sheet": "0.9.4",
-        "@emotion/utils": "0.11.3"
-      }
-    },
-    "@emotion/css": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
-      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-      "requires": {
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/utils": "0.11.3",
-        "babel-plugin-emotion": "^10.0.27"
-      }
-    },
-    "@emotion/hash": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
-    },
-    "@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
-    },
-    "@emotion/serialize": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-      "requires": {
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/unitless": "0.7.5",
-        "@emotion/utils": "0.11.3",
-        "csstype": "^2.5.7"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "2.6.17",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-          "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
-        }
-      }
-    },
-    "@emotion/sheet": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
-    },
-    "@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
-    },
-    "@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-    },
-    "@emotion/utils": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-    },
-    "@emotion/weak-memoize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@formatjs/ecma402-abstract": {
       "version": "1.5.0",
@@ -28673,7 +28464,8 @@
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
     },
     "@types/prettier": {
       "version": "2.6.0",
@@ -29757,23 +29549,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "babel-plugin-emotion": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
-      "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/serialize": "^0.11.16",
-        "babel-plugin-macros": "^2.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^1.0.5",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7"
-      }
-    },
     "babel-plugin-istanbul": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -29797,30 +29572,6 @@
         "@babel/types": "^7.3.3",
         "@types/babel__core": "^7.0.0",
         "@types/babel__traverse": "^7.0.6"
-      }
-    },
-    "babel-plugin-macros": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "cosmiconfig": "^6.0.0",
-        "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
-          }
-        }
       }
     },
     "babel-plugin-polyfill-corejs2": {
@@ -29891,11 +29642,6 @@
           }
         }
       }
-    },
-    "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-imports": {
       "version": "2.0.0",
@@ -30690,7 +30436,8 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
     },
     "camel-case": {
       "version": "4.1.2",
@@ -31176,6 +30923,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -32369,6 +32117,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -33588,11 +33337,6 @@
           "dev": true
         }
       }
-    },
-    "find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "5.0.0",
@@ -35024,6 +34768,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -35032,7 +34777,8 @@
         "resolve-from": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
         }
       }
     },
@@ -35302,7 +35048,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -35354,6 +35101,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
       "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -37508,7 +37256,8 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -37650,7 +37399,8 @@
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -38740,6 +38490,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
@@ -38748,6 +38499,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -38818,7 +38570,8 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "1.8.0",
@@ -38831,7 +38584,8 @@
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
     },
     "pend": {
       "version": "1.2.0",
@@ -40131,12 +39885,10 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-loading-skeleton": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-2.1.1.tgz",
-      "integrity": "sha512-+fGvgG9ieUw4D5QVgpqJkJ75jhzUdz96GRsA0HjTlR0Mpj9DJUEFc0AKELs7ZkqWVH8/DiroaaufSrOPld1kGA==",
-      "requires": {
-        "@emotion/core": "^10.0.22"
-      }
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.1.0.tgz",
+      "integrity": "sha512-j1U1CWWs68nBPOg7tkQqnlFcAMFF6oEK6MgqAo15f8A5p7mjH6xyKn2gHbkcimpwfO0VQXqxAswnSYVr8lWzjw==",
+      "requires": {}
     },
     "react-overlays": {
       "version": "5.1.2",
@@ -40752,6 +40504,7 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -40914,7 +40667,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -41678,7 +41432,8 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "source-map-js": {
       "version": "1.0.2",
@@ -42446,7 +42201,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -43655,7 +43411,8 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-helmet": "5.2.1",
     "react-instantsearch-dom": "^6.8.2",
     "react-intl": "^5.21.1",
-    "react-loading-skeleton": "2.1.1",
+    "react-loading-skeleton": "^3.1.0",
     "react-parallax": "^3.3.0",
     "react-redux": "7.2.2",
     "react-router": "4.3.1",

--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -33,8 +33,7 @@ export const useEnterpriseCustomerConfig = (enterpriseSlug, useCache = true) => 
         const config = results.pop();
         if (config?.enableLearnerPortal) {
           const brandingConfiguration = config.brandingConfiguration || defaultBrandingConfig;
-          const disableSearch = !config?.enableIntegratedCustomerLearnerPortalSearch;
-          // const disableSearch = !!(!config?.enableIntegratedCustomerLearnerPortalSearch && config?.identityProvider);
+          const disableSearch = !!(!config?.enableIntegratedCustomerLearnerPortalSearch && config?.identityProvider);
           const showIntegrationWarning = !!(!disableSearch && config?.identityProvider);
           const {
             logo,

--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -33,7 +33,8 @@ export const useEnterpriseCustomerConfig = (enterpriseSlug, useCache = true) => 
         const config = results.pop();
         if (config?.enableLearnerPortal) {
           const brandingConfiguration = config.brandingConfiguration || defaultBrandingConfig;
-          const disableSearch = !!(!config?.enableIntegratedCustomerLearnerPortalSearch && config?.identityProvider);
+          const disableSearch = !config?.enableIntegratedCustomerLearnerPortalSearch;
+          // const disableSearch = !!(!config?.enableIntegratedCustomerLearnerPortalSearch && config?.identityProvider);
           const showIntegrationWarning = !!(!disableSearch && config?.identityProvider);
           const {
             logo,

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
@@ -71,8 +71,8 @@ function ExecutiveEducation2UPage() {
         ) : (
           <>
             {enterpriseName} has partnered with edX and GetSmarter to offer you high-quality Executive Education
-            courses. To access <strong>&quot;{contentMetadata.title}&quot;</strong>, you{' '}
-            <strong>must accept</strong> Terms of Service and <strong>provide additional data</strong>.
+            courses. To access <strong>&quot;{contentMetadata.title}&quot;</strong>, you must{' '}
+            <strong>accept</strong> Terms of Service and <strong>provide course enrollment data</strong>.
           </>
         )}
       </p>

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useContext, useEffect, useState,
+  useContext, useEffect, useMemo,
 } from 'react';
 import { Container } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
@@ -9,20 +9,31 @@ import { logError } from '@edx/frontend-platform/logging';
 
 import NotFoundPage from '../NotFoundPage';
 import UserEnrollmentForm from './UserEnrollmentForm';
-import { getExecutiveEducation2UContentMetadata, useActiveQueryParams } from './data';
+import {
+  useActiveQueryParams,
+  useExecutiveEducation2UContentMetadata,
+} from './data';
 
 function ExecutiveEducation2UPage() {
   const { enterpriseConfig } = useContext(AppContext);
   const activeQueryParams = useActiveQueryParams();
 
-  const [isLoadingContentMetadata, setIsLoadingContentMetadata] = useState(true);
-  const [contentMetadata, setContentMetadata] = useState();
+  const isExecEd2UFulfillmentEnabled = useMemo(() => (
+    enterpriseConfig.enableExecutiveEducation2UFulfillment && activeQueryParams.has('course_uuid')
+  ), [enterpriseConfig, activeQueryParams]);
 
-  const isExecEd2UFulfillmentEnabled = (enterpriseConfig.enableExecutiveEducation2UFulfillment && activeQueryParams.has('course_uuid'));
+  const {
+    isLoading: isLoadingContentMetadata,
+    contentMetadata,
+  } = useExecutiveEducation2UContentMetadata({
+    courseUUID: activeQueryParams.get('course_uuid'),
+    isExecEd2UFulfillmentEnabled,
+  });
 
   useEffect(() => {
     const isExecEd2UEnabled = enterpriseConfig.enableExecutiveEducation2UFulfillment;
     const hasCourseUUIDQueryParam = activeQueryParams.has('course_uuid');
+
     if (!isExecEd2UEnabled) {
       logError(`Enterprise ${enterpriseConfig.uuid} does not have executive education (2U) fulfillment enabled.`);
     }
@@ -30,24 +41,6 @@ function ExecutiveEducation2UPage() {
       logError(`Enterprise ${enterpriseConfig.uuid} visited ExecutiveEducation2UPage without required course_uuid query parameter.`);
     }
   }, [activeQueryParams, enterpriseConfig]);
-
-  useEffect(() => {
-    const fetchContentMetadata = async () => {
-      setIsLoadingContentMetadata(true);
-      try {
-        const courseUUID = activeQueryParams.get('course_uuid');
-        const metadata = await getExecutiveEducation2UContentMetadata(courseUUID);
-        setContentMetadata(metadata);
-      } catch (error) {
-        logError(error);
-      } finally {
-        setIsLoadingContentMetadata(false);
-      }
-    };
-    if (isExecEd2UFulfillmentEnabled) {
-      fetchContentMetadata();
-    }
-  }, [isExecEd2UFulfillmentEnabled, activeQueryParams]);
 
   if (!isExecEd2UFulfillmentEnabled) {
     return (

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
@@ -31,13 +31,10 @@ function ExecutiveEducation2UPage() {
   });
 
   useEffect(() => {
-    const isExecEd2UEnabled = enterpriseConfig.enableExecutiveEducation2UFulfillment;
-    const hasCourseUUIDQueryParam = activeQueryParams.has('course_uuid');
-
-    if (!isExecEd2UEnabled) {
+    if (!enterpriseConfig.enableExecutiveEducation2UFulfillment) {
       logError(`Enterprise ${enterpriseConfig.uuid} does not have executive education (2U) fulfillment enabled.`);
     }
-    if (!hasCourseUUIDQueryParam) {
+    if (!activeQueryParams.has('course_uuid')) {
       logError(`Enterprise ${enterpriseConfig.uuid} visited ExecutiveEducation2UPage without required course_uuid query parameter.`);
     }
   }, [activeQueryParams, enterpriseConfig]);

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
@@ -1,98 +1,89 @@
-/* eslint-disable react/no-danger */
 import React, {
-  useContext, useEffect, useMemo, useState,
+  useContext, useEffect, useState,
 } from 'react';
-import { Container, Tabs, Tab } from '@edx/paragon';
+import { Container } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
-import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { Helmet } from 'react-helmet';
 import Skeleton from 'react-loading-skeleton';
 import { logError } from '@edx/frontend-platform/logging';
 
 import NotFoundPage from '../NotFoundPage';
-import { getExecutiveEducation2UTerms } from './data';
+import UserEnrollmentForm from './UserEnrollmentForm';
+import { getExecutiveEducation2UContentMetadata, useActiveQueryParams } from './data';
 
 function ExecutiveEducation2UPage() {
   const { enterpriseConfig } = useContext(AppContext);
-  const [isLoading, setIsLoading] = useState(true);
-  const [terms, setTerms] = useState();
+  const activeQueryParams = useActiveQueryParams();
+
+  const [isLoadingContentMetadata, setIsLoadingContentMetadata] = useState(true);
+  const [contentMetadata, setContentMetadata] = useState();
+
+  const isExecEd2UFulfillmentEnabled = (enterpriseConfig.enableExecutiveEducation2UFulfillment && activeQueryParams.has('course_uuid'));
 
   useEffect(() => {
-    const fetchTerms = async () => {
-      setIsLoading(true);
+    const isExecEd2UEnabled = enterpriseConfig.enableExecutiveEducation2UFulfillment;
+    const hasCourseUUIDQueryParam = activeQueryParams.has('course_uuid');
+    if (!isExecEd2UEnabled) {
+      logError(`Enterprise ${enterpriseConfig.uuid} does not have executive education (2U) fulfillment enabled.`);
+    }
+    if (!hasCourseUUIDQueryParam) {
+      logError(`Enterprise ${enterpriseConfig.uuid} visited ExecutiveEducation2UPage without required course_uuid query parameter.`);
+    }
+  }, [activeQueryParams, enterpriseConfig]);
+
+  useEffect(() => {
+    const fetchContentMetadata = async () => {
+      setIsLoadingContentMetadata(true);
       try {
-        const response = await getExecutiveEducation2UTerms();
-        setTerms(camelCaseObject(response.data));
+        const courseUUID = activeQueryParams.get('course_uuid');
+        const metadata = await getExecutiveEducation2UContentMetadata(courseUUID);
+        setContentMetadata(metadata);
       } catch (error) {
         logError(error);
       } finally {
-        setIsLoading(false);
+        setIsLoadingContentMetadata(false);
       }
     };
-    if (enterpriseConfig.enableExecutiveEducation2UFulfillment) {
-      fetchTerms();
+    if (isExecEd2UFulfillmentEnabled) {
+      fetchContentMetadata();
     }
-  }, [enterpriseConfig.enableExecutiveEducation2UFulfillment]);
+  }, [isExecEd2UFulfillmentEnabled, activeQueryParams]);
 
-  const tabs = useMemo(() => {
-    if (!terms) {
-      return [];
-    }
-    const includedTabs = [];
-    if (terms.studentTermsAndConditions) {
-      const key = 'studentTermsAndConditions';
-      includedTabs.push(
-        <Tab eventKey={key} key={key} title="Student Terms and Conditions" className="py-4">
-          <div dangerouslySetInnerHTML={{ __html: terms.studentTermsAndConditions }} />
-        </Tab>,
-      );
-    }
-    if (terms.websiteTermsOfUse) {
-      const key = 'websiteTermsOfUse';
-      includedTabs.push(
-        <Tab eventKey={key} key={key} title="Website Terms of Use" className="py-4">
-          <div dangerouslySetInnerHTML={{ __html: terms.websiteTermsOfUse }} />
-        </Tab>,
-      );
-    }
-    if (terms.privacyPolicy) {
-      const key = 'privacyPolicy';
-      includedTabs.push(
-        <Tab eventKey={key} key={key} title="Privacy Policy" className="py-4">
-          <div dangerouslySetInnerHTML={{ __html: terms.privacyPolicy }} />
-        </Tab>,
-      );
-    }
-    if (terms.cookiePolicy) {
-      const key = 'cookiePolicy';
-      includedTabs.push(
-        <Tab eventKey={key} key={key} title="Cookie Policy" className="py-4">
-          <div dangerouslySetInnerHTML={{ __html: terms.cookiePolicy }} />
-        </Tab>,
-      );
-    }
-    return includedTabs;
-  }, [terms]);
-
-  if (!enterpriseConfig.enableExecutiveEducation2UFulfillment) {
+  if (!isExecEd2UFulfillmentEnabled) {
     return (
       <NotFoundPage />
     );
   }
 
+  const isLoading = isLoadingContentMetadata;
+  const { name: enterpriseName } = enterpriseConfig;
+
+  const pageTitle = 'Share course enrollment information';
+
   return (
     <Container size="lg" className="py-5">
       <Helmet>
-        <title>Executive Education (2U)</title>
+        <title>{pageTitle}</title>
       </Helmet>
-      {isLoading && (
-        <p data-testid="loading-skeleton-geag-terms"><Skeleton count={20} /></p>
-      )}
-      {tabs.length > 0 && (
-        <Tabs defaultActiveKey="studentTermsAndConditions" id="geag-terms">
-          {tabs}
-        </Tabs>
-      )}
+      <h2>
+        {isLoading ? (
+          <Skeleton containerTestId="loading-skeleton-page-title" />
+        ) : (
+          <>{pageTitle}</>
+        )}
+      </h2>
+      <p>
+        {(isLoading || !contentMetadata) ? (
+          <Skeleton count={3} containerTestId="loading-skeleton-text-blurb" />
+        ) : (
+          <>
+            {enterpriseName} has partnered with edX and GetSmarter to offer you high-quality Executive Education
+            courses. To access <strong>&quot;{contentMetadata.title}&quot;</strong>, you{' '}
+            <strong>must accept</strong> Terms of Service and <strong>provide additional data</strong>.
+          </>
+        )}
+      </p>
+      {!isLoading && <UserEnrollmentForm className="mt-5" />}
     </Container>
   );
 }

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.test.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.test.jsx
@@ -1,13 +1,15 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
-import { logError } from '@edx/frontend-platform/logging';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 
 import ExecutiveEducation2UPage from './ExecutiveEducation2UPage';
-import { getContentMetadata, useActiveQueryParams } from './data';
+import {
+  useActiveQueryParams,
+  useExecutiveEducation2UContentMetadata,
+} from './data';
 
 jest.mock('./data');
 jest.mock('@edx/frontend-platform/logging', () => ({
@@ -42,7 +44,9 @@ describe('ExecutiveEducation2UPage', () => {
   });
 
   it('shows 404 when `enableExecutiveEducation2UFulfillment` is false', () => {
-    useActiveQueryParams.mockImplementation(() => new URLSearchParams());
+    useActiveQueryParams.mockReturnValue(new URLSearchParams());
+    useExecutiveEducation2UContentMetadata.mockReturnValue({ isLoading: false, contentMetadata: undefined });
+
     const appContextValue = {
       ...initialAppContextValue,
       enterpriseConfig: {
@@ -52,13 +56,14 @@ describe('ExecutiveEducation2UPage', () => {
     };
     renderWithRouter(<ExecutiveEducation2UPageWrapper appContextValue={appContextValue} />);
     expect(screen.getByText('404')).toBeInTheDocument();
-
-    expect(getContentMetadata).not.toHaveBeenCalled();
   });
 
   it('does not render page when `enableExecutiveEducation2UFulfillment` is true and course_uuid is not provided', async () => {
     const courseTitle = 'edX Demonstration Course';
-    getContentMetadata.mockResolvedValueOnce({ title: courseTitle });
+    useExecutiveEducation2UContentMetadata.mockReturnValue({
+      isLoading: false,
+      contentMetadata: { title: courseTitle },
+    });
     const searchParams = new URLSearchParams();
     useActiveQueryParams.mockImplementation(() => searchParams);
 
@@ -66,42 +71,37 @@ describe('ExecutiveEducation2UPage', () => {
     expect(screen.queryByText('404')).toBeInTheDocument();
   });
 
-  it('renders page when `enableExecutiveEducation2UFulfillment` is true and course_uuid is provided', async () => {
+  it('renders page when `enableExecutiveEducation2UFulfillment` is true and course_uuid is provided', () => {
     const courseTitle = 'edX Demonstration Course';
-    getContentMetadata.mockResolvedValueOnce({ title: courseTitle });
+    useExecutiveEducation2UContentMetadata.mockReturnValue({
+      isLoading: false,
+      contentMetadata: { title: courseTitle },
+    });
     const searchParams = new URLSearchParams({ course_uuid: 'test-course-uuid' });
     useActiveQueryParams.mockImplementation(() => searchParams);
 
     renderWithRouter(<ExecutiveEducation2UPageWrapper />);
     expect(screen.queryByText('404')).not.toBeInTheDocument();
 
-    // initially in loading state
-    expect(screen.getByTestId('loading-skeleton-page-title')).toBeInTheDocument();
-    expect(screen.getByTestId('loading-skeleton-text-blurb')).toBeInTheDocument();
-
-    // no longer in loading state
-    await waitFor(() => {
-      expect(screen.queryByTestId('loading-skeleton-page-title')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('loading-skeleton-text-blurb')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('loading-skeleton-page-title')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loading-skeleton-text-blurb')).not.toBeInTheDocument();
 
     expect(screen.getByText(courseTitle, { exact: false })).toBeInTheDocument();
     expect(screen.getByTestId('user-enrollment-form-component')).toBeInTheDocument();
   });
 
-  it('handles exception when fetching content metadata', async () => {
+  it('renders page with loading states when fetching content metadata', () => {
+    useExecutiveEducation2UContentMetadata.mockReturnValue({
+      isLoading: true,
+      contentMetadata: undefined,
+    });
     const searchParams = new URLSearchParams({ course_uuid: 'test-course-uuid' });
     useActiveQueryParams.mockImplementation(() => searchParams);
-    const mockError = new Error('oh noes');
-    getContentMetadata.mockImplementation(() => new Promise(() => { throw mockError; }));
 
     renderWithRouter(<ExecutiveEducation2UPageWrapper />);
     expect(screen.queryByText('404')).not.toBeInTheDocument();
-    expect(screen.getByTestId('loading-skeleton-text-blurb')).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(logError).toHaveBeenCalledTimes(1);
-      expect(logError).toHaveBeenCalledWith(mockError);
-    });
+    expect(screen.getByTestId('loading-skeleton-page-title')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-skeleton-text-blurb')).toBeInTheDocument();
   });
 });

--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  ActionRow, Button, Stack, Form, Hyperlink,
+} from '@edx/paragon';
+
+import { useActiveQueryParams } from './data';
+
+function UserEnrollmentForm({ className }) {
+  const [isTermsChecked, setIsTermsChecked] = useState(false);
+  const activeQueryParams = useActiveQueryParams();
+
+  return (
+    <form className={className}>
+      <div className="mb-4">
+        <h3 className="h4 mb-3">Personal information</h3>
+        <Stack direction="horizontal" gap={3}>
+          <Form.Group>
+            <Form.Control
+              value=""
+              onChange={() => {}}
+              floatingLabel="First Name"
+            />
+          </Form.Group>
+          <Form.Group>
+            <Form.Control
+              value=""
+              onChange={() => {}}
+              floatingLabel="Last Name"
+            />
+          </Form.Group>
+        </Stack>
+      </div>
+      <div className="mb-4">
+        <h3 className="h4 mb-3">Contact information</h3>
+        <Form.Group>
+          <Form.Control
+            value=""
+            onChange={() => {}}
+            floatingLabel="Address Line 1"
+          />
+        </Form.Group>
+        <Form.Group>
+          <Form.Control
+            value=""
+            onChange={() => {}}
+            floatingLabel="Address Line 2"
+          />
+        </Form.Group>
+        <Stack direction="horizontal" gap={3}>
+          <Form.Group>
+            <Form.Control
+              value=""
+              onChange={() => {}}
+              floatingLabel="City"
+            />
+          </Form.Group>
+          <Form.Group>
+            <Form.Control
+              value=""
+              onChange={() => {}}
+              floatingLabel="State"
+            />
+          </Form.Group>
+          <Form.Group>
+            <Form.Control
+              value=""
+              onChange={() => {}}
+              floatingLabel="Postal Code"
+            />
+          </Form.Group>
+        </Stack>
+        <Form.Group>
+          <Form.Control
+            value=""
+            onChange={() => {}}
+            floatingLabel="Country"
+          />
+        </Form.Group>
+      </div>
+      <div className="mb-4">
+        <Form.Group className="d-flex align-items-center">
+          <Form.Checkbox
+            checked={isTermsChecked}
+            onChange={() => setIsTermsChecked(!isTermsChecked)}
+          >
+            I agree
+          </Form.Checkbox>
+          &nbsp;to the&nbsp;
+          <Hyperlink
+            destination="https://www.getsmarter.com/terms-and-conditions-for-students"
+            target="_blank"
+          >
+            Terms and Conditions for Students
+          </Hyperlink>
+        </Form.Group>
+        <p className="small">
+          By providing these details you agree to the use of your data as described in our{' '}
+          <Hyperlink destination="https://www.getsmarter.com/privacy-policy" target="_blank">privacy policy</Hyperlink>. By
+          using our services or registering for a course, you agree to be bound by these terms. If you do not agree to
+          be bound by these terms, or are not able to enter into a binding agreement then you may not register for a
+          course or use our services.
+        </p>
+      </div>
+      <div>
+        <ActionRow>
+          {activeQueryParams.has('redirect_url') && (
+            <Button as="a" variant="tertiary" href={activeQueryParams.get('redirect_url')}>
+              Go back
+            </Button>
+          )}
+          <Button variant="primary">
+            Continue
+          </Button>
+        </ActionRow>
+      </div>
+    </form>
+  );
+}
+
+UserEnrollmentForm.propTypes = {
+  className: PropTypes.string,
+};
+
+UserEnrollmentForm.defaultProps = {
+  className: undefined,
+};
+
+export default UserEnrollmentForm;

--- a/src/components/executive-education-2u/data/constants.js
+++ b/src/components/executive-education-2u/data/constants.js
@@ -1,6 +1,0 @@
-export const GEAG_TERMS = {
-  privacyPolicy: '<p>privacy policy content</p>',
-  websiteTermsOfUse: '<p>website terms of use content</p>',
-  studentTermsAndConditions: '<p>student terms and conditions content</p>',
-  cookiePolicy: '<p>cookie policy content</p>',
-};

--- a/src/components/executive-education-2u/data/hooks.js
+++ b/src/components/executive-education-2u/data/hooks.js
@@ -1,0 +1,43 @@
+import { useMemo, useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { logError } from '@edx/frontend-platform/logging';
+
+import {
+  getExecutiveEducation2UContentMetadata,
+} from './service';
+
+export function useActiveQueryParams() {
+  const location = useLocation();
+  const activeQueryParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  return activeQueryParams;
+}
+
+export function useExecutiveEducation2UContentMetadata({
+  courseUUID,
+  isExecEd2UFulfillmentEnabled,
+}) {
+  const [isLoadingContentMetadata, setIsLoadingContentMetadata] = useState(isExecEd2UFulfillmentEnabled);
+  const [contentMetadata, setContentMetadata] = useState();
+
+  useEffect(() => {
+    const fetchContentMetadata = async () => {
+      setIsLoadingContentMetadata(true);
+      try {
+        const metadata = await getExecutiveEducation2UContentMetadata(courseUUID);
+        setContentMetadata(metadata);
+      } catch (error) {
+        logError(error);
+      } finally {
+        setIsLoadingContentMetadata(false);
+      }
+    };
+    if (isExecEd2UFulfillmentEnabled) {
+      fetchContentMetadata();
+    }
+  }, [isExecEd2UFulfillmentEnabled, courseUUID]);
+
+  return {
+    isLoadingContentMetadata,
+    contentMetadata,
+  };
+}

--- a/src/components/executive-education-2u/data/hooks.test.js
+++ b/src/components/executive-education-2u/data/hooks.test.js
@@ -1,0 +1,92 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useLocation } from 'react-router-dom';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { logError } from '@edx/frontend-platform/logging';
+
+import {
+  useActiveQueryParams,
+  useExecutiveEducation2UContentMetadata,
+} from './hooks';
+
+jest.mock('@edx/frontend-platform/auth', () => ({
+  getAuthenticatedHttpClient: jest.fn(),
+}));
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn(),
+}));
+
+describe('useActiveQueryParams', () => {
+  it('should parse location search as URLSearchParams', () => {
+    useLocation.mockReturnValue({ search: 'foo=bar' });
+    const { result } = renderHook(() => useActiveQueryParams());
+    expect(result.current.has('foo')).toEqual(true);
+  });
+});
+
+describe('useExecutiveEducation2UContentMetadata', () => {
+  it('should not fetch content metadata if Exec Ed (2U) fulfillment is not enabled', () => {
+    const args = {
+      courseUUID: undefined,
+      isExecEd2UFulfillmentEnabled: false,
+    };
+    const { result } = renderHook(() => useExecutiveEducation2UContentMetadata(args));
+
+    expect(result.current.isLoadingContentMetadata).toEqual(false);
+    expect(result.current.contentMetadata).toEqual(undefined);
+  });
+
+  it('should fetch content metadata', async () => {
+    const courseUUID = 'test-course-uuid';
+    getAuthenticatedHttpClient.mockImplementation(() => ({
+      get: jest.fn(() => Promise.resolve({
+        data: {
+          results: [{ uuid: courseUUID }],
+        },
+      })),
+    }));
+    const args = {
+      courseUUID,
+      isExecEd2UFulfillmentEnabled: true,
+    };
+    const { result, waitForNextUpdate } = renderHook(() => useExecutiveEducation2UContentMetadata(args));
+
+    expect(result.current.isLoadingContentMetadata).toEqual(true);
+    expect(result.current.contentMetadata).toEqual(undefined);
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoadingContentMetadata).toEqual(false);
+    expect(result.current.contentMetadata).toEqual(
+      expect.objectContaining({
+        uuid: expect.any(String),
+      }),
+    );
+  });
+
+  it('should handle fetch content metadata error', async () => {
+    const courseUUID = 'test-course-uuid';
+    const mockError = new Error('oh noes');
+    getAuthenticatedHttpClient.mockImplementation(() => ({
+      get: jest.fn(() => Promise.reject(mockError)),
+    }));
+    const args = {
+      courseUUID,
+      isExecEd2UFulfillmentEnabled: true,
+    };
+    const { result, waitForNextUpdate } = renderHook(() => useExecutiveEducation2UContentMetadata(args));
+
+    expect(result.current.isLoadingContentMetadata).toEqual(true);
+    expect(result.current.contentMetadata).toEqual(undefined);
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoadingContentMetadata).toEqual(false);
+    expect(result.current.contentMetadata).toEqual(undefined);
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith(mockError);
+  });
+});

--- a/src/components/executive-education-2u/data/index.js
+++ b/src/components/executive-education-2u/data/index.js
@@ -1,2 +1,3 @@
 export * from './service';
+export * from './hooks';
 export * from './constants';

--- a/src/components/executive-education-2u/data/service.js
+++ b/src/components/executive-education-2u/data/service.js
@@ -1,9 +1,23 @@
-import { GEAG_TERMS } from './constants';
+import { getConfig } from '@edx/frontend-platform/config';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { snakeCaseObject, camelCaseObject } from '@edx/frontend-platform/utils';
 
-export function getExecutiveEducation2UTerms() {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({ data: GEAG_TERMS });
-    }, 2000);
+/**
+ * Retrieves the executive education (2U) course content metadata for the specified course uuid.
+ *
+ * @param {string} courseUUID Course UUID to retreieve the course content metadata for
+ * @param {object} options Optional options. Keys will automatically be snakecased.
+ *
+ * @returns An object containing the course content metadata for the specified course.
+ */
+export async function getExecutiveEducation2UContentMetadata(courseUUID, options = {}) {
+  const config = getConfig();
+  const queryParams = new URLSearchParams({
+    uuids: courseUUID,
+    ...snakeCaseObject(options),
   });
+  const url = `${config.DISCOVERY_API_BASE_URL}/api/v1/courses/?${queryParams.toString()}}`;
+  const res = await getAuthenticatedHttpClient().get(url);
+  const contentMetadata = camelCaseObject(res.data.results[0]);
+  return contentMetadata;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,6 +8,8 @@
 $fa-font-path: "~font-awesome/fonts";
 @import "~font-awesome/scss/font-awesome";
 
+@import 'react-loading-skeleton/dist/skeleton.css';
+
 @import "./components/course/styles/CourseHeader";
 @import "./components/course/styles/CourseSidebar";
 @import "./components/course/styles/ProgramSidebar";


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6134

On the Executive Education (2U) page:
* Fetch content metadata for Executive Education (2U) content based on from `course_uuid` query parameter.
* Display page title, enterprise branding, and a starting point of the enrollment form.
* Tests for the `ExecutiveEducation2UPage` component

![image](https://user-images.githubusercontent.com/2828721/184137510-f983b2ee-1a8c-4180-a69a-7fa561b64d0e.png)

![image](https://user-images.githubusercontent.com/2828721/184137596-28d20bbe-0ad0-4849-bd88-47aaeb6771a8.png)

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
