### PR TITLE
feat: course length in course search card footer and optimizely A/B test

### DIFF
--- a/src/components/search/SearchCourseCard.jsx
+++ b/src/components/search/SearchCourseCard.jsx
@@ -9,6 +9,10 @@ import { Card } from '@edx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import { getPrimaryPartnerLogo, isDefinedAndNotNull } from '../../utils/common';
+import { GENERAL_LENGTH_COURSE, SHORT_LENGTH_COURSE } from './data/constants';
+import { useCourseAboutPageVisitClickHandler } from './data/hooks';
+import { isExperimentVariant } from '../../utils/optimizely';
+import { isShortCourse } from './utils';
 
 const SearchCourseCard = ({ hit, isLoading, ...rest }) => {
   const { enterpriseConfig: { slug, uuid } } = useContext(AppContext);
@@ -45,12 +49,26 @@ const SearchCourseCard = ({ hit, isLoading, ...rest }) => {
     [course],
   );
 
+  const config = getConfig();
+  const isExperimentVariationA = isExperimentVariant(
+    config.EXPERIMENT_3_ID,
+    config.EXPERIMENT_3_VARIANT_1_ID,
+  );
+
+  const isShortLengthCourse = isShortCourse(course);
+
   const primaryPartnerLogo = getPrimaryPartnerLogo(partnerDetails);
+
+  const handleCourseAboutPageVisitClick = useCourseAboutPageVisitClickHandler({
+    courseKey: course.key,
+    enterpriseId: uuid,
+  });
 
   const handleCardClick = () => {
     if (!linkToCourse) {
       return;
     }
+    handleCourseAboutPageVisitClick();
     sendEnterpriseTrackEvent(
       uuid,
       'edx.ui.enterprise.learner_portal.search.card.clicked',
@@ -92,7 +110,12 @@ const SearchCourseCard = ({ hit, isLoading, ...rest }) => {
         )}
       />
       <Card.Section />
-      <Card.Footer textElement={<span className="text-muted">Course</span>} />
+      <Card.Footer textElement={(
+        <span className="text-muted">
+          {(isExperimentVariationA && isShortLengthCourse) ? SHORT_LENGTH_COURSE : GENERAL_LENGTH_COURSE}
+        </span>
+      )}
+      />
     </Card>
   );
 };

--- a/src/components/search/data/constants.js
+++ b/src/components/search/data/constants.js
@@ -1,0 +1,2 @@
+export const GENERAL_LENGTH_COURSE = 'Course';
+export const SHORT_LENGTH_COURSE = 'Short Course';

--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -1,11 +1,12 @@
 import {
-  useContext, useMemo, useEffect,
+  useContext, useMemo, useEffect, useCallback,
 } from 'react';
 import {
   SearchContext, getCatalogString, SHOW_ALL_NAME, setRefinementAction,
 } from '@edx/frontend-enterprise-catalog-search';
 import { features } from '../../../config';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
