### PR TITLE
feat: Optimizely experiment for learners with a subscription license.

### DIFF
--- a/src/components/course/CourseRunCard.jsx
+++ b/src/components/course/CourseRunCard.jsx
@@ -8,10 +8,12 @@ import {
 
 import { AppContext } from '@edx/frontend-platform/react';
 import { useLocation } from 'react-router-dom';
+import { getConfig } from '@edx/frontend-platform/config';
 import EnrollAction from './enrollment/EnrollAction';
 import { enrollButtonTypes } from './enrollment/constants';
 import {
   COURSE_AVAILABILITY_MAP,
+  LICENSE_SUBSIDY_TYPE,
 } from './data/constants';
 import {
   isUserEntitledForCourse,
@@ -21,16 +23,38 @@ import {
   findUserEnrollmentForCourseRun,
   hasCourseStarted,
   findHighestLevelSeatSku,
+  numberWithPrecision,
 } from './data/utils';
 import { formatStringAsNumber } from '../../utils/common';
+import { isExperimentVariant } from '../../utils/optimizely';
 
 import { useSubsidyDataForCourse } from './enrollment/hooks';
-import { useCourseEnrollmentUrl, useUserHasSubsidyRequestForCourse } from './data/hooks';
+import { useCourseEnrollmentUrl, useUserHasSubsidyRequestForCourse, useCoursePriceForUserSubsidy } from './data/hooks';
 import { determineEnrollmentType } from './enrollment/utils';
 import { SubsidyRequestsContext } from '../enterprise-subsidy-requests/SubsidyRequestsContextProvider';
 
 const DATE_FORMAT = 'MMM D';
 const DEFAULT_BUTTON_LABEL = 'Enroll';
+
+const LicenseSubsidyPriceText = ({
+  courseRun,
+  userSubsidyApplicableToCourse,
+}) => {
+  const [coursePrice, currency] = useCoursePriceForUserSubsidy({
+    activeCourseRun: courseRun, userSubsidyApplicableToCourse,
+  });
+
+  return (
+    <>
+      <div className="mt-2" data-testid="subsidy-license-price-text">
+        <del>
+          <span className="sr-only">Priced reduced from:</span>${numberWithPrecision(coursePrice.list)} {currency}
+        </del>
+        <span>{' '}included in your subscription</span>
+      </div>
+    </>
+  );
+};
 
 const CourseRunCard = ({
   userEntitlements,
@@ -49,6 +73,8 @@ const CourseRunCard = ({
     seats,
     isEnrollable,
   } = courseRun;
+
+  const config = getConfig();
 
   const location = useLocation();
 
@@ -196,6 +222,17 @@ const CourseRunCard = ({
     courseRun,
   ]);
 
+  const shouldShowLicenseSubsidyPriceText = (
+    !courseRunArchived
+    && !enterpriseConfig.hideCourseOriginalPrice
+    && enrollmentType === enrollButtonTypes.TO_DATASHARING_CONSENT
+    && userSubsidyApplicableToCourse?.subsidyType === LICENSE_SUBSIDY_TYPE
+  );
+  // Only users buckted in `Variation 1` can see the change.
+  const isExperimentVariation1 = isExperimentVariant(config.EXPERIMENT_2_ID, config.EXPERIMENT_2_VARIANT_1_ID);
+  // For our experiment, we should trigger our Optimizely event only when this condition is true
+  const triggerLicenseSubsidyEvent = shouldShowLicenseSubsidyPriceText;
+
   return (
     <Card className="w-100">
       <Card.Section
@@ -210,6 +247,12 @@ const CourseRunCard = ({
         >
           <div className="h4 mb-0">{heading}</div>
           <div className="small">{subHeading}</div>
+          {isExperimentVariation1 && shouldShowLicenseSubsidyPriceText && (
+            <LicenseSubsidyPriceText
+              courseRun={courseRun}
+              userSubsidyApplicableToCourse={userSubsidyApplicableToCourse}
+            />
+          )}
         </div>
         {!courseRunArchived && (
           <EnrollAction
@@ -218,6 +261,7 @@ const CourseRunCard = ({
             enrollmentUrl={enrollmentUrl}
             userEnrollment={userEnrollment}
             subscriptionLicense={subscriptionLicense}
+            triggerLicenseSubsidyEvent={triggerLicenseSubsidyEvent}
             courseRunPrice={courseRun.firstEnrollablePaidSeatPrice}
           />
         )}
@@ -247,6 +291,27 @@ CourseRunCard.propTypes = {
   })).isRequired,
   userEntitlements: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   subsidyRequestCatalogsApplicableToCourse: PropTypes.instanceOf(Set).isRequired,
+};
+
+LicenseSubsidyPriceText.propTypes = {
+  courseRun: PropTypes.shape({
+    availability: PropTypes.string.isRequired,
+    isEnrollable: PropTypes.bool.isRequired,
+    pacingType: PropTypes.string.isRequired,
+    courseUuid: PropTypes.string.isRequired,
+    enrollmentCount: PropTypes.number,
+    start: PropTypes.string.isRequired,
+    key: PropTypes.string.isRequired,
+    seats: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+    firstEnrollablePaidSeatPrice: PropTypes.number.isRequired,
+  }).isRequired,
+  userSubsidyApplicableToCourse: PropTypes.shape({
+    discountType: PropTypes.string.isRequired,
+    discountValue: PropTypes.number.isRequired,
+    expirationDate: PropTypes.string.isRequired,
+    startDate: PropTypes.string.isRequired,
+    subsidyId: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default CourseRunCard;

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -494,6 +494,30 @@ export const useTrackSearchConversionClickHandler = ({ href, eventName }) => {
 };
 
 /**
+ * Returns a function to be used as a click handler that emits an optimizely license subsidy enrollment click event.
+ *
+ * @returns Click handler function for clicks on enrollment buttons when a learner possesses a license subsidy.
+ */
+export const useOptimizelyLicenseSubsidyEnrollmentClickHandler = ({ href, courseRunKey }) => {
+  const handleClick = useCallback(
+    (e) => {
+      // If tracking is on a link with an external href destination, we must intentionally delay the default click
+      // behavior to allow enough time for the async analytics event call to resolve.
+      if (href) {
+        e.preventDefault();
+        setTimeout(() => {
+          global.location.href = href;
+        }, CLICK_DELAY_MS);
+      }
+      pushEvent(EVENTS.LICENSE_SUBSIDY_ENROLLMENT_CLICK, { courseKey: courseRunKey });
+    },
+    [courseRunKey, href],
+  );
+
+  return handleClick;
+};
+
+/**
  * Returns a function to be used as a click handler that emits an optimizely enrollment click event.
  *
  * @returns Click handler function for clicks on enrollment buttons.

--- a/src/components/course/enrollment/EnrollAction.jsx
+++ b/src/components/course/enrollment/EnrollAction.jsx
@@ -36,6 +36,7 @@ const EnrollAction = ({
   userEnrollment,
   subscriptionLicense,
   courseRunPrice,
+  triggerLicenseSubsidyEvent,
 }) => {
   switch (enrollmentType) {
     case TO_COURSEWARE_PAGE: // scenario 1: already enrolled
@@ -56,6 +57,7 @@ const EnrollAction = ({
             <ToDataSharingConsentPage
               enrollLabel={enrollLabel}
               enrollmentUrl={enrollmentUrl}
+              triggerLicenseSubsidyEvent={triggerLicenseSubsidyEvent}
             />
           );
       case TO_ECOM_BASKET:
@@ -78,12 +80,14 @@ EnrollAction.propTypes = {
   userEnrollment: PropTypes.shape({}),
   subscriptionLicense: PropTypes.shape({}),
   courseRunPrice: PropTypes.number.isRequired,
+  triggerLicenseSubsidyEvent: PropTypes.bool,
 };
 
 EnrollAction.defaultProps = {
   enrollmentUrl: null,
   userEnrollment: null,
   subscriptionLicense: null,
+  triggerLicenseSubsidyEvent: false,
 };
 
 export default EnrollAction;

--- a/src/components/course/enrollment/components/ToDataSharingConsent.jsx
+++ b/src/components/course/enrollment/components/ToDataSharingConsent.jsx
@@ -6,6 +6,7 @@ import { Hyperlink } from '@edx/paragon';
 import {
   useOptimizelyEnrollmentClickHandler,
   useTrackSearchConversionClickHandler,
+  useOptimizelyLicenseSubsidyEnrollmentClickHandler,
 } from '../../data/hooks';
 import { enrollLinkClass } from '../constants';
 import { EnrollButtonCta } from '../common';
@@ -13,7 +14,7 @@ import { CourseContext } from '../../CourseContextProvider';
 import { CourseEnrollmentsContext } from '../../../dashboard/main-content/course-enrollments/CourseEnrollmentsContextProvider';
 
 // Data sharing consent
-const ToDataSharingConsentPage = ({ enrollLabel, enrollmentUrl }) => {
+const ToDataSharingConsentPage = ({ enrollLabel, enrollmentUrl, triggerLicenseSubsidyEvent }) => {
   const {
     state: {
       activeCourseRun: { key: courseRunKey },
@@ -32,6 +33,10 @@ const ToDataSharingConsentPage = ({ enrollLabel, enrollmentUrl }) => {
     courseRunKey,
     courseEnrollmentsByStatus,
   });
+  const optimizelyLicenseSubsidyHandler = useOptimizelyLicenseSubsidyEnrollmentClickHandler({
+    href: enrollmentUrl,
+    courseRunKey,
+  });
 
   return (
     <EnrollButtonCta
@@ -42,6 +47,7 @@ const ToDataSharingConsentPage = ({ enrollLabel, enrollmentUrl }) => {
       onClick={(e) => {
         analyticsHandler(e);
         optimizelyHandler(e);
+        if (triggerLicenseSubsidyEvent) { optimizelyLicenseSubsidyHandler(e); }
       }}
     />
   );
@@ -50,6 +56,11 @@ const ToDataSharingConsentPage = ({ enrollLabel, enrollmentUrl }) => {
 ToDataSharingConsentPage.propTypes = {
   enrollLabel: PropTypes.node.isRequired,
   enrollmentUrl: PropTypes.string.isRequired,
+  triggerLicenseSubsidyEvent: PropTypes.bool,
+};
+
+ToDataSharingConsentPage.defaultProps = {
+  triggerLicenseSubsidyEvent: false,
 };
 
 export default ToDataSharingConsentPage;

--- a/src/components/course/enrollment/tests/EnrollAction.test.jsx
+++ b/src/components/course/enrollment/tests/EnrollAction.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';
 
@@ -154,6 +154,7 @@ describe('scenarios user not yet enrolled, but eligible to enroll', () => {
         enrollLabel={<EnrollLabel enrollLabelText={enrollLabelText} />}
         enrollmentUrl={enrollmentUrl}
         courseRunPrice={100}
+        triggerLicenseSubsidyEvent
       />
     );
     renderEnrollAction({ enrollAction });
@@ -162,6 +163,9 @@ describe('scenarios user not yet enrolled, but eligible to enroll', () => {
     expect(screen.queryByText(enrollLabelText)).toBeInTheDocument();
     const actualUrl = screen.getByText(enrollLabelText).closest('a').href;
     expect(actualUrl).toContain(`${enrollmentUrl}`);
+
+    const enrollButton = screen.getByText(enrollLabelText);
+    fireEvent.click(enrollButton);
   });
   test('<ToEcomBasketPage /> is rendered if enrollmentType is TO_ECOM_BASKET', () => {
     const enrollAction = (

--- a/src/components/course/tests/CourseRunCard.test.jsx
+++ b/src/components/course/tests/CourseRunCard.test.jsx
@@ -13,6 +13,8 @@ import {
   COURSE_MODES_MAP,
   COURSE_AVAILABILITY_MAP,
   COURSE_PACING_MAP,
+  LICENSE_SUBSIDY_TYPE,
+  CURRENCY_USD,
 } from '../data/constants';
 import CourseRunCard from '../CourseRunCard';
 import { CourseContextProvider } from '../CourseContextProvider';
@@ -20,6 +22,8 @@ import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests/SubsidyRequestsContextProvider';
 import * as subsidyRequestsHooks from '../data/hooks';
 import { enrollButtonTypes } from '../enrollment/constants';
+import * as utils from '../enrollment/utils';
+import * as optimizelyUtils from '../../../utils/optimizely';
 
 const COURSE_UUID = 'foo';
 const COURSE_RUN_START = moment().format();
@@ -28,6 +32,7 @@ const DATE_FORMAT = 'MMM D';
 const COURSE_ID = '123';
 
 jest.mock('../../../config');
+
 jest.mock('../enrollment/EnrollAction', () => ({ enrollLabel, enrollmentType }) => (
   <>
     <span>{enrollLabel}</span>
@@ -38,6 +43,7 @@ jest.mock('../data/hooks', () => ({
   useUserHasSubsidyRequestForCourse: jest.fn(() => false),
   useCourseEnrollmentUrl: jest.fn(() => false),
   useCatalogsForSubsidyRequests: jest.fn(() => []),
+  useCoursePriceForUserSubsidy: jest.fn(() => []),
 }));
 
 const INITIAL_APP_STATE = initialAppState({});
@@ -51,6 +57,11 @@ const selfPacedCourseWithoutLicenseSubsidy = {
     seats: [{ sku: 'sku', type: COURSE_MODES_MAP.VERIFIED }],
   },
   catalog: { catalogList: [] },
+};
+
+const selfPacedCourseWithLicenseSubsidy = {
+  ...selfPacedCourseWithoutLicenseSubsidy,
+  userSubsidyApplicableToCourse: { subsidyType: LICENSE_SUBSIDY_TYPE },
 };
 
 const baseSubsidyRequestCatalogsApplicableToCourse = new Set();
@@ -255,5 +266,26 @@ describe('<CourseRunCard/>', () => {
     expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
     expect(screen.getByText('You are enrolled')).toBeInTheDocument();
     expect(screen.getByText('View course')).toBeInTheDocument();
+  });
+
+  test('user see the struck out price message in the card', () => {
+    jest.spyOn(utils, 'determineEnrollmentType').mockImplementation(() => enrollButtonTypes.TO_DATASHARING_CONSENT);
+    jest.spyOn(optimizelyUtils, 'isExperimentVariant').mockImplementation(() => true);
+    subsidyRequestsHooks.useCoursePriceForUserSubsidy.mockReturnValueOnce([{ list: 100 }, CURRENCY_USD]);
+    const courseRunStart = moment(COURSE_RUN_START).add(1, 'd').format();
+    const courseRun = generateCourseRun({
+      start: courseRunStart,
+      enrollmentCount: 1000,
+    });
+    renderCard({
+      courseRun,
+      courseInitState: selfPacedCourseWithLicenseSubsidy,
+    });
+
+    const element = screen.queryByTestId('subsidy-license-price-text');
+    expect(element).toBeInTheDocument();
+    expect(element.innerHTML).toEqual(
+      '<del><span class="sr-only">Priced reduced from:</span>$100.00 USD</del><span> included in your subscription</span>',
+    );
   });
 });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -43,6 +43,8 @@ initialize({
         LEARNER_SUPPORT_URL: process.env.LEARNER_SUPPORT_URL || null,
         GETSMARTER_STUDENT_TC_URL: process.env.GETSMARTER_STUDENT_TC_URL || null,
         GETSMARTER_PRIVACY_POLICY_URL: process.env.GETSMARTER_PRIVACY_POLICY_URL || null,
+        EXPERIMENT_2_ID: process.env.EXPERIMENT_2_ID || null,
+        EXPERIMENT_2_VARIANT_1_ID: process.env.EXPERIMENT_2_VARIANT_1_ID || null,
       });
     },
   },

--- a/src/utils/optimizely.js
+++ b/src/utils/optimizely.js
@@ -1,6 +1,7 @@
 export const EVENTS = {
   ENROLLMENT_CLICK: 'enterprise_learner_portal_enrollment_click',
   FIRST_ENROLLMENT_CLICK: 'enterprise_learner_portal_first_enrollment_click',
+  LICENSE_SUBSIDY_ENROLLMENT_CLICK: 'enterprise_learner_portal_license_subsidy_enrollment_click',
 };
 
 export const getActiveExperiments = () => {


### PR DESCRIPTION
**Description:**
Hypothesis: IF we show license learners that the course truly is free to them at the moment of enrollment, THEN they will be more likely to enroll, BECAUSE we will be more closely tying together the concepts of “we want you to enroll now” and “this course is free to you”.

Implementation: If the learner has a subscription license, bring the struck out price information in the course sidebar into the enrollment area above the fold. 50% / 50% traffic. Assess whether or not learners are ( 1 ) more likely to enroll in a course based on receiving vs. not receiving the treatment.

**JIRA:** https://2u-internal.atlassian.net/browse/ENT-6204

---
### Screenshots

**Control:**
<img width="1437" alt="Screenshot 2022-09-26 at 4 48 27 PM" src="https://user-images.githubusercontent.com/6767924/192268947-0ca1400f-b72c-4552-bba5-50463325a206.png">

**Variation 1:**

<img width="1436" alt="Screenshot 2022-09-22 at 11 51 21 AM" src="https://user-images.githubusercontent.com/6767924/191706666-f6978e08-6736-4901-abf9-67482de4cfd0.png">



# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
