### PR TITLE
chore: upgrade @edx/paragon to v20.26.2 for Card.ImageCap fallback images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@edx/frontend-enterprise-logistration": "2.1.1",
         "@edx/frontend-enterprise-utils": "2.2.0",
         "@edx/frontend-platform": "2.6.2",
-        "@edx/paragon": "20.26.1",
+        "@edx/paragon": "20.26.2",
         "@fortawesome/fontawesome-svg-core": "1.2.32",
         "@fortawesome/free-brands-svg-icons": "5.15.1",
         "@fortawesome/free-regular-svg-icons": "5.15.1",
@@ -2770,9 +2770,9 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "20.26.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.26.1.tgz",
-      "integrity": "sha512-6PEKEt5BhPD4dMrJuyGUIniYg1dVMLCTAgP/7IBvFvZz1ePoabizr0ficTDN0jiJgEQFMCl8/qQkoryOSIt8FA==",
+      "version": "20.26.2",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.26.2.tgz",
+      "integrity": "sha512-Kby3lxkpHtGgYJ3qiPKuRPZVZouj71mUDNU/HduuuZnVahUSCmMXxmT6I3uao0isgLyH1+9Ki/kHiJ+145QkpA==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -21980,9 +21980,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "20.26.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.26.1.tgz",
-      "integrity": "sha512-6PEKEt5BhPD4dMrJuyGUIniYg1dVMLCTAgP/7IBvFvZz1ePoabizr0ficTDN0jiJgEQFMCl8/qQkoryOSIt8FA==",
+      "version": "20.26.2",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.26.2.tgz",
+      "integrity": "sha512-Kby3lxkpHtGgYJ3qiPKuRPZVZouj71mUDNU/HduuuZnVahUSCmMXxmT6I3uao0isgLyH1+9Ki/kHiJ+145QkpA==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@edx/frontend-enterprise-logistration": "2.1.1",
     "@edx/frontend-enterprise-utils": "2.2.0",
     "@edx/frontend-platform": "2.6.2",
-    "@edx/paragon": "20.26.1",
+    "@edx/paragon": "20.26.2",
     "@fortawesome/fontawesome-svg-core": "1.2.32",
     "@fortawesome/free-brands-svg-icons": "5.15.1",
     "@fortawesome/free-regular-svg-icons": "5.15.1",


### PR DESCRIPTION
Upgrades Paragon to v20.26.2 pull in new `Card` feature related to a default fallback image for the `Card.ImageCap` subcomponent ([docs/example](https://paragon-openedx.netlify.app/components/card/#with-default-fallback-image)).

<img width="651" alt="image" src="https://user-images.githubusercontent.com/2828721/211024500-3411b06c-4578-44f1-8674-c0811680a16a.png">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
