### PR TITLE
fix: remove h-100 for search course card header.

### DIFF
--- a/src/components/search/SearchCourseCard.jsx
+++ b/src/components/search/SearchCourseCard.jsx
@@ -95,7 +95,6 @@ const SearchCourseCard = ({ hit, isLoading }) => {
         />
 
         <Card.Header
-          className="h-100"
           title={(
             <Truncate lines={3} trimWhitespace>
               {course.title}


### PR DESCRIPTION
ENT-6299

Somewhere in Paragon 20, I think the `h-100` became the default for card headers.
Fixes this: 
<img width="1352" alt="image" src="https://user-images.githubusercontent.com/2307986/190201043-77c1e76f-59f0-40c6-948d-a3c875b0c556.png">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
