### PR TITLE
fix: handle undefined `redeemabilityPerContentKey`

### DIFF
--- a/src/components/course/course-header/CourseRunCards.jsx
+++ b/src/components/course/course-header/CourseRunCards.jsx
@@ -29,7 +29,7 @@ const CourseRunCards = () => {
       hasEqualColumnHeights={false}
     >
       {availableCourseRuns.map((courseRun) => {
-        const redeemabilityForContentKey = redeemabilityPerContentKey.find(r => r.contentKey === courseRun.key);
+        const redeemabilityForContentKey = redeemabilityPerContentKey?.find(r => r.contentKey === courseRun.key);
         const redeemableSubsidyAccessPolicy = redeemabilityForContentKey?.redeemableSubsidyAccessPolicy;
 
         if (redeemableSubsidyAccessPolicy || missingUserSubsidyReason?.userMessage) {


### PR DESCRIPTION
In the case of production, the EMET feature flag is disabled so we are not making an API request to enterprise-access's `can-redeem` API endpoint. As such `redeemabilityPerContentKey` is undefined, but we are attempting to do a `.find` on it instead of handling the case when its `undefined`.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
