### PR TITLE
feat: include offers with per-user limits

### DIFF
--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/service.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/service.js
@@ -7,8 +7,6 @@ export function fetchEnterpriseOffers(enterpriseId, options = {
   discount_value: 100,
   status: ENTERPRISE_OFFER_STATUS.OPEN,
   is_current: true,
-  max_user_applications__isnull: true, // We won't handle offers with per user limits for MVP
-  max_user_discount__isnull: true, // Remove filter when we're ready to support per user limit
 }) {
   const queryParams = new URLSearchParams({
     ...options,

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/service.test.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/service.test.js
@@ -23,8 +23,6 @@ describe('fetchEnterpriseOffers', () => {
       discount_value: 100,
       status: ENTERPRISE_OFFER_STATUS.OPEN,
       is_current: true,
-      max_user_applications__isnull: true,
-      max_user_discount__isnull: true,
     });
     const url = `${config.ECOMMERCE_BASE_URL}/api/v2/enterprise/${TEST_ENTERPRISE_UUID}/enterprise-learner-offers/?${queryParams.toString()}`;
     fetchEnterpriseOffers(TEST_ENTERPRISE_UUID);


### PR DESCRIPTION
# Description

Removes per-user balance/enrollment limit filter from the API request. This will start pulling in enterprise offers with the per-user balance/enrollment limits, though we don't have any validation for these per-user limits. This will result in learners seemingly able to enroll with their learner credit, but will get an error (TBD) in ecommerce after confirming their enrollment.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
