### PR TITLE
fix: use imported fallback img from @edx/brand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
+        "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@edx/frontend-component-footer": "11.6.0",
         "@edx/frontend-enterprise-catalog-search": "3.1.5",
         "@edx/frontend-enterprise-hotjar": "1.2.0",
@@ -2454,9 +2454,9 @@
     },
     "node_modules/@edx/brand": {
       "name": "@edx/brand-openedx",
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
-      "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.2.0.tgz",
+      "integrity": "sha512-r4PDN3rCgDsLovW44ayxoNNHgG5I4Rvss6MG5CrQEX4oW8YhQVEod+jJtwR5vi0mFLN2GIaMlDpd7iIy03VqXg=="
     },
     "node_modules/@edx/browserslist-config": {
       "version": "1.1.1",
@@ -21738,9 +21738,9 @@
       "dev": true
     },
     "@edx/brand": {
-      "version": "npm:@edx/brand-openedx@1.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
-      "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+      "version": "npm:@edx/brand-openedx@1.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.2.0.tgz",
+      "integrity": "sha512-r4PDN3rCgDsLovW44ayxoNNHgG5I4Rvss6MG5CrQEX4oW8YhQVEod+jJtwR5vi0mFLN2GIaMlDpd7iIy03VqXg=="
     },
     "@edx/browserslist-config": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "extends @edx/browserslist-config"
   ],
   "dependencies": {
-    "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
+    "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
     "@edx/frontend-component-footer": "11.6.0",
     "@edx/frontend-enterprise-catalog-search": "3.1.5",
     "@edx/frontend-enterprise-hotjar": "1.2.0",

--- a/src/components/search/content-highlights/HighlightedContentCard.jsx
+++ b/src/components/search/content-highlights/HighlightedContentCard.jsx
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Card } from '@edx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
+import cardImageCapFallbackSrc from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 
 import { useHighlightedContentCardData } from './data';
 
@@ -61,6 +62,7 @@ const HighlightedContentCard = ({
     >
       <Card.ImageCap
         src={cardImageUrl}
+        fallbackSrc={cardImageCapFallbackSrc}
         srcAlt=""
         logoSrc={authoringOrganizations?.logoImageUrl}
         logoAlt={`${authoringOrganizations?.content}'s logo`}


### PR DESCRIPTION
Instead of the default solid gray background for fallback image in `Card.ImageCap`, opts to use a more style version from the `@edx/brand` packages:

<img width="690" alt="image" src="https://user-images.githubusercontent.com/2828721/211073011-798adcc5-b148-4381-b2f9-25d35add882a.png">

**Note: Test coverage can be ignored; tests for highlights in this repo were intentionally deferred and will be done in a follow-up PR**

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
