### PR TITLE
feat: Allow job filtering on the basis of current industry

### DIFF
--- a/src/components/skills-quiz/IndustryDropdown.jsx
+++ b/src/components/skills-quiz/IndustryDropdown.jsx
@@ -15,12 +15,12 @@ const IndustryDropdown = () => {
       key={attribute}
       title={refinements[INDUSTRY_ATTRIBUTE_NAME]?.length > 0 ? refinements[INDUSTRY_ATTRIBUTE_NAME][0] : title}
       attribute={attribute}
+      defaultRefinement={refinements[INDUSTRY_ATTRIBUTE_NAME]}
       limit={300} // this is replicating the B2C search experience
       refinements={refinements}
       facetValueType={facetValueType}
       typeaheadOptions={typeaheadOptions}
       searchable={!!typeaheadOptions}
-      doRefinement={false}
       showBadge={false}
     />
   );


### PR DESCRIPTION
# For all changes
This PR allows the refinement of the jobs dropdown on the basis of the value selected In the Industry dropdown.
<img width="809" alt="Screen Shot 2023-03-14 at 12 28 47 PM" src="https://user-images.githubusercontent.com/11922730/224926718-fa48fc86-6da3-43fe-9123-b5e08db923b2.png">
<img width="864" alt="Screen Shot 2023-03-14 at 12 28 33 PM" src="https://user-images.githubusercontent.com/11922730/224926753-d813a66b-e3ed-418b-9de0-181a4387d95a.png">


- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
