### PR TITLE
fix: use NO_SUBSIDY_NO_ADMINS reason type when no admins exist

### DIFF
--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -775,7 +775,12 @@ export const useUserSubsidyApplicableToCourse = ({
           }),
         });
       } else if (!applicableUserSubsidy) {
-        let reasonType = DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY;
+        let reasonType = DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY_NO_ADMINS;
+        if (enterpriseAdminUsers?.length > 0) {
+          reasonType = DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY;
+        }
+        // set reason type as content not in catalog if course is contained
+        // within any of the enterprise customer's catalog(s).
         if (!containsContentItems) {
           reasonType = DISABLED_ENROLL_REASON_TYPES.CONTENT_NOT_IN_CATALOG;
         }

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -1068,6 +1068,36 @@ describe('useUserSubsidyApplicableToCourse', () => {
     });
   });
 
+  it.each([
+    { enterpriseAdminUsers: [] },
+    { enterpriseAdminUsers: ['edx@example.com'] },
+  ])('does not have redeemable subsidy access policy and catalog(s) contains course (%s)', async ({ enterpriseAdminUsers }) => {
+    const args = {
+      ...baseArgs,
+      enterpriseAdminUsers,
+    };
+    const { result, waitForNextUpdate } = renderHook(() => useUserSubsidyApplicableToCourse(args));
+
+    await waitForNextUpdate();
+
+    let expectedReasonType = DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY_NO_ADMINS;
+    let expectedAction = null;
+
+    if (enterpriseAdminUsers.length > 0) {
+      expectedReasonType = DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY;
+      expectedAction = expect.any(Object);
+    }
+
+    expect(result.current).toEqual({
+      userSubsidyApplicableToCourse: undefined,
+      missingUserSubsidyReason: {
+        reason: expectedReasonType,
+        userMessage: DISABLED_ENROLL_USER_MESSAGES[expectedReasonType],
+        actions: expectedAction,
+      },
+    });
+  });
+
   it('does not have redeemable subsidy access policy and has missing subsidy access policy user message', async () => {
     const args = {
       ...baseArgs,


### PR DESCRIPTION
Ensure the "no enterprise admins" variant of the "org out of funds" message is shown for legacy subsidies like enterprise offers, e.g.: 

<img width="186" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/ec4c39d2-3ed6-46a8-8b31-418235149406">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
