### PR TITLE
fix: trim milliseconds from termsAcceptedAt

### DIFF
--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -12,7 +12,7 @@ import { logError } from '@edx/frontend-platform/logging';
 import { getConfig } from '@edx/frontend-platform/config';
 import { sendEnterpriseTrackEvent, sendEnterpriseTrackEventWithDelay } from '@edx/frontend-enterprise-utils';
 
-import { checkoutExecutiveEducation2U } from './data';
+import { checkoutExecutiveEducation2U, toISOStringWithoutMilliseconds } from './data';
 import FormSectionHeading from './FormSectionHeading';
 
 export const formValidationMessages = {
@@ -69,7 +69,7 @@ function UserEnrollmentForm({
           lastName: values.lastName,
           dateOfBirth: values.dateOfBirth,
         },
-        termsAcceptedAt: new Date(Date.now()).toISOString(),
+        termsAcceptedAt: toISOStringWithoutMilliseconds(new Date(Date.now()).toISOString()),
       });
 
       await sendEnterpriseTrackEventWithDelay(

--- a/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import UserEnrollmentForm, { formValidationMessages } from './UserEnrollmentForm';
-import { checkoutExecutiveEducation2U } from './data';
+import { checkoutExecutiveEducation2U, toISOStringWithoutMilliseconds } from './data';
 
 const termsLabelText = 'I agree to GetSmarter\'s Terms and Conditions for Students';
 
@@ -102,7 +102,7 @@ describe('UserEnrollmentForm', () => {
       receiptPageUrl: 'https://edx.org',
     };
     checkoutExecutiveEducation2U.mockResolvedValueOnce(mockCheckoutResponse);
-    const mockTermsAcceptedAt = '2022-08-23';
+    const mockTermsAcceptedAt = '2022-09-28T13:35:06Z';
     Date.now = jest.fn(() => new Date(mockTermsAcceptedAt).valueOf());
 
     render(<UserEnrollmentFormWrapper />);
@@ -125,7 +125,7 @@ describe('UserEnrollmentForm', () => {
             lastName: mockLastName,
             dateOfBirth: mockDateOfBirth,
           },
-          termsAcceptedAt: new Date(mockTermsAcceptedAt).toISOString(),
+          termsAcceptedAt: toISOStringWithoutMilliseconds(new Date(mockTermsAcceptedAt).toISOString()),
         }),
       );
     });

--- a/src/components/executive-education-2u/data/index.js
+++ b/src/components/executive-education-2u/data/index.js
@@ -1,2 +1,3 @@
 export * from './service';
 export * from './hooks';
+export * from './utils';

--- a/src/components/executive-education-2u/data/utils.js
+++ b/src/components/executive-education-2u/data/utils.js
@@ -1,0 +1,6 @@
+export const toISOStringWithoutMilliseconds = (isoString) => {
+  if (isoString.indexOf('.') === -1) {
+    return undefined;
+  }
+  return `${isoString.split('.')[0]}Z`;
+};

--- a/src/components/executive-education-2u/data/utils.js
+++ b/src/components/executive-education-2u/data/utils.js
@@ -1,6 +1,6 @@
 export const toISOStringWithoutMilliseconds = (isoString) => {
   if (isoString.indexOf('.') === -1) {
-    return undefined;
+    return isoString;
   }
   return `${isoString.split('.')[0]}Z`;
 };


### PR DESCRIPTION
# Description

The `/enterprise_allocations` endpoint wants `termsAcceptedAt` to conform to ISO 8601 spec, but _without the milliseconds_ as their API has a character limit on the field.

For example, we generate a timestamp per the following:
```
new Date().toISOString()
'2022-09-28T14:22:11.017Z'
```

However, the GEAG API doesn't want the `.017` at the end, despite being standard spec for ISO 8601.

While we could make this change to get around the GEAG API validation, we've reached out to the GetSmarter team to clarify whether the field should have any valid ISO 8601 input, which we are already passing.

If the validation is changed on the API to support milliseconds per the spec, this PR can be closed. Otherwise, we'll need this fix to properly call the GEAG API.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
