### PR TITLE
feat: add functionality to Executive Education (2U) form and cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "dompurify": "^2.3.6",
         "email-prop-type": "1.1.7",
         "font-awesome": "4.7.0",
+        "formik": "^2.2.9",
         "history": "4.10.1",
         "iso-639-1": "2.1.4",
         "lodash.camelcase": "4.3.0",
@@ -11574,6 +11575,42 @@
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
+    "node_modules/formik": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.9.tgz",
+      "integrity": "sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://opencollective.com/formik"
+        }
+      ],
+      "dependencies": {
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "react-fast-compare": "^2.0.1",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^1.10.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/formik/node_modules/deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/formik/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -16811,8 +16848,12 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -33549,6 +33590,32 @@
       "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
       "dev": true
     },
+    "formik": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.9.tgz",
+      "integrity": "sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==",
+      "requires": {
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "react-fast-compare": "^2.0.1",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+          "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -37476,8 +37543,12 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dompurify": "^2.3.6",
     "email-prop-type": "1.1.7",
     "font-awesome": "4.7.0",
+    "formik": "^2.2.9",
     "history": "4.10.1",
     "iso-639-1": "2.1.4",
     "lodash.camelcase": "4.3.0",

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
@@ -1,7 +1,7 @@
 import React, {
   useContext, useEffect, useMemo,
 } from 'react';
-import { Container } from '@edx/paragon';
+import { Container, Row, Col } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Helmet } from 'react-helmet';
 import Skeleton from 'react-loading-skeleton';
@@ -55,25 +55,29 @@ function ExecutiveEducation2UPage() {
       <Helmet>
         <title>{pageTitle}</title>
       </Helmet>
-      <h2>
+      <h2 className="mb-3">
         {isLoading ? (
           <Skeleton containerTestId="loading-skeleton-page-title" />
         ) : (
           <>{pageTitle}</>
         )}
       </h2>
-      <p>
-        {(isLoading || !contentMetadata) ? (
+      {(isLoading || !contentMetadata) ? (
+        <p>
           <Skeleton count={3} containerTestId="loading-skeleton-text-blurb" />
-        ) : (
-          <>
-            {enterpriseName} has partnered with edX and GetSmarter to offer you high-quality Executive Education
-            courses. To access <strong>&quot;{contentMetadata.title}&quot;</strong>, you must{' '}
-            <strong>accept</strong> Terms of Service and <strong>provide course enrollment data</strong>.
-          </>
-        )}
-      </p>
-      {!isLoading && <UserEnrollmentForm className="mt-5" />}
+        </p>
+      ) : (
+        <Row className="mb-4">
+          <Col xs={12} lg={10}>
+            <p>
+              {enterpriseName} has partnered with edX and GetSmarter to offer you high-quality Executive Education
+              courses. To access <strong>&quot;{contentMetadata.title}&quot;</strong>, you must (1) provide course
+              enrollment data and (2) accept Terms and Conditions.
+            </p>
+          </Col>
+        </Row>
+      )}
+      {!isLoading && <UserEnrollmentForm />}
     </Container>
   );
 }

--- a/src/components/executive-education-2u/FormSectionHeading.jsx
+++ b/src/components/executive-education-2u/FormSectionHeading.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const FormSectionHeading = ({ children }) => (
+  <h3 className="h4 mb-4">{children}</h3>
+);
+
+FormSectionHeading.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default FormSectionHeading;

--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -1,120 +1,171 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  ActionRow, Button, Stack, Form, Hyperlink,
+  Button, Form, Hyperlink, CheckboxControl, Row, Col,
 } from '@edx/paragon';
+import {
+  Formik,
+  Form as FormikForm,
+} from 'formik';
+import { logError } from '@edx/frontend-platform/logging';
 
