### PR TITLE
feat: Added ability to save user selected options on skill quiz

### DIFF
--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -44,6 +44,7 @@ import SkillsQuizHeader from './SkillsQuizHeader';
 
 import headerImage from './images/headerImage.png';
 import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
+import { saveSkillsGoalsAndJobsUserSelected } from './data/utils';
 
 const SkillsQuizStepper = () => {
   const config = getConfig();
@@ -65,7 +66,7 @@ const SkillsQuizStepper = () => {
   const handleIsStudentCheckedChange = e => setIsStudentChecked(e.target.checked);
 
   const {
-    state: { selectedJob, goal },
+    state: { selectedJob, goal, currentJobRole, interestedJobs },
     dispatch: skillsDispatch,
   } = useContext(SkillsContext);
   const { refinements, dispatch } = useContext(SearchContext);
@@ -111,6 +112,7 @@ const SkillsQuizStepper = () => {
   );
 
   const flipToRecommendedCourses = () => {
+    saveSkillsGoalsAndJobsUserSelected(goal, skills, currentJobRole, interestedJobs);
     // show  courses if learner has selected skills or jobs.
     if (goalExceptImproveAndJobSelected) {
       // verify if selectedJob is still checked and within first 3 jobs else

--- a/src/components/skills-quiz/constants.js
+++ b/src/components/skills-quiz/constants.js
@@ -1,7 +1,11 @@
 export const DROPDOWN_OPTION_CHANGE_CAREERS = 'I want to change careers';
+export const DROPDOWN_OPTION_CHANGE_CAREERS_LABEL = 'change_careers';
 export const DROPDOWN_OPTION_GET_PROMOTED = 'I want to get promoted';
+export const DROPDOWN_OPTION_GET_PROMOTED_LABEL = 'get_promoted';
 export const DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE = 'I want to improve at my current role';
+export const DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE_LABEL = 'improve_current_role';
 export const DROPDOWN_OPTION_OTHER = 'Other';
+export const DROPDOWN_OPTION_OTHER_LABEL = 'other';
 export const GOAL_DROPDOWN_DEFAULT_OPTION = 'Select a Goal';
 
 export const JOB_ATTRIBUTE_NAME = 'name';

--- a/src/components/skills-quiz/data/service.js
+++ b/src/components/skills-quiz/data/service.js
@@ -1,0 +1,26 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getConfig } from '@edx/frontend-platform/config';
+import { logError } from '@edx/frontend-platform/logging';
+
+export function fetchSkillsId(skills) {
+  const queryParams = new URLSearchParams({
+    name: skills,
+  });
+  const config = getConfig();
+  const url = `${config.DISCOVERY_API_BASE_URL}/taxonomy/api/v1/skills/?${queryParams.toString()}`;
+  return getAuthenticatedHttpClient().get(url);
+}
+
+export function postSkillsGoalsAndJobsUserSelected(goal, skillsId, interestedJobsId, currentJobRoleId) {
+  const options = {
+    goal,
+    current_job: currentJobRoleId ? currentJobRoleId[0] : null,
+    skills: skillsId,
+    future_jobs: interestedJobsId || [],
+  };
+  const config = getConfig();
+  const url = `${config.DISCOVERY_API_BASE_URL}/taxonomy/api/v1/skills-quiz/`;
+  getAuthenticatedHttpClient().post(url, options).catch((error) => {
+    logError(new Error(error));
+  });
+}

--- a/src/components/skills-quiz/data/tests/service.test.jsx
+++ b/src/components/skills-quiz/data/tests/service.test.jsx
@@ -1,0 +1,61 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import {
+  fetchSkillsId,
+} from '../service';
+
+import * as service from '../service';
+
+import { DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE_LABEL } from '../../constants';
+
+const APP_CONFIG = {
+  DISCOVERY_API_BASE_URL: 'http://localhost:18381',
+};
+
+jest.mock('@edx/frontend-platform/auth');
+jest.mock('@edx/frontend-platform/config', () => ({
+  getConfig: () => (APP_CONFIG),
+}));
+
+const axiosMock = new MockAdapter(axios);
+getAuthenticatedHttpClient.mockReturnValue(axios);
+axiosMock.onAny().reply(200);
+axios.get = jest.fn();
+
+describe('skills quiz service', () => {
+  it('fetches selected skills id', () => {
+    const url = 'http://localhost:18381/taxonomy/api/v1/skills/?name=python';
+    fetchSkillsId(['python']);
+    expect(axios.get).toBeCalledWith(url);
+  });
+
+  it('fetches multiple selected skills id', () => {
+    const url = 'http://localhost:18381/taxonomy/api/v1/skills/?name=python%2C+django';
+    fetchSkillsId(['python, django']);
+    expect(axios.get).toBeCalledWith(url);
+  });
+
+  it('post skills goals and jobs user selected', () => {
+    jest.mock('../service');
+    const skillsId = [1, 2];
+    const interestedJobsId = [3, 4];
+    const currentJobRoleId = 5;
+    service.postSkillsGoalsAndJobsUserSelected = jest.fn()
+      .mockImplementation(() => Promise.resolve({
+      }));
+    service.postSkillsGoalsAndJobsUserSelected(
+      DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE_LABEL,
+      skillsId,
+      interestedJobsId,
+      [currentJobRoleId],
+    );
+    expect(service.postSkillsGoalsAndJobsUserSelected).toBeCalledWith(
+      DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE_LABEL,
+      skillsId,
+      interestedJobsId,
+      [currentJobRoleId],
+    );
+  });
+});

--- a/src/components/skills-quiz/data/tests/utils.test.jsx
+++ b/src/components/skills-quiz/data/tests/utils.test.jsx
@@ -1,4 +1,14 @@
-import { sortSkillsCoursesWithCourseCount } from '../utils';
+import { goalLabels, sortSkillsCoursesWithCourseCount } from '../utils';
+import {
+  DROPDOWN_OPTION_CHANGE_CAREERS,
+  DROPDOWN_OPTION_CHANGE_CAREERS_LABEL,
+  DROPDOWN_OPTION_GET_PROMOTED,
+  DROPDOWN_OPTION_GET_PROMOTED_LABEL,
+  DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE,
+  DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE_LABEL,
+  DROPDOWN_OPTION_OTHER,
+  DROPDOWN_OPTION_OTHER_LABEL,
+} from '../../constants';
 
 describe('sortSkillsCoursesWithCourseCount', () => {
   test('returns sorted skills based on # of courses in descending order', () => {
@@ -13,5 +23,19 @@ describe('sortSkillsCoursesWithCourseCount', () => {
       { key: 'skill-3', value: [{ title: 'course-1' }] },
     ];
     expect(sortSkillsCoursesWithCourseCount(coursesWithSkills)).toEqual(expected);
+  });
+});
+
+describe('returnGoalLabel', () => {
+  test('return right goal label', () => {
+    expect(goalLabels(DROPDOWN_OPTION_CHANGE_CAREERS)).toEqual(DROPDOWN_OPTION_CHANGE_CAREERS_LABEL);
+    expect(goalLabels(DROPDOWN_OPTION_GET_PROMOTED)).toEqual(DROPDOWN_OPTION_GET_PROMOTED_LABEL);
+    expect(goalLabels(DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE)).toEqual(DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE_LABEL);
+    expect(goalLabels(DROPDOWN_OPTION_OTHER)).toEqual(DROPDOWN_OPTION_OTHER_LABEL);
+  });
+
+  test('return other goal label if find no match', () => {
+    expect(goalLabels('random string')).toEqual(DROPDOWN_OPTION_OTHER_LABEL);
+    expect(goalLabels('')).toEqual(DROPDOWN_OPTION_OTHER_LABEL);
   });
 });

--- a/src/components/skills-quiz/data/utils.jsx
+++ b/src/components/skills-quiz/data/utils.jsx
@@ -3,11 +3,38 @@
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
+import { fetchSkillsId, postSkillsGoalsAndJobsUserSelected } from './service';
+import {
+  DROPDOWN_OPTION_CHANGE_CAREERS,
+  DROPDOWN_OPTION_CHANGE_CAREERS_LABEL,
+  DROPDOWN_OPTION_GET_PROMOTED,
+  DROPDOWN_OPTION_GET_PROMOTED_LABEL,
+  DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE,
+  DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE_LABEL,
+  DROPDOWN_OPTION_OTHER,
+  DROPDOWN_OPTION_OTHER_LABEL,
+} from '../constants';
+
 export default function getCommonSkills(content, selectedJobSkills, MAX_VISIBLE_SKILLS) {
   const contentSkills = content.skillNames || [];
   return contentSkills.filter(skill => selectedJobSkills.includes(skill)).slice(0, MAX_VISIBLE_SKILLS);
 }
 
+export const goalLabels = (goal) => {
+  if (goal === DROPDOWN_OPTION_CHANGE_CAREERS) {
+    return DROPDOWN_OPTION_CHANGE_CAREERS_LABEL;
+  }
+  if (goal === DROPDOWN_OPTION_GET_PROMOTED) {
+    return DROPDOWN_OPTION_GET_PROMOTED_LABEL;
+  }
+  if (goal === DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE) {
+    return DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE_LABEL;
+  }
+  if (goal === DROPDOWN_OPTION_OTHER) {
+    return DROPDOWN_OPTION_OTHER_LABEL;
+  }
+  return DROPDOWN_OPTION_OTHER_LABEL;
+};
 export function sortSkillsWithSignificance(job) {
   return job?.skills?.sort((a, b) => (
     (a.significance < b.significance) ? 1 : -1));
@@ -36,3 +63,12 @@ export function linkToCourse(course, slug, enterpriseUUID) {
   );
   return `/${slug}/course/${course.key}?${queryParams.toString()}`;
 }
+
+export const saveSkillsGoalsAndJobsUserSelected = async (goal, skills, currentJobRole, interestedJobs) => {
+  const { data: { results } } = await fetchSkillsId(skills);
+  const skillsId = results?.map(({ id }) => id);
+  const interestedJobsId = interestedJobs?.map(({ id }) => id);
+  const currentJobRoleId = currentJobRole?.map(({ id }) => id);
+  const goalLabel = goalLabels(goal);
+  postSkillsGoalsAndJobsUserSelected(goalLabel, skillsId, interestedJobsId, currentJobRoleId);
+};


### PR DESCRIPTION
# For all changes

Added ability to save user-selected options on the skills quiz page. For that first fetches the skills Id from backend by passing the skills user selected. Jobs IDs are available on the front end. Jobs and skills IDs are then passed to backend to store the data.
Ticket: https://2u-internal.atlassian.net/browse/ENT-6178

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
