### PR TITLE
fix: ensure learner portal works without curation config

### DIFF
--- a/src/components/enterprise-banner/EnterpriseBanner.jsx
+++ b/src/components/enterprise-banner/EnterpriseBanner.jsx
@@ -10,11 +10,10 @@ const EnterpriseBanner = () => {
   const { enterpriseConfig } = useContext(AppContext);
   const { enterpriseConfig: { uuid: enterpriseUUID } } = useContext(AppContext);
   const isSearchPage = `/${ enterpriseConfig.slug }/search` === location.pathname;
-  const {
-    enterpriseCuration: {
-      canOnlyViewHighlightSets,
-    },
-  } = useEnterpriseCuration(enterpriseUUID);
+
+  const { enterpriseCuration } = useEnterpriseCuration(enterpriseUUID);
+  const { canOnlyViewHighlightSets } = enterpriseCuration;
+
   return (
     <div className="enterprise-banner bg-brand-secondary border-brand-tertiary">
       <Container size="lg">

--- a/src/components/search/content-highlights/data/hooks.js
+++ b/src/components/search/content-highlights/data/hooks.js
@@ -57,7 +57,8 @@ export const useEnterpriseCuration = (enterpriseUUID) => {
         setIsLoading(true);
         const response = await getEnterpriseCuration(enterpriseUUID);
         const results = camelCaseObject(response.data.results);
-        const enterpriseCurationConfig = results[0];
+        // if no enterprise curation config is found, fallback to an empty object to match the initial state.
+        const enterpriseCurationConfig = results[0] || { canOnlyViewHighlightSets: false };
         setEnterpriseCuration(enterpriseCurationConfig);
       } catch (err) {
         logError(err);


### PR DESCRIPTION
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
