### PR TITLE
fix: handle current_job_id while saving skill quiz by learner

### DIFF
--- a/src/components/skills-quiz/SearchJobCard.jsx
+++ b/src/components/skills-quiz/SearchJobCard.jsx
@@ -9,7 +9,7 @@ import JobCardComponent from './JobCardComponent';
 
 const SearchJobCard = ({ index }) => {
   const { refinements } = useContext(SearchContext);
-  const { name: jobs } = refinements;
+  const { name: jobs, current_job: currentJob } = refinements;
   const [isLoading, setIsLoading] = useState(true);
   const { dispatch, state } = useContext(SkillsContext);
   const { interestedJobs } = state;
@@ -20,6 +20,13 @@ const SearchJobCard = ({ index }) => {
     }
     return jobsArray;
   }, [jobs]);
+  const jobToFetch = useMemo(() => {
+    const jobArray = [];
+    if (currentJob?.length > 0) {
+      jobArray.push(`name:${currentJob[0]}`);
+    }
+    return jobArray;
+  }, [currentJob]);
 
   useEffect(
     () => {
@@ -42,6 +49,22 @@ const SearchJobCard = ({ index }) => {
     },
     [dispatch, index, jobs, jobsToFetch],
   );
+  useEffect(() => {
+    let fetch = true;
+    if (currentJob) {
+      fetchJob(); // eslint-disable-line no-use-before-define
+    }
+    return () => { fetch = false; };
+    async function fetchJob() {
+      const { hits } = await index.search('', {
+        facetFilters: [
+          jobToFetch,
+        ],
+      });
+      if (!fetch) { return; }
+      dispatch({ type: SET_KEY_VALUE, key: 'currentJobRole', value: hits });
+    }
+  }, [dispatch, index, currentJob, jobToFetch]);
 
   return <JobCardComponent jobs={interestedJobs} isLoading={isLoading} />;
 };

--- a/src/components/skills-quiz/tests/SearchJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchJobCard.test.jsx
@@ -70,7 +70,7 @@ const testIndex = {
 };
 
 const initialSearchState = {
-  refinements: { name: [] },
+  refinements: { name: [], current_job: ['test-current-job'] },
   dispatch: () => null,
 };
 


### PR DESCRIPTION
**Problem**
while saving the skill quiz the current_job_id is not sending to the backend and is saved as null.

**Solution**
CurrentJobRole was only set when the goal was 'I want to improve my current role'. So I set the value of currentJobRole in other goals as well. Now, current_job_id is sending every time to the skill quiz endpoint.
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
