### PR TITLE
style: reduce gap between progress categories

### DIFF
--- a/src/components/progress-category-bubbles/ProgressCategoryBubbles.jsx
+++ b/src/components/progress-category-bubbles/ProgressCategoryBubbles.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import './styles/index.scss';
 
 const ProgressCategoryBubbles = ({ notStarted, inProgress, completed }) => (
-  <Stack direction="horizontal" gap={2.5}>
+  <Stack direction="horizontal" gap={2}>
     <Bubble className="remaining-courses" data-testid="remaining-count">
       {notStarted}
     </Bubble>


### PR DESCRIPTION
# For all changes

the 'in progress' text is breaking into lines due to less availability of space.
so reducing gap to original 
<img width="529" alt="Screenshot 2022-08-30 at 5 56 26 PM" src="https://user-images.githubusercontent.com/49611774/187442264-503d4ace-f108-4ffa-9c14-74963e783e7c.png">

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