-import { useActiveQueryParams } from './data';
+import { checkoutExecutiveEducation2U } from './data';
+import FormSectionHeading from './FormSectionHeading';
+
+export const formValidationMessages = {
+  firstNameRequired: 'First name is required',
+  lastNameRequired: 'Last name is required',
+  studentTermsAndConditionsRequired: 'Please agree to Terms and Conditions for Students',
+};
 
 function UserEnrollmentForm({ className }) {
-  const [isTermsChecked, setIsTermsChecked] = useState(false);
-  const activeQueryParams = useActiveQueryParams();
+  const [isFormSubmitted, setIsFormSubmitted] = useState(false);
+
+  const handleFormValidation = (values) => {
+    const errors = {};
+    if (!values.firstName) {
+      errors.firstName = formValidationMessages.firstNameRequired;
+    }
+    if (!values.lastName) {
+      errors.lastName = formValidationMessages.lastNameRequired;
+    }
+    if (!values.studentTermsAndConditions) {
+      errors.studentTermsAndConditions = formValidationMessages.studentTermsAndConditionsRequired;
+    }
+    return errors;
+  };
+
+  const handleFormSubmit = async (values, { setSubmitting }) => {
+    try {
+      await checkoutExecutiveEducation2U({
+        firstName: values.firstName,
+        lastName: values.lastName,
+      });
+    } catch (error) {
+      logError(error);
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
-    <form className={className}>
-      <div className="mb-4">
-        <h3 className="h4 mb-3">Personal information</h3>
-        <Stack direction="horizontal" gap={3}>
-          <Form.Group>
-            <Form.Control
-              value=""
-              onChange={() => {}}
-              floatingLabel="First Name"
-            />
-          </Form.Group>
-          <Form.Group>
-            <Form.Control
-              value=""
-              onChange={() => {}}
-              floatingLabel="Last Name"
-            />
-          </Form.Group>
-        </Stack>
-      </div>
-      <div className="mb-4">
-        <h3 className="h4 mb-3">Contact information</h3>
-        <Form.Group>
-          <Form.Control
-            value=""
-            onChange={() => {}}
-            floatingLabel="Address Line 1"
-          />
-        </Form.Group>
-        <Form.Group>
-          <Form.Control
-            value=""
-            onChange={() => {}}
-            floatingLabel="Address Line 2"
-          />
-        </Form.Group>
-        <Stack direction="horizontal" gap={3}>
-          <Form.Group>
-            <Form.Control
-              value=""
-              onChange={() => {}}
-              floatingLabel="City"
-            />
-          </Form.Group>
-          <Form.Group>
-            <Form.Control
-              value=""
-              onChange={() => {}}
-              floatingLabel="State"
-            />
-          </Form.Group>
-          <Form.Group>
-            <Form.Control
-              value=""
-              onChange={() => {}}
-              floatingLabel="Postal Code"
-            />
-          </Form.Group>
-        </Stack>
-        <Form.Group>
-          <Form.Control
-            value=""
-            onChange={() => {}}
-            floatingLabel="Country"
-          />
-        </Form.Group>
-      </div>
-      <div className="mb-4">
-        <Form.Group className="d-flex align-items-center">
-          <Form.Checkbox
-            checked={isTermsChecked}
-            onChange={() => setIsTermsChecked(!isTermsChecked)}
-          >
-            I agree
-          </Form.Checkbox>
-          &nbsp;to the&nbsp;
-          <Hyperlink
-            destination="https://www.getsmarter.com/terms-and-conditions-for-students"
-            target="_blank"
-          >
-            Terms and Conditions for Students
-          </Hyperlink>
-        </Form.Group>
-        <p className="small">
-          By providing these details you agree to the use of your data as described in our{' '}
-          <Hyperlink destination="https://www.getsmarter.com/privacy-policy" target="_blank">privacy policy</Hyperlink>. By
-          using our services or registering for a course, you agree to be bound by these terms. If you do not agree to
-          be bound by these terms, or are not able to enter into a binding agreement then you may not register for a
-          course or use our services.
-        </p>
-      </div>
-      <div>
-        <ActionRow>
-          {activeQueryParams.has('redirect_url') && (
-            <Button as="a" variant="tertiary" href={activeQueryParams.get('redirect_url')}>
-              Go back
-            </Button>
-          )}
-          <Button variant="primary">
-            Continue
-          </Button>
-        </ActionRow>
-      </div>
-    </form>
+    <Formik
+      initialValues={{
+        firstName: '',
+        lastName: '',
+        studentTermsAndConditions: false,
+      }}
+      validateOnChange={isFormSubmitted}
+      validateOnBlur={isFormSubmitted}
+      validate={handleFormValidation}
+      onSubmit={handleFormSubmit}
+    >
+      {({
+        values,
+        errors,
+        handleChange,
+        handleBlur,
+        handleSubmit,
+        isSubmitting,
+      }) => (
+        <FormikForm
+          className={className}
+          onSubmit={(e) => {
+            handleSubmit(e);
+            setIsFormSubmitted(true);
+          }}
+        >
+          <FormSectionHeading>Personal information</FormSectionHeading>
+          <Row className="mb-4">
+            <Col xs={12} lg={3}>
+              <Form.Group
+                isInvalid={!!errors.firstName}
+                className="mb-4.5 mb-lg-0"
+              >
+                <Form.Control
+                  value={values.firstName}
+                  floatingLabel="First name *"
+                  name="firstName"
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                />
+                {errors.firstName && isFormSubmitted && (
+                  <Form.Control.Feedback type="invalid">
+                    {errors.firstName}
+                  </Form.Control.Feedback>
+                )}
+              </Form.Group>
+            </Col>
+            <Col xs={12} lg={3}>
+              <Form.Group
+                isInvalid={!!errors.lastName}
+              >
+                <Form.Control
+                  value={values.lastName}
+                  floatingLabel="Last name *"
+                  name="lastName"
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                />
+                {errors.lastName && isFormSubmitted && (
+                  <Form.Control.Feedback type="invalid">
+                    {errors.lastName}
+                  </Form.Control.Feedback>
+                )}
+              </Form.Group>
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              <Form.Group>
+                <div className="d-flex align-items-center">
+                  <CheckboxControl
+                    className="flex-shrink-0"
+                    checked={values.studentTermsAndConditions}
+                    name="studentTermsAndConditions"
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    aria-label="I agree to GetSmarter's Terms and Conditions for Students"
+                  />
+                  <span aria-hidden>
+                    I agree to GetSmarter&apos;s{' '}
+                    <Hyperlink
+                      destination="https://www.getsmarter.com/terms-and-conditions-for-students"
+                      target="_blank"
+                    >
+                      Terms and Conditions for Students
+                    </Hyperlink>
+                  </span>
+                </div>
+                {errors.studentTermsAndConditions && (
+                  <Form.Control.Feedback type="invalid">
+                    {errors.studentTermsAndConditions}
+                  </Form.Control.Feedback>
+                )}
+              </Form.Group>
+            </Col>
+          </Row>
+          <Row className="mb-4">
+            <Col xs={12} lg={8}>
+              <p className="small">
+                By providing these details you agree to the use of your data as described in our{' '}
+                <Hyperlink destination="https://www.getsmarter.com/privacy-policy" target="_blank">privacy policy</Hyperlink>. By
+                using our services or registering for a course, you agree to be bound by these terms. If you do not
+                agree to be bound by these terms, or are not able to enter into a binding agreement then you may not
+                register for a course or use our services.
+              </p>
+            </Col>
+          </Row>
+          <Row>
+            <Col>
+              <Button type="submit" variant="primary" disabled={isSubmitting}>
+                Submit enrollment information
+              </Button>
+            </Col>
+          </Row>
+        </FormikForm>
+      )}
+    </Formik>
   );
 }
 

--- a/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
@@ -1,0 +1,97 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { screen, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+import UserEnrollmentForm, { formValidationMessages } from './UserEnrollmentForm';
+import { checkoutExecutiveEducation2U } from './data';
+
+const termsLabelText = 'I agree to GetSmarter\'s Terms and Conditions for Students';
+const mockFirstName = 'John';
+const mockLastName = 'Doe';
+
+jest.mock('./data', () => ({
+  ...jest.requireActual('./data'),
+  checkoutExecutiveEducation2U: jest.fn(),
+}));
+
+describe('UserEnrollmentForm', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('has personal information section and handles validation', async () => {
+    render(<UserEnrollmentForm />);
+    expect(screen.getByText('Personal information')).toBeInTheDocument();
+
+    // form fields
+    expect(screen.getByLabelText('First name *')).toBeInTheDocument();
+    expect(screen.getByLabelText('Last name *')).toBeInTheDocument();
+
+    // validation
+    userEvent.click(screen.getByText('Submit enrollment information'));
+    expect(await screen.findByText(formValidationMessages.firstNameRequired)).toBeInTheDocument();
+    expect(await screen.findByText(formValidationMessages.lastNameRequired)).toBeInTheDocument();
+
+    // typing in fields after form submission clears validation
+    userEvent.type(screen.getByLabelText('First name *'), mockFirstName);
+    userEvent.type(screen.getByLabelText('Last name *'), mockLastName);
+    await waitFor(() => {
+      expect(screen.queryByText(formValidationMessages.firstNameRequired)).not.toBeInTheDocument();
+      expect(screen.queryByText(formValidationMessages.lastNameRequired)).not.toBeInTheDocument();
+    });
+  });
+
+  it('has terms and conditions checkbox', async () => {
+    render(<UserEnrollmentForm />);
+
+    // form fields
+    expect(screen.getByLabelText(termsLabelText)).toBeInTheDocument();
+
+    // validation
+    userEvent.click(screen.getByText('Submit enrollment information'));
+    expect(await screen.findByText(formValidationMessages.studentTermsAndConditionsRequired)).toBeInTheDocument();
+
+    // checking the checkbox after form submission clears validation
+    userEvent.click(screen.getByLabelText(termsLabelText));
+    await waitFor(() => {
+      expect(screen.queryByText(formValidationMessages.studentTermsAndConditionsRequired)).not.toBeInTheDocument();
+    });
+  });
+
+  it('handles successful form submission', async () => {
+    checkoutExecutiveEducation2U.mockResolvedValueOnce();
+    render(<UserEnrollmentForm />);
+    userEvent.type(screen.getByLabelText('First name *'), mockFirstName);
+    userEvent.type(screen.getByLabelText('Last name *'), mockLastName);
+    userEvent.click(screen.getByLabelText(termsLabelText));
+    userEvent.click(screen.getByText('Submit enrollment information'));
+
+    // disabled while submitting
+    expect(screen.getByText('Submit enrollment information')).toBeDisabled();
+
+    await waitFor(() => {
+      // no longer disabled after submitting
+      expect(screen.getByText('Submit enrollment information')).not.toBeDisabled();
+    });
+  });
+
+  it('handles network error with form submission', async () => {
+    const mockError = new Error('oh noes');
+    checkoutExecutiveEducation2U.mockRejectedValueOnce(mockError);
+    render(<UserEnrollmentForm />);
+    userEvent.type(screen.getByLabelText('First name *'), mockFirstName);
+    userEvent.type(screen.getByLabelText('Last name *'), mockLastName);
+    userEvent.click(screen.getByLabelText(termsLabelText));
+    userEvent.click(screen.getByText('Submit enrollment information'));
+
+    // disabled while submitting
+    expect(screen.getByText('Submit enrollment information')).toBeDisabled();
+
+    await waitFor(() => {
+      // no longer disabled after submitting
+      expect(screen.getByText('Submit enrollment information')).not.toBeDisabled();
+    });
+  });
+});

--- a/src/components/executive-education-2u/data/index.js
+++ b/src/components/executive-education-2u/data/index.js
@@ -1,3 +1,2 @@
 export * from './service';
 export * from './hooks';
-export * from './constants';

--- a/src/components/executive-education-2u/data/service.js
+++ b/src/components/executive-education-2u/data/service.js
@@ -21,3 +21,17 @@ export async function getExecutiveEducation2UContentMetadata(courseUUID, options
   const contentMetadata = camelCaseObject(res.data.results[0]);
   return contentMetadata;
 }
+
+export async function checkoutExecutiveEducation2U() {
+  const res = await new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        data: {
+          receipt_page_url: 'https://edx.org',
+        },
+      });
+    }, 1500);
+  });
+  const result = camelCaseObject(res.data);
+  return result;
+}


### PR DESCRIPTION
Updates the Executive Education (2U) page, where we collect the learner's first and last names, and whether they agree with GetSmarter's Terms and Conditions for Students. Includes form validation for the required fields.

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/2828721/185111794-077b71b3-0078-474c-8735-9be180e62f9d.png">

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/2828721/185111904-e0201c5b-0763-46e1-80e9-bbd97944ea35.png">

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
