### PR TITLE
fix: small learner portal changes for branding

### DIFF
--- a/src/components/enterprise-banner/EnterpriseBanner.jsx
+++ b/src/components/enterprise-banner/EnterpriseBanner.jsx
@@ -10,10 +10,10 @@ export default function EnterpriseBanner() {
   const { enterpriseConfig } = useContext(AppContext);
   const isSearchPage = `/${ enterpriseConfig.slug }/search` === location.pathname;
   return (
-    <div className="enterprise-banner bg-brand-secondary">
+    <div className="enterprise-banner bg-brand-secondary border-brand-tertiary">
       <Container size="lg">
         <div className="row banner-content">
-          <h1 className="h2 mb-0 py-3 pl-3 border-brand-tertiary text-brand-secondary">
+          <h1 className="h2 mb-0 py-3 pl-3 text-brand-secondary">
             {enterpriseConfig.name}
           </h1>
           {isSearchPage

--- a/src/components/enterprise-banner/styles/EnterpriseBanner.scss
+++ b/src/components/enterprise-banner/styles/EnterpriseBanner.scss
@@ -1,8 +1,4 @@
 .enterprise-banner {
-  h1 {
-    border-left-width: 15px;
-    border-left-style: solid;
-  }
   .banner-content{
     justify-content: space-between;
   }
@@ -10,4 +6,9 @@
     margin: 1%;
     height: max-content;
   }
+}
+
+.border-brand-tertiary {
+  border-bottom-width: 7px;
+  border-bottom-style: solid;
 }

--- a/src/components/layout/data/hooks.js
+++ b/src/components/layout/data/hooks.js
@@ -6,7 +6,6 @@ import colors from '../../../colors.scss';
 import { isDefinedAndNotNull, isDefined } from '../../../utils/common';
 
 const COLOR_LIGHTEN_DARKEN_MODIFIER = 0.2;
-const COLOR_MIX_MODIFIER = 0.1;
 
 export const useStylesForCustomBrandColors = (enterpriseConfig) => {
   const brandColors = useMemo(
@@ -72,17 +71,6 @@ export const useStylesForCustomBrandColors = (enterpriseConfig) => {
       .btn-brand-${colorName}:focus:before {
         border-color: ${brandColors[colorName].regular.hex()} !important;
       }
-      .btn-brand-outline-${colorName} {
-        border-color: ${brandColors[colorName].regular.hex()} !important;
-        color: ${brandColors[colorName].regular.hex()} !important;
-      }
-      .btn-brand-outline-${colorName}:hover {
-        border-color: ${brandColors[colorName].dark.hex()} !important;
-        background-color: ${brandColors.white.mix(brandColors[colorName].light, COLOR_MIX_MODIFIER).hex()} !important;
-      }
-      .btn-brand-outline-${colorName}:focus:before {
-        border-color: ${brandColors[colorName].regular.hex()} !important;
-      }
       .bg-brand-${colorName} {
         background-color: ${brandColors[colorName].regular.hex()} !important;
       }
@@ -106,6 +94,13 @@ export const useStylesForCustomBrandColors = (enterpriseConfig) => {
         border-color: ${brandColors.primary.regular.hex()} !important;
         color: ${brandColors.primary.textColor.hex()} !important;
       }
+      .btn-primary:hover {
+        background-color: ${brandColors.primary.dark.hex()} !important;
+        border-color: ${brandColors.primary.dark.hex()} !important;
+      }
+      .btn-primary:focus:before {
+        border-color: ${brandColors.primary.regular.hex()} !important;
+      }
       .btn-brand {
         background-color: ${brandColors.primary.regular.hex()} !important;
         border-color: ${brandColors.primary.regular.hex()} !important;
@@ -116,13 +111,6 @@ export const useStylesForCustomBrandColors = (enterpriseConfig) => {
         border-color: ${brandColors.primary.dark.hex()} !important;
       }
       .btn-brand:focus:before {
-        border-color: ${brandColors.primary.regular.hex()} !important;
-      }
-      .btn-primary:hover {
-        background-color: ${brandColors.primary.dark.hex()} !important;
-        border-color: ${brandColors.primary.dark.hex()} !important;
-      }
-      .btn-primary:focus:before {
         border-color: ${brandColors.primary.regular.hex()} !important;
       }
     `),

--- a/src/components/layout/data/hooks.js
+++ b/src/components/layout/data/hooks.js
@@ -72,7 +72,6 @@ export const useStylesForCustomBrandColors = (enterpriseConfig) => {
       .btn-brand-${colorName}:focus:before {
         border-color: ${brandColors[colorName].regular.hex()} !important;
       }
-
       .btn-brand-outline-${colorName} {
         border-color: ${brandColors[colorName].regular.hex()} !important;
         color: ${brandColors[colorName].regular.hex()} !important;
@@ -84,24 +83,50 @@ export const useStylesForCustomBrandColors = (enterpriseConfig) => {
       .btn-brand-outline-${colorName}:focus:before {
         border-color: ${brandColors[colorName].regular.hex()} !important;
       }
-
       .bg-brand-${colorName} {
         background-color: ${brandColors[colorName].regular.hex()} !important;
       }
-
       .border-brand-${colorName} {
         border-color: ${brandColors[colorName].regular.hex()} !important;
       }
-
       .color-brand-${colorName} {
         color: ${brandColors[colorName].regular.hex()} !important;
       }
-
       .text-brand-${colorName} {
         color: ${brandColors[colorName].textColor.hex()} !important;
       }
     `),
   }));
+
+  styles.push({
+    key: 'general',
+    styles: (`
+      .btn-primary {
+        background-color: ${brandColors.primary.regular.hex()} !important;
+        border-color: ${brandColors.primary.regular.hex()} !important;
+        color: ${brandColors.primary.textColor.hex()} !important;
+      }
+      .btn-brand {
+        background-color: ${brandColors.primary.regular.hex()} !important;
+        border-color: ${brandColors.primary.regular.hex()} !important;
+        color: ${brandColors.primary.textColor.hex()} !important;
+      }
+      .btn-brand:hover {
+        background-color: ${brandColors.primary.dark.hex()} !important;
+        border-color: ${brandColors.primary.dark.hex()} !important;
+      }
+      .btn-brand:focus:before {
+        border-color: ${brandColors.primary.regular.hex()} !important;
+      }
+      .btn-primary:hover {
+        background-color: ${brandColors.primary.dark.hex()} !important;
+        border-color: ${brandColors.primary.dark.hex()} !important;
+      }
+      .btn-primary:focus:before {
+        border-color: ${brandColors.primary.regular.hex()} !important;
+      }
+    `),
+  });
 
   return styles;
 };


### PR DESCRIPTION
In talking with Jenn and Alena, they want all primary buttons (even primary-brand) buttons to look the color that they have customized in the admin portal. I recommended that the secondary color (banner color in admin portal) could be used as a brand color so we could have differing styles for different buttons, but since these color's haven't passed accessibility checks, they just made the decision for the first iteration, we will have all buttons be the "button" color. 

[Figma](https://www.figma.com/file/d0I9hSyXdSGtsqgniJPmK2/Admin-Portal-Redesign?node-id=1597%3A53228) | [JIRA ticket](https://2u-internal.atlassian.net/browse/ENT-6101)

![Screen Shot 2022-09-16 at 4 18 34 PM](https://user-images.githubusercontent.com/31229189/190802345-77148a65-5439-4545-82ea-05b3f1128658.png)

![Screen Shot 2022-09-16 at 4 18 42 PM](https://user-images.githubusercontent.com/31229189/190802393-4178191e-0f55-484e-b859-f7bd6af8b9e3.png)

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
