### PR TITLE
fix: Remove redirect to dashboard on course 'request enrollment'

### DIFF
--- a/src/components/course/CourseHeader.jsx
+++ b/src/components/course/CourseHeader.jsx
@@ -89,7 +89,7 @@ export default function CourseHeader() {
             {catalog.containsContentItems ? (
               <>
                 <CourseRunCards />
-                <SubsidyRequestButton enterpriseSlug={enterpriseConfig.slug} />
+                <SubsidyRequestButton />
                 {defaultProgram && (
                   <p className="font-weight-bold mt-3 mb-0">
                     This course is part of a {formatProgramType(defaultProgram.type)}.

--- a/src/components/course/SubsidyRequestButton.jsx
+++ b/src/components/course/SubsidyRequestButton.jsx
@@ -1,10 +1,8 @@
 import React, {
   useContext, useMemo, useState, useCallback,
 } from 'react';
-import PropTypes from 'prop-types';
 import { StatefulButton } from '@edx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
-import { useHistory } from 'react-router-dom';
 
 import { SubsidyRequestsContext, SUBSIDY_TYPE } from '../enterprise-subsidy-requests';
 import { CourseContext } from './CourseContextProvider';
@@ -24,8 +22,7 @@ const props = {
   className: 'mb-4 mt-1',
 };
 
-const SubsidyRequestButton = ({ enterpriseSlug }) => {
-  const history = useHistory();
+const SubsidyRequestButton = () => {
   const { addToast } = useContext(ToastsContext);
   const [loadingRequest, setLoadingRequest] = useState(false);
 
@@ -112,7 +109,6 @@ const SubsidyRequestButton = ({ enterpriseSlug }) => {
       setLoadingRequest(false);
       addToast('Request for course submitted');
       refreshSubsidyRequests();
-      history.push(`/${enterpriseSlug}`);
     } catch (error) {
       logError(error);
       setLoadingRequest(false);
@@ -122,10 +118,6 @@ const SubsidyRequestButton = ({ enterpriseSlug }) => {
   return (
     <StatefulButton {...props} state={getButtonState()} onClick={handleRequestButtonClick} />
   );
-};
-
-SubsidyRequestButton.propTypes = {
-  enterpriseSlug: PropTypes.string.isRequired,
 };
 
 export default SubsidyRequestButton;

--- a/src/components/course/tests/SubsidyRequestButton.test.jsx
+++ b/src/components/course/tests/SubsidyRequestButton.test.jsx
@@ -13,7 +13,6 @@ import * as entepriseAccessService from '../../enterprise-subsidy-requests/data/
 jest.mock('../../enterprise-subsidy-requests/data/service');
 
 const mockEnterpriseUUID = 'uuid';
-const mockEnterpriseSlug = 'sluggy';
 const mockCourseKey = 'edx+101';
 const mockCourseRunKey = `${mockCourseKey}+v1`;
 
@@ -60,7 +59,7 @@ const SubsidyRequestButtonWrapper = ({
   <ToastsContext.Provider value={initialToastsState}>
     <SubsidyRequestsContext.Provider value={{ ...initialSubsidyRequestsState, ...subsidyRequestsState }}>
       <CourseContext.Provider value={{ ...initialCourseState, ...courseState }}>
-        <SubsidyRequestButton enterpriseSlug={mockEnterpriseSlug} />
+        <SubsidyRequestButton />
       </CourseContext.Provider>
     </SubsidyRequestsContext.Provider>
   </ToastsContext.Provider>
@@ -158,7 +157,8 @@ describe('<SubsidyRequestButton />', () => {
         }}
       />,
     );
-    expect(screen.getByText('Awaiting approval'));
+    expect(screen.queryByText('Request enrollment')).not.toBeInTheDocument();
+    expect(screen.getByText('Awaiting approval')).toBeInTheDocument();
   });
 
   it.each(


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6300

Removes useHistory on SubsidyRequestButton callback that redirects on button click after displaying Toast
Remove prop parameter 'enterpriseSlug' used solely to redirect user to dashboard
Remove passed prop within CourseHeader component
Refactored corresponding tests using enterpriseSlug prop

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
