### PR TITLE
feat: Update user subsidy logic to accept stacked subsidy and licence

### DIFF
--- a/src/components/dashboard/sidebar/CouponCodesSummaryCard.jsx
+++ b/src/components/dashboard/sidebar/CouponCodesSummaryCard.jsx
@@ -81,16 +81,18 @@ const CouponCodesSummaryCard = ({
           <SidebarCard
             title={(
               <div className="d-flex align-items-start justify-content-between">
-                {`${COUPON_CODES_SUMMARY_TITLE}${couponCodesCount > 0 ? `: ${couponCodesCount}` : ''}`}
-                {badgeVariantAndLabel && (
-                  <Badge
-                    variant={badgeVariantAndLabel.variant}
-                    className="ml-2"
-                    data-testid="subscription-status-badge"
-                  >
-                    {badgeVariantAndLabel.label}
-                  </Badge>
-                )}
+                <div>{`${COUPON_CODES_SUMMARY_TITLE}${couponCodesCount > 0 ? `: ${couponCodesCount}` : ''}`}</div>
+                <div>
+                  {badgeVariantAndLabel && (
+                    <Badge
+                      variant={badgeVariantAndLabel.variant}
+                      className="ml-2"
+                      data-testid="subscription-status-badge"
+                    >
+                      {badgeVariantAndLabel.label}
+                    </Badge>
+                  )}
+                </div>
               </div>
             )}
             cardClassNames={className}

--- a/src/components/dashboard/sidebar/EnterpriseOffersSummaryCard.jsx
+++ b/src/components/dashboard/sidebar/EnterpriseOffersSummaryCard.jsx
@@ -35,7 +35,7 @@ const EnterpriseOffersSummaryCard = ({ className, offer, searchCoursesCta }) => 
       ? (
         <p data-testid="offer-summary-text-detailed">
           Apply your <b>${offer.remainingBalanceForUser}</b>{' '}
-          learner credit balance to enroll into courses with no out of pocket cost.
+          balance to enroll into courses.
         </p>
       )
       : (
@@ -53,7 +53,7 @@ const EnterpriseOffersSummaryCard = ({ className, offer, searchCoursesCta }) => 
 
     {searchCoursesCta && (
       <Row className="mt-3 d-flex justify-content-end">
-        <Col xl={7}>{searchCoursesCta}</Col>
+        <Col xl={12}>{searchCoursesCta}</Col>
       </Row>
     )}
   </SidebarCard>

--- a/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
+++ b/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
@@ -217,7 +217,6 @@ describe('<DashboardSidebar />', () => {
         }}
       />,
     );
-    // expect(screen.getByText('Pikachu')).toBeInTheDocument();
     expect(screen.queryByText(ENTERPRISE_OFFER_SUMMARY_CARD_TITLE)).toBeInTheDocument();
     expect(screen.queryByText(SUBSCRIPTION_SUMMARY_CARD_TITLE)).not.toBeInTheDocument();
     expect(screen.queryByText(COUPON_CODES_SUMMARY_NOTICE)).toBeInTheDocument();

--- a/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
+++ b/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
@@ -185,21 +185,42 @@ describe('<DashboardSidebar />', () => {
     );
     expect(screen.getByText(ENTERPRISE_OFFER_SUMMARY_CARD_TITLE)).toBeInTheDocument();
   });
-  test('Enterprise offers summary card is not displayed when enterprise has active offers and but has subscriptions or coupons', () => {
+  test('Enterprise offers summary card is displayed when enterprise has active offers and has subscriptions', () => {
+    renderWithRouter(
+      <DashboardSidebarWithContext
+        initialAppState={initialAppState}
+        initialUserSubsidyState={{
+          ...userSubsidyStateWithSubscription,
+          enterpriseOffers: [{
+            uuid: 'enterprise-offer-id',
+          }],
+          canEnrollWithEnterpriseOffers: true,
+        }}
+      />,
+    );
+
+    expect(screen.queryByText(ENTERPRISE_OFFER_SUMMARY_CARD_TITLE)).toBeInTheDocument();
+    expect(screen.queryByText(SUBSCRIPTION_SUMMARY_CARD_TITLE)).toBeInTheDocument();
+    expect(screen.queryByText(COUPON_CODES_SUMMARY_NOTICE)).not.toBeInTheDocument();
+  });
+  test('Enterprise offers summary card is displayed when enterprise has active offers and has coupon codes', () => {
     renderWithRouter(
       <DashboardSidebarWithContext
         initialAppState={initialAppState}
         initialUserSubsidyState={{
           ...defaultUserSubsidyState,
-          customerAgreementConfig: undefined,
+          couponCodes: { ...defaultUserSubsidyState.couponCodes, couponCodesCount: 2 },
           enterpriseOffers: [{
             uuid: 'enterprise-offer-id',
           }],
-          canEnrollWithEnterpriseOffers: false,
+          canEnrollWithEnterpriseOffers: true,
         }}
       />,
     );
-    expect(screen.queryByText(ENTERPRISE_OFFER_SUMMARY_CARD_TITLE)).not.toBeInTheDocument();
+    // expect(screen.getByText('Pikachu')).toBeInTheDocument();
+    expect(screen.queryByText(ENTERPRISE_OFFER_SUMMARY_CARD_TITLE)).toBeInTheDocument();
+    expect(screen.queryByText(SUBSCRIPTION_SUMMARY_CARD_TITLE)).not.toBeInTheDocument();
+    expect(screen.queryByText(COUPON_CODES_SUMMARY_NOTICE)).toBeInTheDocument();
   });
   test('Find a course button is not rendered when user has no coupon codes or license subsidy', () => {
     renderWithRouter(

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/hooks.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/hooks.js
@@ -7,7 +7,6 @@ import { logError } from '@edx/frontend-platform/logging';
 import { fetchCouponsOverview } from '../../coupons/data/service';
 import { features } from '../../../../config';
 import * as enterpriseOffersService from './service';
-import { hasValidStartExpirationDates } from '../../../../utils/common';
 import { transformEnterpriseOffer } from './utils';
 
 export const useEnterpriseOffers = ({
@@ -77,22 +76,12 @@ export const useEnterpriseOffers = ({
       return;
     }
 
-    const enterpriseHasActiveCoupons = enterpriseCoupons.length > 0;
-    const enterpriseHasActiveSubscription = !!(customerAgreementConfig?.subscriptions ?? []).find(({
-      startDate,
-      expirationDate,
-    }) => hasValidStartExpirationDates({
-      startDate,
-      expirationDate,
-    }));
-
     // For MVP we will only support enterprises with one active offer
     const enterpriseHasOneOffer = enterpriseOffers.length === 1;
 
-    if (enterpriseHasActiveCoupons || enterpriseHasActiveSubscription || !enterpriseHasOneOffer) {
+    if (!enterpriseHasOneOffer) {
       return;
     }
-
     setCanEnrollWithEnterpriseOffers(true);
     setHasLowEnterpriseOffersBalance(enterpriseOffers[0].isLowOnBalance);
     setHasNoEnterpriseOffersBalance(enterpriseOffers[0].isOutOfBalance);

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/hooks.test.jsx
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/hooks.test.jsx
@@ -97,7 +97,7 @@ describe('useEnterpriseOffers', () => {
     },
   );
 
-  it('returns canEnrollWithEnterpriseOffers = true if the enterprise has coupons', async () => {
+  it('returns canEnrollWithEnterpriseOffers = true if the enterprise has coupons and offers simultaneously', async () => {
     couponService.fetchCouponsOverview.mockResolvedValueOnce({
       data: {
         results: mockCouponOverview,
@@ -128,7 +128,7 @@ describe('useEnterpriseOffers', () => {
     expect(isLoading).toEqual(false);
   });
 
-  it('returns canEnrollWithEnterpriseOffers = true if the enterprise has an active sub', async () => {
+  it('returns canEnrollWithEnterpriseOffers = true if the enterprise has an active sub and offer simultaneously', async () => {
     subsidyService.fetchSubscriptionLicensesForUser.mockResolvedValue({
       data: {
         results: [{ ...mockLicense, status: LICENSE_STATUS.ACTIVATED }],

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Sidebar = props => (
-  <aside className="col-12 col-lg-4 pl-5" {...props}>
+  <aside className="col-12 col-lg-4" {...props}>
     {props.children}
   </aside>
 );


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6290
Associated Figma: https://www.figma.com/file/glKHoHBACvTw2oeKs2TO1O/Offers?node-id=314%3A24838

Initial PR to review implementation and test of crossing out the price for a stacked enterprise customer with both Subsidy and Licenses. Additional UI changes would need to be implemented to take into account stacked license and subscription. 

Initial UI changes implemented. Requires consolidation of component display logic, but pushing for feedback on consolidation techniques. 
![Screen Shot 2022-10-11 at 08 57 28 AM](https://user-images.githubusercontent.com/82611798/195098353-7279c186-9eb2-4965-96f1-2e97f1e582dc.png)
![Screen Shot 2022-10-11 at 08 57 44 AM](https://user-images.githubusercontent.com/82611798/195098359-b6ff6c0d-1bf3-4e96-ac48-3012808e13c2.png)
![Screen Shot 2022-10-11 at 8 54 32 AM](https://user-images.githubusercontent.com/82611798/195098397-d66f3f99-73f9-47ab-91c5-49f4151bf889.png)
![Screen Shot 2022-10-11 at 8 51 38 AM](https://user-images.githubusercontent.com/82611798/195098399-bd2d76bf-2e6e-4375-8e65-7fc0e68f72ec.png)
![Screen Shot 2022-10-11 at 9 15 54 AM](https://user-images.githubusercontent.com/82611798/195101108-01e5641f-7ea0-4056-b9c2-e35a1bb99475.png)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
