### PR TITLE
fix: Adds additional conditional for contentType

### DIFF
--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -92,8 +92,7 @@ const Search = () => {
   const shouldDisplayBalanceAlert = hasNoEnterpriseOffersBalance || hasLowEnterpriseOffersBalance;
 
   const { content_type: contentType } = refinements;
-  const hasRefinements = Object.keys(refinements).filter(refinement => refinement !== 'showAll').length > 0;
-
+  const hasRefinements = Object.keys(refinements).filter(refinement => refinement !== 'showAll').length > 0 && contentType?.length > 0;
   return (
     <>
       <Helmet title={PAGE_TITLE} />


### PR DESCRIPTION
Adds a conditional to `hasRefinements` to check `contentTypes` length individually on top of the current facet filters filter that exist

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
