### PR TITLE
feat: determine course price correctly for EE (2U) courses

### DIFF
--- a/src/components/course/CourseRunCards.jsx
+++ b/src/components/course/CourseRunCards.jsx
@@ -18,7 +18,12 @@ const CourseRunCards = () => {
     catalog: { catalogList },
   } = courseData;
 
-  const { course: { key } } = courseData;
+  const {
+    course: {
+      key,
+      entitlements: courseEntitlements,
+    },
+  } = courseData;
 
   return (
     <CardGrid columnSizes={{ sm: 12, lg: 5 }}>
@@ -30,6 +35,7 @@ const CourseRunCards = () => {
           courseRun={courseRun}
           catalogList={catalogList}
           userEntitlements={userEntitlements}
+          courseEntitlements={courseEntitlements}
           subsidyRequestCatalogsApplicableToCourse={subsidyRequestCatalogsApplicableToCourse}
         />
       ))}

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -22,11 +22,17 @@ export const INSUFFICIENT_ENTERPRISE_OFFER_BALANCE = 'Your organization doesn\'t
 const CourseSidebarPrice = () => {
   const { enterpriseConfig } = useContext(AppContext);
   const { state: courseData } = useContext(CourseContext);
-  const { activeCourseRun, userSubsidyApplicableToCourse } = courseData;
+  const {
+    activeCourseRun,
+    userSubsidyApplicableToCourse,
+    course: { entitlements: courseEntitlements },
+  } = courseData;
   const { subsidyRequestConfiguration } = useContext(SubsidyRequestsContext);
 
   const [coursePrice, currency] = useCoursePriceForUserSubsidy({
-    activeCourseRun, userSubsidyApplicableToCourse,
+    activeCourseRun,
+    userSubsidyApplicableToCourse,
+    courseEntitlements,
   });
 
   const {

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -30,6 +30,9 @@ const mockCourseData = {
     containsContentItems: true,
     catalogList: ['catalog-1'],
   },
+  courseDetails: {
+    entitlements: [],
+  },
 };
 
 const mockLicenseForCourse = {
@@ -245,7 +248,7 @@ describe('useAllCourseData', () => {
       });
     });
 
-    it('prefers offers with user bookings limit over global bookings limit', async () => {
+    it.only('prefers offers with user bookings limit over global bookings limit', async () => {
       const offers = [
         mockEnterpriseOffersForCourse.globalBookingsLimit,
         mockEnterpriseOffersForCourse.userBookingsLimit,
@@ -256,6 +259,8 @@ describe('useAllCourseData', () => {
         canEnrollWithEnterpriseOffers: true,
       }));
       await waitForNextUpdate();
+
+      console.log('RESULTS?!', result.current);
 
       expect(result.current.courseData).toEqual({
         ...mockCourseData,

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -340,6 +340,15 @@ export const createEnrollWithCouponCodeUrl = ({
   return `${config.ECOMMERCE_BASE_URL}/coupons/redeem/?${queryParams.toString()}`;
 };
 
+/**
+ * Determines the price of a course.
+ *
+ * @param {args} Arguments
+ * @param {object} args.activeCourseRun Metadata for the advertised course run, which includes
+ * a field for the first paid seat price.
+ * @param {array} args.courseEntitlements List of entitlements associated with the courses.
+ * @returns The price of the course as a number.
+ */
 export const getCoursePrice = ({ activeCourseRun, courseEntitlements }) => {
   let coursePrice;
   const { firstEnrollablePaidSeatPrice } = activeCourseRun || {};

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -339,3 +339,14 @@ export const createEnrollWithCouponCodeUrl = ({
 
   return `${config.ECOMMERCE_BASE_URL}/coupons/redeem/?${queryParams.toString()}`;
 };
+
+export const getCoursePrice = ({ activeCourseRun, courseEntitlements }) => {
+  let coursePrice;
+  const { firstEnrollablePaidSeatPrice } = activeCourseRun || {};
+  if (firstEnrollablePaidSeatPrice !== null) {
+    coursePrice = firstEnrollablePaidSeatPrice;
+  } else {
+    coursePrice = parseFloat(courseEntitlements[0]?.price);
+  }
+  return coursePrice;
+};


### PR DESCRIPTION
# Description

Due to the differences in metadata between Executive Education (2U) courses and regular OCM courses is where the correct product `sku` and `price` come from.

For regular OCM courses, these data were grabbed from the configured `seats` for the advertised course run, which included a paid seat. However, Executive Education (2U) content does not include a paid seat (it includes "unpaid-executive-education"), so we need to get its `sku` and `price` from the entitlements associated with the course instead.

This PR treats the entitlement `sku` and `price` as a fallback should no paid `sku` / `price` exists for the course's `seats`, which should be a generic enough solution to avoid needing to specifically handle "Executive Education (2U)" courses directly/conditionally.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
