### PR TITLE
ENT-6851: Redirect the user to search page if he is visiting dashboard for the very first time.

### DIFF
--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -18,6 +18,7 @@ import { useLearnerProgramsListData } from '../program-progress/data/hooks';
 import { useInProgressPathwaysData } from '../pathway-progress/data/hooks';
 import CoursesTabComponent from './main-content/CoursesTabComponent';
 import { MyCareerTab } from '../my-career';
+import EnterpriseLearnerFirstVisitRedirect from '../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect';
 
 const DashboardPage = () => {
   const { state } = useLocation();
@@ -51,6 +52,7 @@ const DashboardPage = () => {
         <h2 className="h1 mb-4 mt-4">
           {userFirstName ? `Welcome, ${userFirstName}!` : 'Welcome!'}
         </h2>
+        <EnterpriseLearnerFirstVisitRedirect />
         <Tabs defaultActiveKey="courses">
           <Tab eventKey="courses" title="Courses">
             <CoursesTabComponent canOnlyViewHighlightSets={canOnlyViewHighlightSets} />

--- a/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
+++ b/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+import { Redirect } from 'react-router-dom';
+import Cookies from 'universal-cookie';
+import { getConfig } from '@edx/frontend-platform/config';
+
+import { isExperimentVariant } from '../../utils/optimizely';
+
+const EnterpriseLearnerFirstVisitRedirect = () => {
+  const cookies = new Cookies();
+  const config = getConfig();
+
+  const isFirstVisit = () => {
+    const hasUserVisitedDashboard = cookies.get('has-user-visited-learner-dashboard');
+    return !hasUserVisitedDashboard;
+  };
+
+  const isExperimentVariationA = isExperimentVariant(
+    config.EXPERIMENT_4_ID,
+    config.EXPERIMENT_4_VARIANT_1_ID,
+  );
+
+  useEffect(() => {
+    if (isFirstVisit() && isExperimentVariationA) {
+      cookies.set('has-user-visited-learner-dashboard', true, { path: '/' });
+    }
+  });
+
+  if (isFirstVisit() && isExperimentVariationA) {
+    return <Redirect to="/r/search" />;
+  }
+
+  return null;
+};
+
+export default EnterpriseLearnerFirstVisitRedirect;

--- a/src/components/enterprise-redirects/tests/EnterpriseLearnerFirstVisitRedirect.test.jsx
+++ b/src/components/enterprise-redirects/tests/EnterpriseLearnerFirstVisitRedirect.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import Cookies from 'universal-cookie';
+
+import { renderWithRouter } from '../../../utils/tests';
+import EnterpriseLearnerFirstVisitRedirect from '../EnterpriseLearnerFirstVisitRedirect';
+import * as optimizelyUtils from '../../../utils/optimizely';
+
+const COOKIE_NAME = 'has-user-visited-learner-dashboard';
+const TEST_ENTERPRISE = {
+  uuid: 'some-fake-uuid',
+  name: 'Test Enterprise',
+  slug: 'test-enterprise',
+};
+
+describe('<EnterpriseLearnerFirstVisitRedirect />', () => {
+  beforeEach(() => {
+    const cookies = new Cookies();
+    cookies.remove(COOKIE_NAME);
+  });
+
+  test('redirects to search if user is visiting for the first time.', async () => {
+    jest.spyOn(optimizelyUtils, 'isExperimentVariant').mockImplementation(() => true);
+
+    const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirect />, { route: `/${TEST_ENTERPRISE.slug}` });
+    expect(history.location.pathname).toEqual('/r/search');
+  });
+
+  test('Does not redirect the returning user to search.', async () => {
+    jest.spyOn(optimizelyUtils, 'isExperimentVariant').mockImplementation(() => true);
+
+    // Simulate a returning user by setting the cookie.
+    const cookies = new Cookies();
+    cookies.set(COOKIE_NAME, true);
+
+    const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirect />, { route: `/${TEST_ENTERPRISE.slug}` });
+    expect(history.location.pathname).toEqual(`/${TEST_ENTERPRISE.slug}`);
+  });
+
+  test('Does not redirect user to search if experiment is disabled even if user is visiting for the first time.', async () => {
+    jest.spyOn(optimizelyUtils, 'isExperimentVariant').mockImplementation(() => false);
+
+    const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirect />, { route: `/${TEST_ENTERPRISE.slug}` });
+    expect(history.location.pathname).toEqual(`/${TEST_ENTERPRISE.slug}`);
+  });
+
+  test('Does not redirect the returning user to search if experiment is disabled.', async () => {
+    jest.spyOn(optimizelyUtils, 'isExperimentVariant').mockImplementation(() => false);
+
+    // Simulate a returning user by setting the cookie.
+    const cookies = new Cookies();
+    cookies.set(COOKIE_NAME, true);
+
+    const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirect />, { route: `/${TEST_ENTERPRISE.slug}` });
+    expect(history.location.pathname).toEqual(`/${TEST_ENTERPRISE.slug}`);
+  });
+});

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -50,6 +50,8 @@ initialize({
         EXPERIMENT_3_ID: process.env.EXPERIMENT_3_ID || null,
         EXPERIMENT_3_VARIANT_1_ID: process.env.EXPERIMENT_3_VARIANT_1_ID || null,
         FEATURE_CONTENT_HIGHLIGHTS: process.env.FEATURE_CONTENT_HIGHLIGHTS || null,
+        EXPERIMENT_4_ID: process.env.EXPERIMENT_4_ID || null,
+        EXPERIMENT_4_VARIANT_1_ID: process.env.EXPERIMENT_4_VARIANT_1_ID || null,
       });
     },
   },


### PR DESCRIPTION
__Jira Ticket:__ [ENT-6851](https://2u-internal.atlassian.net/browse/ENT-6851)

__Description:__
IF a learner on their first visit to their enterprise’s learner portal is redirected to the /search page, THEN they will be more likely to enroll, BECAUSE the /search page has the most to offer learners who are entering their organization’s learner portal for the first time.

**Acceptance Criteria:**

1. Detect if this is the user’s first visit to the learner portal.
2. Detect if the page they are going to is the learner dashboard page.
3. If both are true, redirect the learner to the learner portal /search page. 
4. Upon subsequent, future logins, no redirect should happen. It is only on the first time that we redirect.
5. This should be implemented as a 50/50 split in Optimizely.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
