### PR TITLE
fix: add max prop to date Form.Control for date of birth

### DIFF
--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -210,6 +210,7 @@ const UserEnrollmentForm = ({
                           placeholder="mm/dd/yyyy"
                           onChange={handleChange}
                           onBlur={handleBlur}
+                          max={new Date().toISOString().split('T')[0]} // only allow before or on today's date
                         />
                         {errors.dateOfBirth && isFormSubmitted && (
                           <Form.Control.Feedback type="invalid">


### PR DESCRIPTION
Enforces a max date allowed on the native browser date picker input field, where dates beyond today's date are disabled on the selection. Usability improvement.

<img width="1178" alt="image" src="https://user-images.githubusercontent.com/2828721/235911464-b04902ea-03f4-4e14-90c4-b1c68661db72.png">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
