### PR TITLE
feat: add exec ed no remaining applications failure message. ENT-7059

### DIFF
--- a/src/components/executive-education-2u/ExecutiveEducation2UError.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UError.jsx
@@ -15,8 +15,9 @@ const ExecutiveEducation2UError = ({ failureReason, httpReferrer }) => {
   const createExecutiveEducationFailureMessage = (failureCode) => {
     const failureCodeMessages = {
       no_offer_available: 'No offer is available to cover this course.',
-      no_offer_with_enough_balance: 'Your organization doesn’t have sufficient balance to cover this course.',
-      no_offer_with_enough_user_balance: 'You don’t have sufficient balance to cover this course.',
+      no_offer_with_enough_balance: 'Your enrollment was not completed! Your organization does not have remaining credit.',
+      no_offer_with_enough_user_balance: 'Your enrollment was not completed! You have already spent your personal budget for enrollments.',
+      no_offer_with_remaining_applications: 'Your enrollment was not completed! You have reached your maximum number of allowed enrollments.',
       system_error: 'System Error has occured.',
       default: 'An error has occured.',
     };

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.test.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.test.jsx
@@ -154,7 +154,43 @@ describe('ExecutiveEducation2UPage', () => {
     renderWithRouter(<ExecutiveEducation2UPageWrapper />);
     expect(screen.queryByText('404')).not.toBeInTheDocument();
     expect(screen.queryByText('Return to your learning platform')).not.toBeInTheDocument();
-    expect(screen.getByText('Your organization doesn’t have sufficient balance to cover this course.')).toBeInTheDocument();
+    expect(screen.getByText('Your enrollment was not completed! Your organization does not have remaining credit.')).toBeInTheDocument();
+  });
+
+  it('renders error page with valid user balance failure message', () => {
+    useExecutiveEducation2UContentMetadata.mockReturnValue({
+      isLoading: false,
+      contentMetadata: undefined,
+    });
+    const searchParams = new URLSearchParams({
+      course_uuid: 'test-course-uuid',
+      sku: 'ABC123',
+      failure_reason: 'no_offer_with_enough_user_balance',
+    });
+    useActiveQueryParams.mockImplementation(() => searchParams);
+
+    renderWithRouter(<ExecutiveEducation2UPageWrapper />);
+    expect(screen.queryByText('404')).not.toBeInTheDocument();
+    expect(screen.queryByText('Return to your learning platform')).not.toBeInTheDocument();
+    expect(screen.getByText('Your enrollment was not completed! You have already spent your personal budget for enrollments.')).toBeInTheDocument();
+  });
+
+  it('renders error page with valid no remaining applications failure message', () => {
+    useExecutiveEducation2UContentMetadata.mockReturnValue({
+      isLoading: false,
+      contentMetadata: undefined,
+    });
+    const searchParams = new URLSearchParams({
+      course_uuid: 'test-course-uuid',
+      sku: 'ABC123',
+      failure_reason: 'no_offer_with_remaining_applications',
+    });
+    useActiveQueryParams.mockImplementation(() => searchParams);
+
+    renderWithRouter(<ExecutiveEducation2UPageWrapper />);
+    expect(screen.queryByText('404')).not.toBeInTheDocument();
+    expect(screen.queryByText('Return to your learning platform')).not.toBeInTheDocument();
+    expect(screen.getByText('Your enrollment was not completed! You have reached your maximum number of allowed enrollments.')).toBeInTheDocument();
   });
 
   it('renders error page with invalid failure_reason', () => {


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-7059
Added new message for not enough applications (enrollments) remaining, updated existing balance messages to be consistent with message pattern.

Not enough remaining applications
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/2307986/232150808-a698f0f6-b113-4ada-a9b8-e5405cc3f590.png">

Not enough balance
<img width="1314" alt="image" src="https://user-images.githubusercontent.com/2307986/232150942-6fe47f89-e3ac-4a5b-a8e9-4f2a63e1e13f.png">

Not enough user balance
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/2307986/232151084-ebbde57d-7af0-4229-b829-136517b1d61c.png">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
