### PR TITLE
fix: use `isInitialLoading` instead of using `isLoading || isFetching`

### DIFF
--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -72,7 +72,7 @@ const CoursePage = () => {
     courseData,
     courseRecommendations,
     fetchError,
-    isLoading,
+    isLoadingCourseData,
   } = useAllCourseData({
     courseKey,
     enterpriseConfig,
@@ -85,21 +85,17 @@ const CoursePage = () => {
   });
 
   const {
-    isLoading: isLoadingAccessPolicyRedemptionStatus,
-    isFetching: isFetchingAccessPolicyRedemptionStatus,
+    isInitialLoading: isLoadingAccessPolicyRedemptionStatus,
     data: accessPolicyRedemptionEligibilityData,
   } = useCheckAccessPolicyRedemptionEligibility({
     courseRunKeys: courseData?.courseDetails.courseRunKeys || [],
   });
-  const isLoadingAccessPolicyRedemptionEligibility = (
-    isLoadingAccessPolicyRedemptionStatus || isFetchingAccessPolicyRedemptionStatus
-  );
   const isPolicyRedemptionEnabled = checkPolicyRedemptionEnabled({ accessPolicyRedemptionEligibilityData });
 
   const initialState = useMemo(
     () => {
       const isLoadingAny = (
-        isLoading || isLoadingAccessPolicyRedemptionEligibility
+        isLoadingCourseData || isLoadingAccessPolicyRedemptionStatus
       );
       if (isLoadingAny || !courseData || !courseRecommendations) {
         return undefined;
@@ -131,8 +127,8 @@ const CoursePage = () => {
       };
     },
     [
-      isLoading,
-      isLoadingAccessPolicyRedemptionEligibility,
+      isLoadingCourseData,
+      isLoadingAccessPolicyRedemptionStatus,
       courseData,
       courseRecommendations,
       algoliaSearchParams,
@@ -144,7 +140,7 @@ const CoursePage = () => {
     return <ErrorPage message={fetchError.message} />;
   }
 
-  if (isLoading || !initialState) {
+  if (!initialState) {
     return (
       <Container size="lg" className="py-5">
         <LoadingSpinner screenReaderText="loading course" />

--- a/src/components/course/tests/CoursePage.test.jsx
+++ b/src/components/course/tests/CoursePage.test.jsx
@@ -17,8 +17,7 @@ jest.mock('@edx/frontend-enterprise-utils', () => ({
 }));
 jest.mock('../data/hooks', () => ({
   useCheckAccessPolicyRedemptionEligibility: jest.fn(() => ({
-    isLoading: false,
-    isFetching: false,
+    isInitialLoading: false,
     data: [],
   })),
   useAllCourseData: jest.fn(() => ({


### PR DESCRIPTION
# Description

Use `isInitialLoading` ([docs](https://tanstack.com/query/v4/docs/react/guides/disabling-queries#isinitialloading)) instead. 

If the query isn't enabled, `isLoading: true` will always be returned but `isFetching` will be false. `isInitialLoading` takes into account both of these with an `&&` instead of the previous implementation's `||`.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
