### PR TITLE
fix: enterprise colors for explore programs and explore pathways buttons

### DIFF
--- a/src/components/pathway-progress/PathwayProgressListingPage.jsx
+++ b/src/components/pathway-progress/PathwayProgressListingPage.jsx
@@ -52,7 +52,7 @@ const PathwayProgressListingPage = () => {
             <div className="no-content-message">
               <h2>{NO_PATHWAYS_ERROR_MESSAGE}</h2>
               <Link to={`/${enterpriseConfig.slug}/search?content_type=${CONTENT_TYPE_PATHWAY}`}>
-                <Button variant="primary" iconBefore={Search} className="mt-2">Explore pathways</Button>
+                <Button variant="primary" iconBefore={Search} className="btn-brand-primary mt-2">Explore pathways</Button>
               </Link>
             </div>
           )}

--- a/src/components/program-progress/ProgramListingPage.jsx
+++ b/src/components/program-progress/ProgramListingPage.jsx
@@ -47,7 +47,7 @@ const ProgramListingPage = () => {
             <div className="no-content-message">
               <h2>{NO_PROGRAMS_ERROR_MESSAGE}</h2>
               <Link to={`/${enterpriseConfig.slug}/search?content_type=${CONTENT_TYPE_PROGRAM}`}>
-                <Button variant="primary" iconBefore={Search} className="mt-2">Explore programs</Button>
+                <Button variant="primary" iconBefore={Search} className="btn-brand-primary mt-2">Explore programs</Button>
               </Link>
             </div>
           )}


### PR DESCRIPTION
# Description
This PR is to sync the colors for all the buttons in all the dashboard tabs. Screenshots are attached bellow

![Screenshot 2022-09-19 at 2 33 52 PM](https://user-images.githubusercontent.com/106396899/190989633-abeeeacf-4fdc-4e31-b438-604c3bec7a03.png)

![Screenshot 2022-09-19 at 2 33 55 PM](https://user-images.githubusercontent.com/106396899/190989650-549ec7d0-686b-4a00-b9e6-ed53779e9911.png)

![Screenshot 2022-09-19 at 2 33 58 PM](https://user-images.githubusercontent.com/106396899/190989659-f5cdebaa-e2a8-44be-8164-75a2fbd39100.png)


# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
