### PR TITLE
feat: support upgrading course using coupon code

### DIFF
--- a/src/components/course/EnrollModal.jsx
+++ b/src/components/course/EnrollModal.jsx
@@ -1,20 +1,14 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Modal } from '@edx/paragon';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
-import {
-  useOptimizelyEnrollmentClickHandler,
-  useTrackSearchConversionClickHandler,
-} from './data/hooks';
 import { COUPON_CODE_SUBSIDY_TYPE, ENTERPRISE_OFFER_SUBSIDY_TYPE } from './data/constants';
 import { ENTERPRISE_OFFER_TYPE } from '../enterprise-user-subsidy/enterprise-offers/data/constants';
-import { CourseContext } from './CourseContextProvider';
-import { CourseEnrollmentsContext } from '../dashboard/main-content/course-enrollments/CourseEnrollmentsContextProvider';
 
 export const ENROLL_MODAL_TEXT_HAS_NO_SUBSIDY = 'Your organization has not provided you with access to courses, but you may still enroll in this course after payment.';
-export const createUseCouponCodeText = couponCodesCount => `Enrolling in this course will use 1 of your ${couponCodesCount} enrollment codes.`;
+export const createUseCouponCodeText = couponCodesCount => `You are about to redeem 1 enrollment code from your ${couponCodesCount} remaining codes.`;
 export const createUseEnterpriseOfferText = (offer, courseRunPrice) => {
   if (offer.offerType === ENTERPRISE_OFFER_TYPE.ENROLLMENTS_LIMIT) {
     return 'You are about to redeem 1 learner credit. This action cannot be reversed.';
@@ -48,26 +42,8 @@ const EnrollModal = ({
   courseRunPrice,
   userSubsidyApplicableToCourse,
   couponCodesCount,
+  onEnroll,
 }) => {
-  const {
-    state: {
-      activeCourseRun: { key: courseRunKey },
-    },
-  } = useContext(CourseContext);
-  const {
-    courseEnrollmentsByStatus,
-  } = useContext(CourseEnrollmentsContext);
-
-  const analyticsHandler = useTrackSearchConversionClickHandler({
-    href: enrollmentUrl,
-    eventName: 'edx.ui.enterprise.learner_portal.course.enroll_button.to_ecommerce_basket.clicked',
-  });
-  const optimizelyHandler = useOptimizelyEnrollmentClickHandler({
-    href: enrollmentUrl,
-    courseRunKey,
-    courseEnrollmentsByStatus,
-  });
-
   const [isLoading, setIsLoading] = useState(false);
 
   const getModalTexts = () => {
@@ -98,8 +74,9 @@ const EnrollModal = ({
 
   const handleEnroll = (e) => {
     setIsLoading(true);
-    analyticsHandler(e);
-    optimizelyHandler(e);
+    if (onEnroll) {
+      onEnroll(e);
+    }
   };
 
   const { titleText, enrollText, buttonText } = getModalTexts();
@@ -141,10 +118,12 @@ EnrollModal.propTypes = {
   }),
   couponCodesCount: PropTypes.number.isRequired,
   courseRunPrice: PropTypes.number.isRequired,
+  onEnroll: PropTypes.func,
 };
 
 EnrollModal.defaultProps = {
   userSubsidyApplicableToCourse: undefined,
+  onEnroll: undefined,
 };
 
 export default EnrollModal;

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -356,6 +356,7 @@ export const useCourseEnrollmentUrl = ({
     failure_url: `${global.location.origin}${location.pathname}?${baseQueryParams.toString()}`,
   };
 
+  // TODO: use the new helper functions (createEnrollWithLicenseUrl, createEnrollWithCouponCodeUrl) to generate url
   const enrollmentUrl = useMemo(
     () => {
       if (userSubsidyApplicableToCourse?.subsidyType === LICENSE_SUBSIDY_TYPE) {

--- a/src/components/course/enrollment/components/ToEcomBasketPage.jsx
+++ b/src/components/course/enrollment/components/ToEcomBasketPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -7,6 +7,12 @@ import EnrollModal from '../../EnrollModal';
 
 import { enrollLinkClass } from '../constants';
 import { EnrollButtonCta } from '../common';
+import { CourseContext } from '../../CourseContextProvider';
+import { CourseEnrollmentsContext } from '../../../dashboard/main-content/course-enrollments/CourseEnrollmentsContextProvider';
+import {
+  useOptimizelyEnrollmentClickHandler,
+  useTrackSearchConversionClickHandler,
+} from '../../data/hooks';
 
 /**
  * ToEcom page component implemention for Enroll Button.
@@ -18,6 +24,31 @@ import { EnrollButtonCta } from '../common';
 const ToEcomBasketPage = ({ enrollLabel, enrollmentUrl, courseRunPrice }) => {
   const { userSubsidyApplicableToCourse, couponCodesCount } = useSubsidyDataForCourse();
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const {
+    state: {
+      activeCourseRun: { key: courseRunKey },
+    },
+  } = useContext(CourseContext);
+  const {
+    courseEnrollmentsByStatus,
+  } = useContext(CourseEnrollmentsContext);
+
+  const analyticsHandler = useTrackSearchConversionClickHandler({
+    href: enrollmentUrl,
+    eventName: 'edx.ui.enterprise.learner_portal.course.enroll_button.to_ecommerce_basket.clicked',
+  });
+
+  const optimizelyHandler = useOptimizelyEnrollmentClickHandler({
+    href: enrollmentUrl,
+    courseRunKey,
+    courseEnrollmentsByStatus,
+  });
+
+  const handleEnroll = (e) => {
+    analyticsHandler(e);
+    optimizelyHandler(e);
+  };
 
   return (
     <>
@@ -33,6 +64,7 @@ const ToEcomBasketPage = ({ enrollLabel, enrollmentUrl, courseRunPrice }) => {
         courseRunPrice={courseRunPrice}
         userSubsidyApplicableToCourse={userSubsidyApplicableToCourse}
         couponCodesCount={couponCodesCount}
+        onEnroll={handleEnroll}
       />
     </>
   );

--- a/src/components/course/enrollment/tests/ToEcomBasketPage.test.jsx
+++ b/src/components/course/enrollment/tests/ToEcomBasketPage.test.jsx
@@ -5,6 +5,8 @@ import '@testing-library/jest-dom/extend-expect';
 
 import * as hooks from '../hooks';
 import ToEcomBasketPage from '../components/ToEcomBasketPage';
+import { CourseContext } from '../../CourseContextProvider';
+import { CourseEnrollmentsContext } from '../../../dashboard/main-content/course-enrollments/CourseEnrollmentsContextProvider';
 
 jest.mock('../common', () => ({
   __esModule: true,
@@ -18,6 +20,28 @@ jest.mock('../../EnrollModal', () => ({
 
 jest.mock('../hooks');
 
+const ToEcomBasketPageWrapper = ({
+  courseContextValue = {
+    state: {
+      activeCourseRun: {
+        key: 'course-key',
+      },
+    },
+  },
+  CourseEnrollmentsContextVAlue = {
+    courseEnrollmentsByStatus: {},
+  },
+  ...rest
+}) => (
+  <CourseContext.Provider value={courseContextValue}>
+    <CourseEnrollmentsContext.Provider value={CourseEnrollmentsContextVAlue}>
+      <ToEcomBasketPage
+        {...rest}
+      />,
+    </CourseEnrollmentsContext.Provider>
+  </CourseContext.Provider>
+);
+
 describe('<ToEcomBasketPage />', () => {
   it('should render <EnrollButtonCta /> and <EnrollModal />', () => {
     hooks.useSubsidyDataForCourse.mockReturnValue(
@@ -25,7 +49,7 @@ describe('<ToEcomBasketPage />', () => {
     );
 
     render(
-      <ToEcomBasketPage
+      <ToEcomBasketPageWrapper
         enrollLabel="enroll"
         enrollmentUrl="enroll_url"
         courseRunPrice={100}

--- a/src/components/course/tests/EnrollModal.test.jsx
+++ b/src/components/course/tests/EnrollModal.test.jsx
@@ -5,34 +5,11 @@ import { screen, render, fireEvent } from '@testing-library/react';
 
 import EnrollModal, { MODAL_TEXTS } from '../EnrollModal';
 import { COUPON_CODE_SUBSIDY_TYPE, ENTERPRISE_OFFER_SUBSIDY_TYPE } from '../data/constants';
-import * as hooks from '../data/hooks';
-import { CourseContext } from '../CourseContextProvider';
-import { CourseEnrollmentsContext } from '../../dashboard/main-content/course-enrollments/CourseEnrollmentsContextProvider';
 
 jest.mock('../data/hooks', () => ({
   useTrackSearchConversionClickHandler: jest.fn(),
   useOptimizelyEnrollmentClickHandler: jest.fn(),
 }));
-
-const EnrollModalWrapper = ({
-  courseContextValue = {
-    state: {
-      activeCourseRun: {
-        key: 'course-key',
-      },
-    },
-  },
-  CourseEnrollmentsContextVAlue = {
-    courseEnrollmentsByStatus: {},
-  },
-  ...rest
-}) => (
-  <CourseContext.Provider value={courseContextValue}>
-    <CourseEnrollmentsContext.Provider value={CourseEnrollmentsContextVAlue}>
-      <EnrollModal {...rest} />
-    </CourseEnrollmentsContext.Provider>
-  </CourseContext.Provider>
-);
 
 describe('<EnrollModal />', () => {
   const basicProps = {
@@ -46,7 +23,7 @@ describe('<EnrollModal />', () => {
 
   it('displays the correct texts when user has no applicable subsidy', () => {
     render(
-      <EnrollModalWrapper {...basicProps} />,
+      <EnrollModal {...basicProps} />,
     );
     expect(screen.getByText(MODAL_TEXTS.HAS_NO_SUBSIDY.title)).toBeInTheDocument();
     expect(screen.getByText(MODAL_TEXTS.HAS_NO_SUBSIDY.body)).toBeInTheDocument();
@@ -62,7 +39,7 @@ describe('<EnrollModal />', () => {
       couponCodesCount: 5,
     };
     render(
-      <EnrollModalWrapper {...props} />,
+      <EnrollModal {...props} />,
     );
     expect(screen.getByText(MODAL_TEXTS.HAS_COUPON_CODE.title)).toBeInTheDocument();
     expect(screen.getByText(MODAL_TEXTS.HAS_COUPON_CODE.body(props.couponCodesCount))).toBeInTheDocument();
@@ -77,7 +54,7 @@ describe('<EnrollModal />', () => {
       },
     };
     render(
-      <EnrollModalWrapper {...props} />,
+      <EnrollModal {...props} />,
     );
     expect(screen.getByText(MODAL_TEXTS.HAS_ENTERPRISE_OFFER.title)).toBeInTheDocument();
     expect(screen.getByText(MODAL_TEXTS.HAS_ENTERPRISE_OFFER.body(
@@ -86,19 +63,15 @@ describe('<EnrollModal />', () => {
     expect(screen.getByText(MODAL_TEXTS.HAS_ENTERPRISE_OFFER.button)).toBeInTheDocument();
   });
 
-  it('calls analyticsHandler and optimizelyHandler when enrollmentUrl is clicked', () => {
-    const mockTrackSearchConversionClickHandler = jest.fn();
-    const mockOptimizelyEnrollmentClickHandler = jest.fn();
-    hooks.useTrackSearchConversionClickHandler.mockImplementation(() => mockTrackSearchConversionClickHandler);
-    hooks.useOptimizelyEnrollmentClickHandler.mockImplementation(() => mockOptimizelyEnrollmentClickHandler);
+  it('calls onEnroll when enrollmentUrl is clicked', () => {
+    const mockHandleEnroll = jest.fn();
 
     render(
-      <EnrollModalWrapper {...basicProps} />,
+      <EnrollModal {...basicProps} onEnroll={mockHandleEnroll} />,
     );
     const enrollButton = screen.getByText(MODAL_TEXTS.HAS_NO_SUBSIDY.button);
     fireEvent.click(enrollButton);
 
-    expect(mockTrackSearchConversionClickHandler).toHaveBeenCalled();
-    expect(mockOptimizelyEnrollmentClickHandler).toHaveBeenCalled();
+    expect(mockHandleEnroll).toHaveBeenCalled();
   });
 });

--- a/src/components/dashboard/main-content/course-enrollments/UpgradeableCourseEnrollmentContextProvider.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/UpgradeableCourseEnrollmentContextProvider.jsx
@@ -11,19 +11,32 @@ export const UpgradeableCourseEnrollmentContext = createContext({ isLoading: fal
 
 export const UpgradeableCourseEnrollmentContextProvider = ({ courseEnrollment, children }) => {
   const { enterpriseConfig } = useContext(AppContext);
-  const { subscriptionLicense } = useContext(UserSubsidyContext);
+  const { subscriptionLicense, couponCodes: { couponCodes } } = useContext(UserSubsidyContext);
   const location = useLocation();
 
-  const { isLoading, upgradeUrl } = useCourseUpgradeData({
+  // If a licenseUpgradeUrl exists, couponUpgradeUrl will always be undefined
+  // since we would always use the license to upgrade instead
+  const {
+    isLoading,
+    subsidyForCourse,
+    licenseUpgradeUrl,
+    couponUpgradeUrl,
+  } = useCourseUpgradeData({
     courseRunKey: courseEnrollment.courseRunId,
     enterpriseId: enterpriseConfig.uuid,
     subscriptionLicense,
+    couponCodes,
     location,
   });
 
   const context = useMemo(() => ({
-    isLoading, upgradeUrl,
-  }), [isLoading, upgradeUrl]);
+    isLoading, licenseUpgradeUrl, couponUpgradeUrl, subsidyForCourse,
+  }), [
+    isLoading,
+    subsidyForCourse,
+    licenseUpgradeUrl,
+    couponUpgradeUrl,
+  ]);
 
   return (
     <UpgradeableCourseEnrollmentContext.Provider value={context}>

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/ContinueLearningButton.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/ContinueLearningButton.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { AppContext } from '@edx/frontend-platform/react';
+import classNames from 'classnames';
 
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
@@ -14,7 +15,12 @@ import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
  *
  * @returns {Function} A functional React component for the continue learning button.
  */
-export default function ContinueLearningButton({ linkToCourse, title, courseRunId }) {
+export default function ContinueLearningButton({
+  className,
+  linkToCourse,
+  title,
+  courseRunId,
+}) {
   const { enterpriseConfig } = useContext(AppContext);
 
   const onClickHandler = () => {
@@ -28,17 +34,22 @@ export default function ContinueLearningButton({ linkToCourse, title, courseRunI
   };
   return (
     <a
-      className="btn btn-outline-primary btn-xs-block"
+      className={classNames('btn btn-xs-block', className)}
       href={linkToCourse}
       onClick={onClickHandler}
     >
-      Continue learning
+      Resume
       <span className="sr-only">for {title}</span>
     </a>
   );
 }
 
+ContinueLearningButton.defaultProps = {
+  className: 'btn-outline-primary',
+};
+
 ContinueLearningButton.propTypes = {
+  className: PropTypes.string,
   linkToCourse: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   courseRunId: PropTypes.string.isRequired,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
@@ -12,6 +12,7 @@ import Notification from './Notification';
 
 import { CourseEnrollmentsContext } from '../CourseEnrollmentsContextProvider';
 import { UpgradeableCourseEnrollmentContext } from '../UpgradeableCourseEnrollmentContextProvider';
+import UpgradeCourseButton from './UpgradeCourseButton';
 
 export const InProgressCourseCard = ({
   linkToCourse,
@@ -23,8 +24,12 @@ export const InProgressCourseCard = ({
 }) => {
   const {
     isLoading: isLoadingUpgradeUrl,
-    upgradeUrl,
+    licenseUpgradeUrl,
+    couponUpgradeUrl,
   } = useContext(UpgradeableCourseEnrollmentContext);
+
+  // The upgrade button is only for upgrading via coupon, upgrades via license are automatic through the course link.
+  const shouldShowUpgradeButton = !!couponUpgradeUrl;
 
   const {
     updateCourseEnrollmentStatus,
@@ -34,11 +39,15 @@ export const InProgressCourseCard = ({
   const { courseCards, enterpriseConfig } = useContext(AppContext);
 
   const renderButtons = () => (
-    <ContinueLearningButton
-      linkToCourse={upgradeUrl ?? linkToCourse}
-      title={title}
-      courseRunId={courseRunId}
-    />
+    <>
+      <ContinueLearningButton
+        className={shouldShowUpgradeButton ? 'btn-primary' : undefined}
+        linkToCourse={licenseUpgradeUrl ?? linkToCourse}
+        title={title}
+        courseRunId={courseRunId}
+      />
+      {shouldShowUpgradeButton && <UpgradeCourseButton className="ml-1" title={title} />}
+    </>
   );
 
   const filteredNotifications = notifications.filter((notification) => {
@@ -140,7 +149,7 @@ export const InProgressCourseCard = ({
       buttons={renderButtons()}
       dropdownMenuItems={getDropdownMenuItems()}
       title={title}
-      linkToCourse={upgradeUrl ?? linkToCourse}
+      linkToCourse={licenseUpgradeUrl ?? linkToCourse}
       courseRunId={courseRunId}
       isLoading={isLoadingUpgradeUrl}
       {...rest}

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/UpgradeCourseButton.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/UpgradeCourseButton.jsx
@@ -1,0 +1,78 @@
+import React, { useContext, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '@edx/paragon';
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
+import { AppContext } from '@edx/frontend-platform/react';
+
+import EnrollModal from '../../../../course/EnrollModal';
+import { UpgradeableCourseEnrollmentContext } from '../UpgradeableCourseEnrollmentContextProvider';
+import { UserSubsidyContext } from '../../../../enterprise-user-subsidy';
+
+/**
+ * Button for upgrading a course via coupon code (possibly offer later on).
+ */
+export default function UpgradeCourseButton({
+  className,
+  title,
+  variant,
+}) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const { enterpriseConfig: { uuid } } = useContext(AppContext);
+  const { couponCodes: { couponCodes } } = useContext(UserSubsidyContext);
+  const {
+    subsidyForCourse,
+    couponUpgradeUrl,
+    courseRunPrice,
+  } = useContext(UpgradeableCourseEnrollmentContext);
+
+  const handleClick = () => {
+    setIsModalOpen(true);
+    sendEnterpriseTrackEvent(
+      uuid,
+      'edx.ui.enterprise.learner_portal.course.upgrade_button.clicked',
+    );
+  };
+
+  const handleEnroll = () => {
+    sendEnterpriseTrackEvent(
+      uuid,
+      'edx.ui.enterprise.learner_portal.course.upgrade_button.to_ecommerce_basket.clicked',
+    );
+  };
+
+  return (
+    <>
+      <Button
+        className={className}
+        variant={variant}
+        onClick={handleClick}
+        data-testid="upgrade-course-button"
+      >
+        Upgrade
+        <span className="sr-only">for {title}</span>
+      </Button>
+      <EnrollModal
+        isModalOpen={isModalOpen}
+        setIsModalOpen={setIsModalOpen}
+        enrollmentUrl={couponUpgradeUrl}
+        courseRunPrice={courseRunPrice}
+        userSubsidyApplicableToCourse={subsidyForCourse}
+        couponCodesCount={couponCodes.length}
+        onEnroll={handleEnroll}
+      />
+    </>
+
+  );
+}
+
+UpgradeCourseButton.defaultProps = {
+  className: undefined,
+  variant: 'outline-primary',
+};
+
+UpgradeCourseButton.propTypes = {
+  className: PropTypes.string,
+  variant: PropTypes.string,
+  title: PropTypes.string.isRequired,
+};

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/InProgressCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/InProgressCourseCard.test.jsx
@@ -1,0 +1,83 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { AppContext } from '@edx/frontend-platform/react';
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
+
+import { CourseEnrollmentsContext } from '../../CourseEnrollmentsContextProvider';
+import { UpgradeableCourseEnrollmentContext } from '../../UpgradeableCourseEnrollmentContextProvider';
+import { InProgressCourseCard } from '../InProgressCourseCard';
+import { UserSubsidyContext } from '../../../../../enterprise-user-subsidy';
+
+jest.mock('@edx/frontend-enterprise-utils', () => ({
+  ...jest.requireActual('@edx/frontend-enterprise-utils'),
+  sendEnterpriseTrackEvent: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform/auth');
+getAuthenticatedUser.mockReturnValue({ username: 'test-username' });
+
+const basicProps = {
+  courseRunStatus: 'in_progress',
+  title: 'edX Demonstration Course',
+  linkToCourse: 'https://edx.org',
+  courseRunId: 'my+course+key',
+  notifications: [],
+};
+
+const InProgressCourseCardWrapper = ({
+  appContextValue =
+  {
+    enterpriseConfig: {
+      uuid: 123,
+    },
+  },
+  userSubsidyContextValue = {
+    couponCodes: {
+      couponCodes: [],
+    },
+  },
+  courseEnrollmentsContextValue = {
+    updateCourseEnrollmentStatus: jest.fn(),
+    setShowMarkCourseCompleteSuccess: jest.fn(),
+  },
+  upgradeableCourseEnrollmentContextValue = {
+    isLoading: false,
+    licenseUpgradeUrl: undefined,
+    couponUpgradeUrl: undefined,
+  },
+  ...rest
+}) => (
+  <AppContext.Provider value={appContextValue}>
+    <UserSubsidyContext.Provider value={userSubsidyContextValue}>
+      <CourseEnrollmentsContext.Provider value={courseEnrollmentsContextValue}>
+        <UpgradeableCourseEnrollmentContext.Provider value={upgradeableCourseEnrollmentContextValue}>
+          <InProgressCourseCard {...rest} />
+        </UpgradeableCourseEnrollmentContext.Provider>
+      </CourseEnrollmentsContext.Provider>
+    </UserSubsidyContext.Provider>
+  </AppContext.Provider>
+);
+
+describe('<InProgressCourseCard />', () => {
+  it('should not render upgrade course button if there is no couponUpgradeUrl', () => {
+    render(<InProgressCourseCardWrapper {...basicProps} />);
+    expect(screen.queryByTestId('upgrade-course-button')).not.toBeInTheDocument();
+  });
+
+  it('should render upgrade course button if there is a couponUpgradeUrl', () => {
+    render(<InProgressCourseCardWrapper
+      {...basicProps}
+      upgradeableCourseEnrollmentContextValue={
+        {
+          isLoading: false,
+          licenseUpgradeUrl: undefined,
+          couponUpgradeUrl: 'coupon-upgrade-url',
+        }
+      }
+    />);
+
+    expect(screen.getByTestId('upgrade-course-button')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -5,11 +5,18 @@ import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { logError } from '@edx/frontend-platform/logging';
 import _camelCase from 'lodash.camelcase';
 import _cloneDeep from 'lodash.clonedeep';
+
 import * as service from './service';
 import { groupCourseEnrollmentsByStatus, transformCourseEnrollment } from './utils';
 import { COURSE_STATUSES } from './constants';
 import CourseService from '../../../../course/data/service';
-import { createEnrollWithLicenseUrl } from '../../../../course/data/utils';
+import {
+  createEnrollWithLicenseUrl,
+  createEnrollWithCouponCodeUrl,
+  findCouponCodeForCourse,
+  findHighestLevelSeatSku,
+  getSubsidyToApplyForCourse,
+} from '../../../../course/data/utils';
 
 export const useCourseEnrollments = ({
   enterpriseUUID,
@@ -93,15 +100,20 @@ export const useCourseEnrollments = ({
  * @param {Object} args.subscriptionLicense the user's subscription license
  * @param {Object} args.location location object from useLocation()
  *
- * @returns {Object} { isLoading, upgradeUrl }
+ * @returns {Object} { isLoading, licenseUpgradeUrl, couponUpgradeUrl, upgradeUrl }
  */
 export const useCourseUpgradeData = ({
   courseRunKey,
   enterpriseId,
   subscriptionLicense,
+  couponCodes,
   location,
 }) => {
-  const [upgradeUrl, setUpgradeUrl] = useState();
+  const [licenseUpgradeUrl, setLicenseUpgradeUrl] = useState();
+  const [couponUpgradeUrl, setCouponUpgradeUrl] = useState();
+  const [subsidyForCourse, setSubsidyForCourse] = useState();
+  const [courseRunPrice, setCourseRunPrice] = useState();
+
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -116,18 +128,17 @@ export const useCourseUpgradeData = ({
 
       try {
         const containsContentResponse = await courseService.fetchEnterpriseCustomerContainsContent([courseRunKey]);
-        const { containsContentItems } = camelCaseObject(containsContentResponse.data);
+        const { containsContentItems, catalogList } = camelCaseObject(containsContentResponse.data);
 
         // Don't do anything if the course is not part of the enterprise's catalog
-        if (containsContentItems) {
-          let licenseSubsidy;
+        if (!containsContentItems) {
+          return;
+        }
 
-          if (subscriptionLicense) {
-            // get subscription license with extra information (i.e. discount type, discount value, subsidy checksum)
-            const fetchUserLicenseSubsidyResponse = await courseService.fetchUserLicenseSubsidy(courseRunKey);
-            licenseSubsidy = camelCaseObject(fetchUserLicenseSubsidyResponse.data);
-          }
-
+        if (subscriptionLicense) {
+          // get subscription license with extra information (i.e. discount type, discount value, subsidy checksum)
+          const fetchUserLicenseSubsidyResponse = await courseService.fetchUserLicenseSubsidy(courseRunKey);
+          const licenseSubsidy = camelCaseObject(fetchUserLicenseSubsidyResponse.data);
           if (licenseSubsidy) {
             const url = createEnrollWithLicenseUrl({
               courseRunKey,
@@ -136,8 +147,27 @@ export const useCourseUpgradeData = ({
               location,
             });
 
-            setUpgradeUrl(url);
+            setSubsidyForCourse({ getSubsidyToApplyForCourse: licenseSubsidy });
+            setLicenseUpgradeUrl(url);
+            return;
           }
+        }
+
+        const couponSubsidy = findCouponCodeForCourse(couponCodes, catalogList);
+        if (couponSubsidy) {
+          const fetchCourseRunResponse = await courseService.fetchCourseRun(courseRunKey);
+          const courseRunDetails = camelCaseObject(fetchCourseRunResponse.data);
+          const sku = findHighestLevelSeatSku(courseRunDetails.seats);
+          const url = createEnrollWithCouponCodeUrl({
+            courseRunKey,
+            sku,
+            code: couponSubsidy.code,
+            location,
+          });
+          setSubsidyForCourse(getSubsidyToApplyForCourse({ applicableCouponCode: couponSubsidy }));
+          setCouponUpgradeUrl(url);
+          setCourseRunPrice(courseRunDetails.firstEnrollablePaidSeatPrice);
+          return;
         }
       } catch (error) {
         logError(error);
@@ -147,15 +177,13 @@ export const useCourseUpgradeData = ({
     };
 
     fetchData();
-  }, [
-    courseRunKey,
-    enterpriseId,
-    subscriptionLicense,
-    location,
-  ]);
+  }, [courseRunKey, enterpriseId, subscriptionLicense, location, couponCodes]);
 
   return {
     isLoading,
-    upgradeUrl,
+    subsidyForCourse,
+    licenseUpgradeUrl,
+    couponUpgradeUrl,
+    courseRunPrice,
   };
 };

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.js
@@ -1,13 +1,14 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import * as logger from '@edx/frontend-platform/logging';
 import camelCase from 'lodash.camelcase';
+import moment from 'moment';
 
 import { useCourseEnrollments, useCourseUpgradeData } from '../hooks';
 import * as service from '../service';
 import { COURSE_STATUSES } from '../constants';
 import { transformCourseEnrollment } from '../utils';
 import { createRawCourseEnrollment } from '../../tests/enrollment-testutils';
-import { createEnrollWithLicenseUrl } from '../../../../../course/data/utils';
+import { createEnrollWithLicenseUrl, createEnrollWithCouponCodeUrl } from '../../../../../course/data/utils';
 
 jest.mock('../service');
 jest.mock('@edx/frontend-platform/logging', () => ({
@@ -17,6 +18,7 @@ jest.mock('@edx/frontend-platform/logging', () => ({
 const mockCourseService = {
   fetchUserLicenseSubsidy: jest.fn(),
   fetchEnterpriseCustomerContainsContent: jest.fn(),
+  fetchCourseRun: jest.fn(),
 };
 
 jest.mock('../../../../../course/data/service', () => ({
@@ -30,11 +32,11 @@ const mockTransformedMockCourseEnrollment = transformCourseEnrollment(mockRawCou
 describe('useCourseEnrollments', () => {
   it('should fetch and set course enrollments', async () => {
     service.fetchEnterpriseCourseEnrollments.mockResolvedValue({ data: [mockRawCourseEnrollment] });
-    const args = {
+    const basicArgs = {
       enterpriseUUID: 'uuid',
       requestedCourseEnrollments: [],
     };
-    const { result, waitForNextUpdate } = renderHook(() => useCourseEnrollments(args));
+    const { result, waitForNextUpdate } = renderHook(() => useCourseEnrollments(basicArgs));
     await waitForNextUpdate();
     expect(service.fetchEnterpriseCourseEnrollments).toHaveBeenCalled();
     expect(result.current.courseEnrollmentsByStatus).toEqual({
@@ -46,11 +48,11 @@ describe('useCourseEnrollments', () => {
   it('should set fetchError if an error occurs', async () => {
     const error = Error('something went wrong');
     service.fetchEnterpriseCourseEnrollments.mockRejectedValue(error);
-    const args = {
+    const basicArgs = {
       enterpriseUUID: 'uuid',
       requestedCourseEnrollments: [],
     };
-    const { result, waitForNextUpdate } = renderHook(() => useCourseEnrollments(args));
+    const { result, waitForNextUpdate } = renderHook(() => useCourseEnrollments(basicArgs));
     await waitForNextUpdate();
     expect(result.current.fetchError).toBe(error);
   });
@@ -58,11 +60,11 @@ describe('useCourseEnrollments', () => {
   describe('updateCourseEnrollmentStatus', () => {
     it('should move a course enrollment to the correct status group', async () => {
       service.fetchEnterpriseCourseEnrollments.mockResolvedValue({ data: [mockRawCourseEnrollment] });
-      const args = {
+      const basicArgs = {
         enterpriseUUID: 'uuid',
         requestedCourseEnrollments: [],
       };
-      const { result, waitForNextUpdate } = renderHook(() => useCourseEnrollments(args));
+      const { result, waitForNextUpdate } = renderHook(() => useCourseEnrollments(basicArgs));
       await waitForNextUpdate();
 
       act(() => result.current.updateCourseEnrollmentStatus({
@@ -91,11 +93,11 @@ describe('useCourseEnrollments', () => {
   describe('removeCourseEnrollment', () => {
     it('should remove a course enrollment', async () => {
       service.fetchEnterpriseCourseEnrollments.mockResolvedValue({ data: [mockRawCourseEnrollment] });
-      const args = {
+      const basicArgs = {
         enterpriseUUID: 'uuid',
         requestedCourseEnrollments: [],
       };
-      const { result, waitForNextUpdate } = renderHook(() => useCourseEnrollments(args));
+      const { result, waitForNextUpdate } = renderHook(() => useCourseEnrollments(basicArgs));
       await waitForNextUpdate();
 
       expect(result.current.courseEnrollmentsByStatus.inProgress).toHaveLength(1);
@@ -122,49 +124,22 @@ describe('useCourseEnrollments', () => {
     const enterpriseId = 'uuid';
     const subscriptionLicense = { uuid: 'license-uuid' };
     const location = { search: '' };
-    const args = {
+    const basicArgs = {
       courseRunKey,
       enterpriseId,
       subscriptionLicense,
+      couponCodes: [],
       location,
     };
 
     afterEach(() => jest.clearAllMocks());
 
-    it('should return an upgrade url if the course can be upgraded using a license', async () => {
-      mockCourseService.fetchEnterpriseCustomerContainsContent.mockResolvedValueOnce(
-        { data: { contains_content_items: true } },
-      );
-      mockCourseService.fetchUserLicenseSubsidy.mockResolvedValueOnce({
-        data: {
-          subsidy_id: 'subsidy-id',
-        },
-      });
-
-      const { result, waitForNextUpdate } = renderHook(() => useCourseUpgradeData(args));
-
-      expect(result.current.isLoading).toEqual(true);
-
-      await waitForNextUpdate();
-
-      expect(mockCourseService.fetchEnterpriseCustomerContainsContent).toHaveBeenCalledWith([courseRunKey]);
-      expect(mockCourseService.fetchUserLicenseSubsidy).toHaveBeenCalledWith(courseRunKey);
-
-      expect(result.current.upgradeUrl).toEqual(createEnrollWithLicenseUrl({
-        courseRunKey,
-        enterpriseId,
-        licenseUUID: subscriptionLicense.uuid,
-        location,
-      }));
-      expect(result.current.isLoading).toEqual(false);
-    });
-
-    it('should return undefined for upgrade url if the course is not part of the enterprise catalog', async () => {
+    it('should return undefined for upgrade urls if the course is not part of the enterprise catalog', async () => {
       mockCourseService.fetchEnterpriseCustomerContainsContent.mockResolvedValueOnce(
         { data: { contains_content_items: false } },
       );
 
-      const { result, waitForNextUpdate } = renderHook(() => useCourseUpgradeData(args));
+      const { result, waitForNextUpdate } = renderHook(() => useCourseUpgradeData(basicArgs));
 
       expect(result.current.isLoading).toEqual(true);
 
@@ -173,36 +148,133 @@ describe('useCourseEnrollments', () => {
       expect(mockCourseService.fetchEnterpriseCustomerContainsContent).toHaveBeenCalledWith([courseRunKey]);
       expect(mockCourseService.fetchUserLicenseSubsidy).not.toHaveBeenCalled();
 
-      expect(result.current.upgradeUrl).toBeUndefined();
+      expect(result.current.licenseUpgradeUrl).toBeUndefined();
+      expect(result.current.couponUpgradeUrl).toBeUndefined();
+      expect(result.current.courseRunPrice).toBeUndefined();
       expect(result.current.isLoading).toEqual(false);
     });
 
-    it('should return undefined for upgrade url if fetchUserLicenseSubsidy returned undefined', async () => {
-      mockCourseService.fetchEnterpriseCustomerContainsContent.mockResolvedValueOnce(
-        { data: { contains_content_items: true } },
-      );
-      mockCourseService.fetchUserLicenseSubsidy.mockResolvedValueOnce({
-        data: undefined,
+    describe('upgradeable via license', () => {
+      it('should return a license upgrade url', async () => {
+        mockCourseService.fetchEnterpriseCustomerContainsContent.mockResolvedValueOnce(
+          { data: { contains_content_items: true } },
+        );
+        mockCourseService.fetchUserLicenseSubsidy.mockResolvedValueOnce({
+          data: {
+            subsidy_id: 'subsidy-id',
+          },
+        });
+
+        const { result, waitForNextUpdate } = renderHook(() => useCourseUpgradeData(basicArgs));
+
+        expect(result.current.isLoading).toEqual(true);
+
+        await waitForNextUpdate();
+
+        expect(mockCourseService.fetchEnterpriseCustomerContainsContent).toHaveBeenCalledWith([courseRunKey]);
+        expect(mockCourseService.fetchUserLicenseSubsidy).toHaveBeenCalledWith(courseRunKey);
+
+        expect(result.current.licenseUpgradeUrl).toEqual(createEnrollWithLicenseUrl({
+          courseRunKey,
+          enterpriseId,
+          licenseUUID: subscriptionLicense.uuid,
+          location,
+        }));
+        expect(result.current.couponUpgradeUrl).toBeUndefined();
+        expect(result.current.courseRunPrice).toBeUndefined();
+        expect(result.current.isLoading).toEqual(false);
       });
 
-      const { result, waitForNextUpdate } = renderHook(() => useCourseUpgradeData(args));
+      it('should return undefined for licenseUpgradeUrl upgrade url if fetchUserLicenseSubsidy returned undefined', async () => {
+        mockCourseService.fetchEnterpriseCustomerContainsContent.mockResolvedValueOnce(
+          { data: { contains_content_items: true } },
+        );
+        mockCourseService.fetchUserLicenseSubsidy.mockResolvedValueOnce({
+          data: undefined,
+        });
 
-      expect(result.current.isLoading).toEqual(true);
+        const { result, waitForNextUpdate } = renderHook(() => useCourseUpgradeData(basicArgs));
 
-      await waitForNextUpdate();
+        expect(result.current.isLoading).toEqual(true);
 
-      expect(mockCourseService.fetchEnterpriseCustomerContainsContent).toHaveBeenCalledWith([courseRunKey]);
-      expect(mockCourseService.fetchUserLicenseSubsidy).toHaveBeenCalledWith(courseRunKey);
+        await waitForNextUpdate();
 
-      expect(result.current.upgradeUrl).toBeUndefined();
-      expect(result.current.isLoading).toEqual(false);
+        expect(mockCourseService.fetchEnterpriseCustomerContainsContent).toHaveBeenCalledWith([courseRunKey]);
+        expect(mockCourseService.fetchUserLicenseSubsidy).toHaveBeenCalledWith(courseRunKey);
+
+        expect(result.current.upgradeUrl).toBeUndefined();
+        expect(result.current.couponUpgradeUrl).toBeUndefined();
+        expect(result.current.courseRunPrice).toBeUndefined();
+        expect(result.current.isLoading).toEqual(false);
+      });
+    });
+
+    describe('upgradeable via coupon', () => {
+      const mockCouponCode = {
+        code: 'coupon-code',
+        catalog: 'catalog-1',
+        couponStartDate: moment().subtract(1, 'w').toISOString(),
+        couponEndDate: moment().add(8, 'w').toISOString(),
+      };
+
+      it('should return a coupon upgrade url', async () => {
+        mockCourseService.fetchEnterpriseCustomerContainsContent.mockResolvedValueOnce(
+          { data: { contains_content_items: true, catalog_list: [mockCouponCode.catalog] } },
+        );
+        const sku = 'ABCDEF';
+        const coursePrice = '149.00';
+
+        mockCourseService.fetchCourseRun.mockResolvedValueOnce(
+          {
+            data: {
+              firstEnrollablePaidSeatPrice: coursePrice,
+              seats: [
+                {
+                  type: 'verified',
+                  price: coursePrice,
+                  sku,
+                },
+                {
+                  type: 'audit',
+                  price: '0.00',
+                  sku: 'abcdef',
+                },
+              ],
+            },
+          },
+        );
+
+        const args = {
+          ...basicArgs,
+          subscriptionLicense: undefined,
+          couponCodes: [mockCouponCode],
+        };
+        const { result, waitForNextUpdate } = renderHook(() => useCourseUpgradeData(args));
+
+        expect(result.current.isLoading).toEqual(true);
+
+        await waitForNextUpdate();
+
+        expect(mockCourseService.fetchEnterpriseCustomerContainsContent).toHaveBeenCalledWith([courseRunKey]);
+        expect(mockCourseService.fetchUserLicenseSubsidy).not.toHaveBeenCalled();
+        expect(mockCourseService.fetchCourseRun).toHaveBeenCalledWith(courseRunKey);
+        expect(result.current.licenseUpgradeUrl).toBeUndefined();
+        expect(result.current.couponUpgradeUrl).toEqual(createEnrollWithCouponCodeUrl({
+          courseRunKey,
+          sku,
+          code: mockCouponCode.code,
+          location,
+        }));
+        expect(result.current.courseRunPrice).toEqual(coursePrice);
+        expect(result.current.isLoading).toEqual(false);
+      });
     });
 
     it('should handle errors', async () => {
       const error = Error('Uh oh');
       mockCourseService.fetchEnterpriseCustomerContainsContent.mockRejectedValueOnce(error);
 
-      const { result, waitForNextUpdate } = renderHook(() => useCourseUpgradeData(args));
+      const { result, waitForNextUpdate } = renderHook(() => useCourseUpgradeData(basicArgs));
 
       expect(result.current.isLoading).toEqual(true);
 
@@ -210,7 +282,6 @@ describe('useCourseEnrollments', () => {
 
       expect(mockCourseService.fetchEnterpriseCustomerContainsContent).toHaveBeenCalledWith([courseRunKey]);
       expect(mockCourseService.fetchUserLicenseSubsidy).not.toHaveBeenCalled();
-      expect();
 
       expect(result.current.upgradeUrl).toBeUndefined();
       expect(result.current.isLoading).toEqual(false);


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-5827

- Support upgrading a course to verified track using a coupon code
- Does not have the upgrade message in the card footer yet, we can ship this as a stand-alone or wait for the paragon changes required for the light grey card status (secondary variant).


![Screen Shot 2022-08-22 at 9 27 44 AM](https://user-images.githubusercontent.com/17792243/185932775-1ec967b2-bffb-42aa-9a38-c13d36fdbfae.png)
![Screen Shot 2022-08-22 at 9 27 50 AM](https://user-images.githubusercontent.com/17792243/185932778-618a68fa-3257-4429-b29f-0a3c62dc7d20.png)
![Screen Shot 2022-08-22 at 9 28 45 AM](https://user-images.githubusercontent.com/17792243/185932779-bd5e9b37-37e8-4926-8542-a89909dc5368.png)



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
