### PR TITLE
ENT-7035: Sending an optimizely event for first time visiting learner.

### DIFF
--- a/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
+++ b/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
@@ -1,13 +1,17 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Redirect } from 'react-router-dom';
 import Cookies from 'universal-cookie';
 import { getConfig } from '@edx/frontend-platform/config';
 
-import { isExperimentVariant } from '../../utils/optimizely';
+import { AppContext } from '@edx/frontend-platform/react';
+import { EVENTS, isExperimentVariant, pushEvent } from '../../utils/optimizely';
 
 const EnterpriseLearnerFirstVisitRedirect = () => {
   const cookies = new Cookies();
   const config = getConfig();
+
+  const { authenticatedUser } = useContext(AppContext);
+  const { username } = authenticatedUser;
 
   const isFirstVisit = () => {
     const hasUserVisitedDashboard = cookies.get('has-user-visited-learner-dashboard');
@@ -20,8 +24,9 @@ const EnterpriseLearnerFirstVisitRedirect = () => {
   );
 
   useEffect(() => {
-    if (isFirstVisit() && isExperimentVariationA) {
+    if (isFirstVisit()) {
       cookies.set('has-user-visited-learner-dashboard', true, { path: '/' });
+      pushEvent(EVENTS.ENTERPRISE_LEARNER_FIRST_VISIT_TO_DASHBOARD, { username });
     }
   });
 

--- a/src/utils/optimizely.js
+++ b/src/utils/optimizely.js
@@ -1,6 +1,7 @@
 export const EVENTS = {
   ENROLLMENT_CLICK: 'enterprise_learner_portal_enrollment_click',
   FIRST_ENROLLMENT_CLICK: 'enterprise_learner_portal_first_enrollment_click',
+  ENTERPRISE_LEARNER_FIRST_VISIT_TO_DASHBOARD: 'enterprise_learner_portal_first_visit_to_dashboard',
 };
 
 export const getActiveExperiments = () => {


### PR DESCRIPTION
__Jira Ticket:__ [ENT-7035](https://2u-internal.atlassian.net/browse/ENT-7035)

__Description:__
We added an experiment in Optimizely to see the impact of redirecting first time visitor from dashboard to search page. But without a way to identify the first time learner visit on the Optimizely side we can not make sense of the data. We need to fire an event when a first time learner lands on the dashboard page. 
 
**Acceptance Criteria:**

1. Optimizely event is fired for each first time learner on the dashboard.
2. Update the experiment in Optimizely to handle the new event.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