+import { pushEvent, EVENTS } from '../../../utils/optimizely';
 
 export const useSearchCatalogs = ({
   subscriptionPlan,
@@ -75,4 +76,21 @@ export const useDefaultSearchFilters = ({
   );
 
   return { filters };
+};
+
+/**
+ * Returns a function to be used as a click handler emitting an optimizely event on course about page visit click event.
+ *
+ * @returns Click handler function for course about page visit click events.
+ */
+export const useCourseAboutPageVisitClickHandler = ({ courseKey, enterpriseId }) => {
+  const handleClick = useCallback(
+    () => {
+      // Send the Optimizely event to track the course about page visit
+      pushEvent(EVENTS.COURSE_ABOUT_PAGE_CLICK, { courseKey, enterpriseId });
+    },
+    [courseKey, enterpriseId],
+  );
+
+  return handleClick;
 };

--- a/src/components/search/tests/SearchCourseCard.test.jsx
+++ b/src/components/search/tests/SearchCourseCard.test.jsx
@@ -3,11 +3,15 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AppContext } from '@edx/frontend-platform/react';
 import '@testing-library/jest-dom/extend-expect';
+import { renderHook } from '@testing-library/react-hooks';
 
 import SearchCourseCard from '../SearchCourseCard';
+import * as optimizelyUtils from '../../../utils/optimizely';
+import * as courseSearchUtils from '../utils';
 
 import { renderWithRouter } from '../../../utils/tests';
 import { TEST_ENTERPRISE_SLUG, TEST_IMAGE_URL } from './constants';
+import { useCourseAboutPageVisitClickHandler } from '../data/hooks';
 
 jest.mock('react-truncate', () => ({
   __esModule: true,
@@ -82,5 +86,47 @@ describe('<SearchCourseCard />', () => {
     const cardEl = screen.getByTestId('search-course-card');
     userEvent.click(cardEl);
     expect(history.entries).toHaveLength(1);
+  });
+
+  test('render course_length field in place of course text', () => {
+    jest.spyOn(optimizelyUtils, 'isExperimentVariant').mockImplementation(() => true);
+    jest.spyOn(courseSearchUtils, 'isShortCourse').mockImplementation(() => true);
+
+    const { container } = renderWithRouter(<SearchCourseCardWithAppContext {...defaultProps} />);
+
+    // assert that the card footer shows text "Short Course"
+    expect(container.querySelector('.pgn__card-footer-text')).toHaveTextContent('Short Course');
+  });
+
+  test('do not render course_length field in place of course text', () => {
+    jest.spyOn(optimizelyUtils, 'isExperimentVariant').mockImplementation(() => true);
+    jest.spyOn(courseSearchUtils, 'isShortCourse').mockImplementation(() => false);
+
+    const { container } = renderWithRouter(<SearchCourseCardWithAppContext {...defaultProps} />);
+
+    // assert that the card footer shows text "Course"
+    expect(container.querySelector('.pgn__card-footer-text')).toHaveTextContent('Course');
+  });
+
+  test('optimizely event is being triggered in onClick when search card is clicked', () => {
+    const basicProps = {
+      courseKey: 'course-key',
+      enterpriseId: 'enterprise-id',
+    };
+    const pushEventSpy = jest.spyOn(optimizelyUtils, 'pushEvent').mockImplementation(() => (true));
+
+    const { result } = renderHook(() => useCourseAboutPageVisitClickHandler(basicProps));
+    result.current({ preventDefault: jest.fn() });
+
+    const { container } = renderWithRouter(<SearchCourseCardWithAppContext {...defaultProps} />);
+
+    // select card with class pgn__card and click on it
+    const card = container.querySelector('.pgn__card');
+    card.click();
+
+    expect(pushEventSpy).toHaveBeenCalledWith('enterprise_learner_portal_course_about_page_click', {
+      courseKey: 'course-key',
+      enterpriseId: 'enterprise-id',
+    });
   });
 });

--- a/src/components/search/utils.js
+++ b/src/components/search/utils.js
@@ -1,0 +1,3 @@
+export function isShortCourse(course) {
+  return course.course_length === 'short';
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -47,6 +47,8 @@ initialize({
         GETSMARTER_PRIVACY_POLICY_URL: process.env.GETSMARTER_PRIVACY_POLICY_URL || null,
         EXPERIMENT_2_ID: process.env.EXPERIMENT_2_ID || null,
         EXPERIMENT_2_VARIANT_1_ID: process.env.EXPERIMENT_2_VARIANT_1_ID || null,
+        EXPERIMENT_3_ID: process.env.EXPERIMENT_3_ID || null,
+        EXPERIMENT_3_VARIANT_1_ID: process.env.EXPERIMENT_3_VARIANT_1_ID || null,
       });
     },
   },

--- a/src/utils/optimizely.js
+++ b/src/utils/optimizely.js
@@ -2,6 +2,7 @@ export const EVENTS = {
   ENROLLMENT_CLICK: 'enterprise_learner_portal_enrollment_click',
   FIRST_ENROLLMENT_CLICK: 'enterprise_learner_portal_first_enrollment_click',
   LICENSE_SUBSIDY_ENROLLMENT_CLICK: 'enterprise_learner_portal_license_subsidy_enrollment_click',
+  COURSE_ABOUT_PAGE_CLICK: 'enterprise_learner_portal_course_about_page_click',
 };
 
 export const getActiveExperiments = () => {


### PR DESCRIPTION
# Description
These changes are to show the course length in the course search card footer on the search page. We have this picture for a clear view 

![3887974a-c6db-4138-9a2e-78f1ee0f4366](https://user-images.githubusercontent.com/106396899/198583658-bd9e7324-7c71-4bf5-9e6c-3a431522cc33.png)

This PR implements the A/B test where 50% of the learners are shown the course length on the course search card while the other users get the regular experience. 

The Algolia Index contains the `course_length` field which specifies the course length as `short`, `medium` or `long` but we just change the footer from the regular text "Course" to "Short Course" when the course length is short. 

JIRA: [ENT-6372](https://2u-internal.atlassian.net/browse/ENT-6372)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
