### PR TITLE
fix: ensure to only fetch highlight sets for the current enterprise customer

### DIFF
--- a/src/components/search/content-highlights/ContentHighlights.jsx
+++ b/src/components/search/content-highlights/ContentHighlights.jsx
@@ -1,20 +1,21 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-
 import {
   Container, Stack,
 } from '@edx/paragon';
 import { getConfig } from '@edx/frontend-platform/config';
+import { AppContext } from '@edx/frontend-platform/react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { useContentHighlights } from './data';
 import ContentHighlightSet from './ContentHighlightSet';
 
 const ContentHighlights = ({ className }) => {
+  const { enterpriseConfig: { uuid: enterpriseUUID } } = useContext(AppContext);
   const {
     isLoading,
     contentHighlights,
-  } = useContentHighlights();
+  } = useContentHighlights(enterpriseUUID);
 
   if (!getConfig().FEATURE_CONTENT_HIGHLIGHTS) {
     return null;

--- a/src/components/search/content-highlights/data/hooks.js
+++ b/src/components/search/content-highlights/data/hooks.js
@@ -11,7 +11,7 @@ import {
   getContentPageUrl,
 } from './utils';
 
-export const useContentHighlights = () => {
+export const useContentHighlights = (enterpriseUUID) => {
   const [isLoading, setIsLoading] = useState(true);
   const [contentHighlights, setContentHighlights] = useState([]);
   const [fetchError, setFetchError] = useState();
@@ -20,7 +20,7 @@ export const useContentHighlights = () => {
     const fetchContentHighlights = async () => {
       try {
         setIsLoading(true);
-        const response = await getContentHighlights();
+        const response = await getContentHighlights(enterpriseUUID);
         const results = camelCaseObject(response.data.results);
         const highlightSetsWithContent = results.filter(highlightSet => highlightSet.highlightedContent.length > 0);
         setContentHighlights(highlightSetsWithContent);
@@ -34,7 +34,7 @@ export const useContentHighlights = () => {
     if (getConfig().FEATURE_CONTENT_HIGHLIGHTS) {
       fetchContentHighlights();
     }
-  }, []);
+  }, [enterpriseUUID]);
 
   return {
     isLoading,

--- a/src/components/search/content-highlights/data/service.js
+++ b/src/components/search/content-highlights/data/service.js
@@ -1,7 +1,10 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 
-export const getContentHighlights = () => {
-  const url = `${getConfig().ENTERPRISE_CATALOG_API_BASE_URL}/api/v1/highlight-sets/`;
+export const getContentHighlights = (enterpriseUUID) => {
+  const queryParams = new URLSearchParams({
+    enterprise_customer: enterpriseUUID,
+  });
+  const url = `${getConfig().ENTERPRISE_CATALOG_API_BASE_URL}/api/v1/highlight-sets/?${queryParams.toString()}`;
   return getAuthenticatedHttpClient().get(url);
 };


### PR DESCRIPTION
# Description

Only fetch the highlight sets for the current enterprise customer (like this PRs predecessor, we're deferring on tests until tomorrow as a fast follow; minimal risk).

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
