### PR TITLE
fix: Do not let the user pass if age is not valid.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "react-router-dom": "5.2.0",
         "react-router-hash-link": "2.3.1",
         "react-scroll": "1.8.4",
+        "react-string-replace": "^1.1.0",
         "react-transition-group": "4.4.1",
         "react-truncate": "2.4.0",
         "redux": "4.0.5",
@@ -16352,6 +16353,14 @@
         "react": "^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/react-string-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-string-replace/-/react-string-replace-1.1.0.tgz",
+      "integrity": "sha512-N6RalSDFGbOHs0IJi1H611WbZsvk3ZT47Jl2JEXFbiS3kTwsdCYij70Keo/tWtLy7sfhDsYm7CwNM/WmjXIaMw==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.0.tgz",
@@ -32537,6 +32546,11 @@
       "requires": {
         "shallowequal": "^1.0.1"
       }
+    },
+    "react-string-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-string-replace/-/react-string-replace-1.1.0.tgz",
+      "integrity": "sha512-N6RalSDFGbOHs0IJi1H611WbZsvk3ZT47Jl2JEXFbiS3kTwsdCYij70Keo/tWtLy7sfhDsYm7CwNM/WmjXIaMw=="
     },
     "react-style-singleton": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-router-dom": "5.2.0",
     "react-router-hash-link": "2.3.1",
     "react-scroll": "1.8.4",
+    "react-string-replace": "^1.1.0",
     "react-transition-group": "4.4.1",
     "react-truncate": "2.4.0",
     "redux": "4.0.5",

--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
-  StatefulButton, Form, Hyperlink, CheckboxControl, Row, Col, Alert, Card,
+  StatefulButton, Form, Hyperlink, CheckboxControl, Row, Col, Alert, Card, MailtoLink,
 } from '@edx/paragon';
 import {
   Formik,
@@ -12,14 +12,18 @@ import { logError } from '@edx/frontend-platform/logging';
 import { getConfig } from '@edx/frontend-platform/config';
 import { sendEnterpriseTrackEvent, sendEnterpriseTrackEventWithDelay } from '@edx/frontend-enterprise-utils';
 import moment from 'moment/moment';
+import reactStringReplace from 'react-string-replace';
+
 import { checkoutExecutiveEducation2U, toISOStringWithoutMilliseconds } from './data';
 
 export const formValidationMessages = {
   firstNameRequired: 'First name is required',
   lastNameRequired: 'Last name is required',
   dateOfBirthRequired: 'Date of birth is required',
-  invalidDateOfBirth: 'Unfortunately you don\'t meet the minimum age requirement of 18 years and without any'
-    + ' parent or guardian consent you cannot proceed with your registration.',
+  invalidDateOfBirth:
+    'The date of birth you entered indicates that you are under the age of 18, and we need your parent or legal '
+    + 'guardian to consent to your registration and GetSmarter processing your personal information. '
+    + 'Please reach out to privacy@getsmarter.com to proceed with your registration.',
   studentTermsAndConditionsRequired: 'Please agree to Terms and Conditions for Students',
   dataSharingConsentRequired: 'Please agree to Terms and Conditions for Date Sharing Consent',
 };
@@ -209,7 +213,15 @@ const UserEnrollmentForm = ({
                         />
                         {errors.dateOfBirth && isFormSubmitted && (
                           <Form.Control.Feedback type="invalid">
-                            {errors.dateOfBirth}
+                            {
+                              reactStringReplace(
+                                errors.dateOfBirth,
+                                'privacy@getsmarter.com',
+                                (match) => (
+                                  <MailtoLink to={match}>{match}</MailtoLink>
+                                ),
+                              )
+                            }
                           </Form.Control.Feedback>
                         )}
                       </Form.Group>

--- a/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
@@ -255,8 +255,12 @@ describe('UserEnrollmentForm', () => {
     userEvent.click(screen.getByLabelText(dataSharingConsentLabelText));
     userEvent.click(screen.getByText('Confirm registration'));
 
+    const invalidAgeErrorMessage = 'The date of birth you entered indicates '
+      + 'that you are under the age of 18, and we need your parent or legal '
+      + 'guardian to consent to your registration and GetSmarter processing '
+      + 'your personal information.';
     await waitFor(() => {
-      expect(screen.getByText(formValidationMessages.invalidDateOfBirth)).toBeInTheDocument();
+      expect(screen.getByText(invalidAgeErrorMessage, { exact: false })).toBeInTheDocument();
       expect(checkoutExecutiveEducation2U).toHaveBeenCalledTimes(0);
     });
     expect(mockOnCheckoutSuccess).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
__Description:__

If user is not 18 years old then we should block the user from moving forward with course enrollment and do not allow him to simply update the age.

Here is the screenshot of the new error screen.
![screencapture-localhost-8734-test-enterprise-executive-education-2u-2023-04-18-15_00_11](https://user-images.githubusercontent.com/7114956/232743155-87371b71-6121-417e-9760-c5baa35cbd7d.png)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
