### PR TITLE
fix: ensure new CourseRunCard interacts well with Browse and Request

### DIFF
--- a/src/components/course/CourseContextProvider.jsx
+++ b/src/components/course/CourseContextProvider.jsx
@@ -1,5 +1,5 @@
 import React, {
-  createContext, useReducer, useMemo, useContext,
+  createContext, useReducer, useMemo,
 } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -11,7 +11,6 @@ import {
   LICENSE_SUBSIDY_TYPE,
   SET_COURSE_RUN,
 } from './data/constants';
-import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 
 export const CourseContext = createContext();
 
@@ -114,6 +113,8 @@ CourseContextProvider.propTypes = {
       }),
     })),
   })),
+  subsidyRequestCatalogsApplicableToCourse: PropTypes.instanceOf(Set),
+  userCanRequestSubsidyForCourse: PropTypes.bool,
   coursePrice: PropTypes.shape({
     list: PropTypes.number,
     discounted: PropTypes.number,
@@ -126,6 +127,8 @@ CourseContextProvider.defaultProps = {
   missingUserSubsidyReason: undefined,
   userSubsidyApplicableToCourse: undefined,
   redeemabilityPerContentKey: undefined,
+  subsidyRequestCatalogsApplicableToCourse: undefined,
+  userCanRequestSubsidyForCourse: false,
   coursePrice: undefined,
   currency: undefined,
 };

--- a/src/components/course/CourseContextProvider.jsx
+++ b/src/components/course/CourseContextProvider.jsx
@@ -31,25 +31,17 @@ export const CourseContextProvider = ({
   missingUserSubsidyReason,
   userSubsidyApplicableToCourse,
   redeemabilityPerContentKey,
+  subsidyRequestCatalogsApplicableToCourse,
+  userCanRequestSubsidyForCourse,
   coursePrice,
   currency,
 }) => {
-  const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
   const [state, dispatch] = useReducer(reducer, initialCourseState);
-
-  const { catalog } = state;
-
-  const subsidyRequestCatalogsApplicableToCourse = useMemo(() => {
-    const catalogsContainingCourse = new Set(catalog.catalogList);
-    const subsidyRequestCatalogIntersection = new Set(
-      catalogsForSubsidyRequests.filter(el => catalogsContainingCourse.has(el)),
-    );
-    return subsidyRequestCatalogIntersection;
-  }, [catalog, catalogsForSubsidyRequests]);
 
   const value = useMemo(() => ({
     state,
     dispatch,
+    userCanRequestSubsidyForCourse,
     subsidyRequestCatalogsApplicableToCourse,
     isPolicyRedemptionEnabled,
     missingUserSubsidyReason,
@@ -59,6 +51,7 @@ export const CourseContextProvider = ({
     currency,
   }), [
     state,
+    userCanRequestSubsidyForCourse,
     subsidyRequestCatalogsApplicableToCourse,
     isPolicyRedemptionEnabled,
     missingUserSubsidyReason,

--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -33,6 +33,7 @@ import {
   getCourseTypeConfig,
   getEntitlementPrice,
 } from './data/utils';
+import { canUserRequestSubsidyForCourse } from './enrollment/utils';
 
 import NotFoundPage from '../NotFoundPage';
 import { CourseEnrollmentsContextProvider } from '../dashboard/main-content/course-enrollments';
@@ -56,7 +57,7 @@ const CoursePage = () => {
     enterpriseOffers,
     canEnrollWithEnterpriseOffers,
   } = useContext(UserSubsidyContext);
-  const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
+  const { catalogsForSubsidyRequests, subsidyRequestConfiguration } = useContext(SubsidyRequestsContext);
 
   const {
     enterpriseCuration: {
@@ -215,6 +216,20 @@ const CoursePage = () => {
     }
   }, [enterpriseSlug, history, courseState, pathname]);
 
+  const subsidyRequestCatalogsApplicableToCourse = useMemo(() => {
+    const catalogsContainingCourse = new Set(courseState?.catalog?.catalogList);
+    const subsidyRequestCatalogIntersection = new Set(
+      catalogsForSubsidyRequests.filter(el => catalogsContainingCourse.has(el)),
+    );
+    return subsidyRequestCatalogIntersection;
+  }, [courseState?.catalog?.catalogList, catalogsForSubsidyRequests]);
+
+  const userCanRequestSubsidyForCourse = canUserRequestSubsidyForCourse({
+    subsidyRequestConfiguration,
+    subsidyRequestCatalogsApplicableToCourse,
+    userSubsidyApplicableToCourse,
+  });
+
   if (error) {
     return <ErrorPage message={error.message} />;
   }
@@ -244,6 +259,8 @@ const CoursePage = () => {
           userSubsidyApplicableToCourse={userSubsidyApplicableToCourse}
           isPolicyRedemptionEnabled={isPolicyRedemptionEnabled}
           redeemabilityPerContentKey={redeemabilityPerContentKey}
+          userCanRequestSubsidyForCourse={userCanRequestSubsidyForCourse}
+          subsidyRequestCatalogsApplicableToCourse={subsidyRequestCatalogsApplicableToCourse}
           coursePrice={coursePrice}
           currency={currency}
         >

--- a/src/components/course/course-header/CourseRunCard.jsx
+++ b/src/components/course/course-header/CourseRunCard.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Card } from '@edx/paragon';
 
 import { CourseContext } from '../CourseContextProvider';
@@ -20,6 +21,7 @@ const CourseRunCard = ({
       userEnrollments,
     },
     missingUserSubsidyReason,
+    userCanRequestSubsidyForCourse,
   } = useContext(CourseContext);
 
   const userEnrollmentForCourseRun = findUserEnrollmentForCourseRun({
@@ -33,23 +35,29 @@ const CourseRunCard = ({
     action,
   } = useCourseRunCardData({
     courseRun,
-    subsidyAccessPolicy,
     userEnrollment: userEnrollmentForCourseRun,
     courseRunUrl: userEnrollmentForCourseRun?.courseRunUrl,
+    userCanRequestSubsidyForCourse,
+    subsidyAccessPolicy,
   });
 
   return (
     <Card>
-      <Card.Section>
-        <div className="text-center">
-          <div className="h4 mb-0">{heading}</div>
-          <p className="small">{subHeading}</p>
-          {action}
-        </div>
+      <Card.Section className="text-center">
+        <div className="h4 mb-0">{heading}</div>
+        <p
+          className={classNames('small', {
+            'mb-0': userCanRequestSubsidyForCourse,
+          })}
+        >
+          {subHeading}
+        </p>
+        {action}
       </Card.Section>
       <CourseRunCardStatus
         isUserEnrolled={!!userEnrollmentForCourseRun}
         missingUserSubsidyReason={missingUserSubsidyReason}
+        userCanRequestSubsidyForCourse={userCanRequestSubsidyForCourse}
       />
     </Card>
   );

--- a/src/components/course/course-header/CourseRunCardStatus.jsx
+++ b/src/components/course/course-header/CourseRunCardStatus.jsx
@@ -19,16 +19,21 @@ import { DISABLED_ENROLL_REASON_TYPES } from '../data/constants';
  * @param {object} args.missingUserSubsidyReason An object containing a reason slug and user
  * @param {object} args.isUserEnrolled Whether the learner is already enrolled in the course run.
  *   message for why there is no redeemable subsidy for the course.
+ * @param {boolean} args.userCanRequestSubsidyForCourse Whether the user can request a subsidy for the course.
  *
  * @returns Card.Status component with appropriate message and actions.
  */
-const CourseRunCardStatus = ({ missingUserSubsidyReason, isUserEnrolled }) => {
+const CourseRunCardStatus = ({
+  missingUserSubsidyReason,
+  isUserEnrolled,
+  userCanRequestSubsidyForCourse,
+}) => {
   const missingUserSubsidyReasonType = missingUserSubsidyReason?.reason;
   const missingUserSubsidyReasonUserMessage = missingUserSubsidyReason?.userMessage;
   const missingUserSubsidyReasonActions = missingUserSubsidyReason?.actions;
 
   const hasValidReason = !!(missingUserSubsidyReasonType && missingUserSubsidyReasonUserMessage);
-  if (isUserEnrolled || !hasValidReason) {
+  if (isUserEnrolled || !hasValidReason || userCanRequestSubsidyForCourse) {
     return null;
   }
 
@@ -52,11 +57,13 @@ CourseRunCardStatus.propTypes = {
     userMessage: PropTypes.string,
     actions: PropTypes.node,
   }),
+  userCanRequestSubsidyForCourse: PropTypes.bool,
 };
 
 CourseRunCardStatus.defaultProps = {
   isUserEnrolled: false,
   missingUserSubsidyReason: undefined,
+  userCanRequestSubsidyForCourse: false,
 };
 
 export default CourseRunCardStatus;

--- a/src/components/course/course-header/CourseRunCards.jsx
+++ b/src/components/course/course-header/CourseRunCards.jsx
@@ -18,7 +18,6 @@ const CourseRunCards = () => {
       course: { key, entitlements: courseEntitlements },
       catalog: { catalogList },
     },
-    subsidyRequestCatalogsApplicableToCourse,
     missingUserSubsidyReason,
     redeemabilityPerContentKey,
   } = useContext(CourseContext);
@@ -49,7 +48,6 @@ const CourseRunCards = () => {
             courseRun={courseRun}
             catalogList={catalogList}
             userEntitlements={userEntitlements}
-            subsidyRequestCatalogsApplicableToCourse={subsidyRequestCatalogsApplicableToCourse}
             courseEntitlements={courseEntitlements}
             missingUserSubsidyReason={missingUserSubsidyReason}
           />

--- a/src/components/course/course-header/data/hooks/tests/useCourseRunCardAction.test.jsx
+++ b/src/components/course/course-header/data/hooks/tests/useCourseRunCardAction.test.jsx
@@ -201,4 +201,12 @@ describe('useCourseRunCardAction', () => {
       }),
     );
   });
+
+  it('returns null if user is not yet enrolled and can request a subsidy for the course', () => {
+    const { result } = renderUseCourseRunCardActionHook({
+      isUserEnrolled: false,
+      userCanRequestSubsidyForCourse: true,
+    });
+    expect(result.current).toBeNull();
+  });
 });

--- a/src/components/course/course-header/data/hooks/useCourseRunCardAction.jsx
+++ b/src/components/course/course-header/data/hooks/useCourseRunCardAction.jsx
@@ -35,6 +35,8 @@ const checkUserEnrollmentUpgradeEligibility = ({
  * @param {string} args.courseTypeEnrollmentUrl The url to navigate to the course enrollment page
  * @param {string} args.contentKey The course run key.
  * @param {string} args.subsidyAccessPolicy The redeemable subsidy access policy applicable to the course, if any.
+ * @param {boolean} args.userCanRequestSubsidyForCourse, Whether the user can request a subsidy for the course.
+ *
  * @returns A JSX element to render as the CTA for the course run.
  */
 const useCourseRunCardAction = ({
@@ -44,6 +46,7 @@ const useCourseRunCardAction = ({
   courseTypeEnrollmentUrl,
   contentKey,
   subsidyAccessPolicy,
+  userCanRequestSubsidyForCourse,
 }) => {
   const {
     redemptionStatus,
@@ -74,6 +77,13 @@ const useCourseRunCardAction = ({
         />
       </Stack>
     );
+  }
+
+  if (userCanRequestSubsidyForCourse) {
+    // User can request a subsidy for the course, but is not enrolled so
+    // hide the "Enroll" CTA in favor of the "Request enrollment" CTA below
+    // the course run cards.
+    return null;
   }
 
   if (!subsidyAccessPolicy) {

--- a/src/components/course/course-header/data/hooks/useCourseRunCardData.js
+++ b/src/components/course/course-header/data/hooks/useCourseRunCardData.js
@@ -18,6 +18,7 @@ import { findHighestLevelEntitlementSku, pathContainsCourseTypeSlug } from '../.
  * @param {object} args.userEnrollment The user's enrollment in the course run, if any.
  * @param {string} args.courseRunUrl The URL to the course run coureware page.
  * @param {object} args.subsidyAccessPolicy A redeemable subsidy access policy applicable to the course, if any.
+ * @param {boolean} args.userCanRequestSubsidyForCourse Whether the user can request a subsidy for the course.
  * @returns An object containing the `heading, `subHeading`, and `action` data needed to render the `CourseRunCard`.
  */
 const useCourseRunCardData = ({
@@ -25,6 +26,7 @@ const useCourseRunCardData = ({
   userEnrollment,
   courseRunUrl,
   subsidyAccessPolicy,
+  userCanRequestSubsidyForCourse,
 }) => {
   const location = useLocation();
   const {
@@ -70,6 +72,7 @@ const useCourseRunCardData = ({
     courseTypeEnrollmentUrl,
     contentKey,
     subsidyAccessPolicy,
+    userCanRequestSubsidyForCourse,
   });
 
   return {

--- a/src/components/course/course-header/deprecated/CourseRunCard.jsx
+++ b/src/components/course/course-header/deprecated/CourseRunCard.jsx
@@ -36,7 +36,6 @@ const CourseRunCard = ({
   courseRun,
   userEnrollments,
   courseKey,
-  subsidyRequestCatalogsApplicableToCourse,
   missingUserSubsidyReason,
 }) => {
   const {
@@ -101,7 +100,6 @@ const CourseRunCard = ({
   const enrollmentType = determineEnrollmentType({
     subsidyData: { userSubsidyApplicableToCourse },
     userHasSubsidyRequestForCourse,
-    subsidyRequestCatalogsApplicableToCourse,
     isUserEnrolled,
     isEnrollable,
     isCourseStarted,
@@ -250,7 +248,6 @@ CourseRunCard.propTypes = {
     sku: PropTypes.string.isRequired,
   })).isRequired,
   userEntitlements: PropTypes.arrayOf(PropTypes.shape()).isRequired,
-  subsidyRequestCatalogsApplicableToCourse: PropTypes.instanceOf(Set).isRequired,
   missingUserSubsidyReason: PropTypes.shape(),
 };
 

--- a/src/components/course/course-header/deprecated/CourseRunCard.jsx
+++ b/src/components/course/course-header/deprecated/CourseRunCard.jsx
@@ -25,7 +25,7 @@ import {
   useUserHasSubsidyRequestForCourse,
 } from '../../data/hooks';
 import { determineEnrollmentType } from '../../enrollment/utils';
-import { SubsidyRequestsContext } from '../../../enterprise-subsidy-requests/SubsidyRequestsContextProvider';
+import { CourseContext } from '../../CourseContextProvider';
 
 const DATE_FORMAT = 'MMM D';
 const DEFAULT_BUTTON_LABEL = 'Enroll';
@@ -52,7 +52,7 @@ const CourseRunCard = ({
 
   const location = useLocation();
   const { enterpriseConfig } = useContext(AppContext);
-  const { subsidyRequestConfiguration } = useContext(SubsidyRequestsContext);
+  const { userCanRequestSubsidyForCourse } = useContext(CourseContext);
 
   const isCourseStarted = useMemo(
     () => hasCourseStarted(start),
@@ -99,16 +99,14 @@ const CourseRunCard = ({
   });
 
   const enrollmentType = determineEnrollmentType({
-    subsidyData: {
-      userSubsidyApplicableToCourse,
-      subsidyRequestConfiguration,
-    },
+    subsidyData: { userSubsidyApplicableToCourse },
     userHasSubsidyRequestForCourse,
     subsidyRequestCatalogsApplicableToCourse,
     isUserEnrolled,
     isEnrollable,
     isCourseStarted,
     isExecutiveEducation2UCourse,
+    userCanRequestSubsidyForCourse,
   });
 
   const courseRunArchived = isArchived(courseRun);

--- a/src/components/course/course-header/tests/CourseRunCardStatus.test.jsx
+++ b/src/components/course/course-header/tests/CourseRunCardStatus.test.jsx
@@ -41,4 +41,15 @@ describe('<CourseRunCardStatus />', () => {
     expect(screen.getByText(mockMissingUserSubsidyReason.userMessage)).toBeInTheDocument();
     expect(screen.getByTestId(mockActionTestId)).toBeInTheDocument();
   });
+
+  test('does not render if the user can request a subsidy for the course', () => {
+    const props = {
+      ...baseProps,
+      missingUserSubsidyReason: mockMissingUserSubsidyReason,
+      userCanRequestSubsidyForCourse: true,
+    };
+    render(<CourseRunCardStatus {...props} />);
+    expect(screen.queryByText(mockMissingUserSubsidyReason.userMessage)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(mockActionTestId)).not.toBeInTheDocument();
+  });
 });

--- a/src/components/course/course-header/tests/DeprecatedCourseRunCard.test.jsx
+++ b/src/components/course/course-header/tests/DeprecatedCourseRunCard.test.jsx
@@ -49,15 +49,12 @@ const defaultCourse = initialCourseState({});
 
 const selfPacedCourseWithoutLicenseSubsidy = {
   ...defaultCourse,
-  userSubsidyApplicableToCourse: null,
   activeCourseRun: {
     ...defaultCourse.activeCourseRun,
     seats: [{ sku: 'sku', type: COURSE_MODES_MAP.VERIFIED }],
   },
   catalog: { catalogList: [] },
 };
-
-const baseSubsidyRequestCatalogsApplicableToCourse = new Set();
 
 const generateCourseRun = ({
   availability = COURSE_AVAILABILITY_MAP.STARTING_SOON,
@@ -81,6 +78,7 @@ const generateCourseRun = ({
 const renderCard = ({
   courseRun,
   userEntitlements = [],
+  courseEntitlements = [],
   userEnrollments = [],
   courseInitState = selfPacedCourseWithoutLicenseSubsidy,
   initialUserSubsidyState = {
@@ -97,21 +95,26 @@ const renderCard = ({
     isLoading: false,
     catalogsForSubsidyRequests: [],
   },
-  subsidyRequestCatalogsApplicableToCourse = baseSubsidyRequestCatalogsApplicableToCourse,
+  userSubsidyApplicableToCourse = undefined,
+  userCanRequestSubsidyForCourse = false,
 }) => {
   // need to use router, to render component such as react-router's <Link>
   renderWithRouter(
     <AppContext.Provider value={INITIAL_APP_STATE}>
       <SubsidyRequestsContext.Provider value={initialSubsidyRequestsState}>
         <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-          <CourseContextProvider initialCourseState={courseInitState}>
+          <CourseContextProvider
+            initialCourseState={courseInitState}
+            userSubsidyApplicableToCourse={userSubsidyApplicableToCourse}
+            userCanRequestSubsidyForCourse={userCanRequestSubsidyForCourse}
+          >
             <CourseRunCardDeprecated
               catalogList={['foo']}
               userEntitlements={userEntitlements}
               userEnrollments={userEnrollments}
               courseRun={courseRun}
               courseKey={COURSE_ID}
-              subsidyRequestCatalogsApplicableToCourse={subsidyRequestCatalogsApplicableToCourse}
+              courseEntitlements={courseEntitlements}
             />
           </CourseContextProvider>
         </UserSubsidyContext.Provider>
@@ -209,7 +212,7 @@ describe('<DeprecatedCourseRunCard />', () => {
     renderCard({
       courseRun,
       initialUserSubsidyState: noUserSubsidyState,
-      subsidyRequestCatalogsApplicableToCourse: new Set(['test-catalog-uuid']),
+      userCanRequestSubsidyForCourse: true,
     });
     const startDate = moment(COURSE_RUN_START).format(DATE_FORMAT);
     expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();

--- a/src/components/course/enrollment/tests/utils.test.js
+++ b/src/components/course/enrollment/tests/utils.test.js
@@ -16,12 +16,8 @@ const baseArgs = {
   isUserEnrolled: false,
   isEnrollable: true,
   isCourseStarted: true,
-  subsidyData: {
-    userSubsidyApplicableToCourse: null,
-    subsidyRequestConfiguration: null,
-  },
+  subsidyData: { userSubsidyApplicableToCourse: null },
   userHasSubsidyRequestForCourse: false,
-  subsidyRequestCatalogsApplicableToCourse: new Set(),
 };
 
 describe('determineEnrollmentType correctly resolves enrollment type', () => {
@@ -84,7 +80,7 @@ describe('determineEnrollmentType correctly resolves enrollment type', () => {
         ...baseArgs.subsidyData,
         subsidyRequestConfiguration: { subsidyRequestsEnabled: true },
       },
-      subsidyRequestCatalogsApplicableToCourse: new Set(['test-catalog']),
+      userCanRequestSubsidyForCourse: true,
     };
     expect(determineEnrollmentType(args)).toBe(HIDE_BUTTON);
   });

--- a/src/components/course/enrollment/tests/utils.test.js
+++ b/src/components/course/enrollment/tests/utils.test.js
@@ -1,7 +1,7 @@
 import { COUPON_CODE_SUBSIDY_TYPE, ENTERPRISE_OFFER_SUBSIDY_TYPE, LICENSE_SUBSIDY_TYPE } from '../../data/constants';
 import { enrollButtonTypes } from '../constants';
 
-import { determineEnrollmentType } from '../utils';
+import { determineEnrollmentType, canUserRequestSubsidyForCourse } from '../utils';
 
 const {
   TO_COURSEWARE_PAGE,
@@ -12,15 +12,15 @@ const {
   HIDE_BUTTON,
 } = enrollButtonTypes;
 
-const baseArgs = {
-  isUserEnrolled: false,
-  isEnrollable: true,
-  isCourseStarted: true,
-  subsidyData: { userSubsidyApplicableToCourse: null },
-  userHasSubsidyRequestForCourse: false,
-};
+describe('determineEnrollmentType', () => {
+  const baseArgs = {
+    isUserEnrolled: false,
+    isEnrollable: true,
+    isCourseStarted: true,
+    subsidyData: { userSubsidyApplicableToCourse: null },
+    userHasSubsidyRequestForCourse: false,
+  };
 
-describe('determineEnrollmentType correctly resolves enrollment type', () => {
   test('resolves user-enrolled, course-started to "to courseware page" type', () => {
     const args = {
       ...baseArgs,
@@ -28,6 +28,7 @@ describe('determineEnrollmentType correctly resolves enrollment type', () => {
     };
     expect(determineEnrollmentType(args)).toBe(TO_COURSEWARE_PAGE);
   });
+
   test('resolves user-enrolled case to "view on dashboard" page type', () => {
     const args = {
       ...baseArgs,
@@ -36,6 +37,7 @@ describe('determineEnrollmentType correctly resolves enrollment type', () => {
     };
     expect(determineEnrollmentType(args)).toBe(VIEW_ON_DASHBOARD);
   });
+
   test('resolves unenrollable case to disabled enroll button', () => {
     const args = {
       ...baseArgs,
@@ -47,9 +49,11 @@ describe('determineEnrollmentType correctly resolves enrollment type', () => {
     };
     expect(determineEnrollmentType(args)).toBe(ENROLL_DISABLED);
   });
+
   test('no subsidy, show disabled enroll button', () => {
     expect(determineEnrollmentType(baseArgs)).toBe(ENROLL_DISABLED);
   });
+
   test('license subsidy, show data sharing consent button', () => {
     const args = {
       ...baseArgs,
@@ -60,6 +64,7 @@ describe('determineEnrollmentType correctly resolves enrollment type', () => {
     };
     expect(determineEnrollmentType(args)).toBe(TO_DATASHARING_CONSENT);
   });
+
   test.each([
     { subsidyType: COUPON_CODE_SUBSIDY_TYPE },
     { subsidyType: ENTERPRISE_OFFER_SUBSIDY_TYPE },
@@ -73,6 +78,7 @@ describe('determineEnrollmentType correctly resolves enrollment type', () => {
     };
     expect(determineEnrollmentType(args)).toBe(TO_ECOM_BASKET);
   });
+
   test('user has subsidy request for course, hide enroll button', () => {
     const args = {
       ...baseArgs,
@@ -84,6 +90,7 @@ describe('determineEnrollmentType correctly resolves enrollment type', () => {
     };
     expect(determineEnrollmentType(args)).toBe(HIDE_BUTTON);
   });
+
   test.each([
     { hasSubsidyData: true },
     { hasSubsidyData: false },
@@ -96,5 +103,55 @@ describe('determineEnrollmentType correctly resolves enrollment type', () => {
       } : undefined,
     };
     expect(determineEnrollmentType(args)).toBe(ENROLL_DISABLED);
+  });
+});
+
+describe('canUserRequestSubsidyForCourse', () => {
+  const disabledSubsidyRequests = { subsidyRequestsEnabled: false };
+  const enabledSubsidyRequests = { subsidyRequestsEnabled: true };
+
+  test.each([
+    {
+      subsidyRequestConfiguration: undefined,
+      subsidyRequestCatalogsApplicableToCourse: undefined,
+      userSubsidyApplicableToCourse: undefined,
+      expected: false,
+    },
+    {
+      subsidyRequestConfiguration: enabledSubsidyRequests,
+      subsidyRequestCatalogsApplicableToCourse: undefined,
+      userSubsidyApplicableToCourse: undefined,
+      expected: false,
+    },
+    {
+      subsidyRequestConfiguration: disabledSubsidyRequests,
+      subsidyRequestCatalogsApplicableToCourse: new Set(['catalog-uuid']),
+      userSubsidyApplicableToCourse: { subsidyType: LICENSE_SUBSIDY_TYPE },
+      expected: false,
+    },
+    {
+      subsidyRequestConfiguration: enabledSubsidyRequests,
+      subsidyRequestCatalogsApplicableToCourse: new Set(['catalog-uuid']),
+      userSubsidyApplicableToCourse: { subsidyType: LICENSE_SUBSIDY_TYPE },
+      expected: false,
+    },
+    {
+      subsidyRequestConfiguration: enabledSubsidyRequests,
+      subsidyRequestCatalogsApplicableToCourse: new Set(['catalog-uuid']),
+      userSubsidyApplicableToCourse: undefined,
+      expected: true,
+    },
+  ])('returns expected value with the provided inputs (%s)', ({
+    subsidyRequestConfiguration,
+    subsidyRequestCatalogsApplicableToCourse,
+    userSubsidyApplicableToCourse,
+    expected,
+  }) => {
+    const args = {
+      subsidyRequestConfiguration,
+      subsidyRequestCatalogsApplicableToCourse,
+      userSubsidyApplicableToCourse,
+    };
+    expect(canUserRequestSubsidyForCourse(args)).toEqual(expected);
   });
 });

--- a/src/components/course/enrollment/utils.js
+++ b/src/components/course/enrollment/utils.js
@@ -15,31 +15,39 @@ const {
   HIDE_BUTTON,
 } = enrollButtonTypes;
 
+export function canUserRequestSubsidyForCourse({
+  subsidyRequestConfiguration,
+  subsidyRequestCatalogsApplicableToCourse,
+  userSubsidyApplicableToCourse,
+}) {
+  // Hide enroll button if browse and request is turned on and the user has no applicable subsidy
+  if (!subsidyRequestConfiguration || !subsidyRequestCatalogsApplicableToCourse) {
+    return false;
+  }
+  return (
+    subsidyRequestConfiguration.subsidyRequestsEnabled
+    && subsidyRequestCatalogsApplicableToCourse.size > 0
+    && !userSubsidyApplicableToCourse
+  );
+}
+
 /**
  * The main logic to determine enrollment type (scenario).
  */
 export function determineEnrollmentType({
-  subsidyData: {
-    userSubsidyApplicableToCourse,
-    subsidyRequestConfiguration,
-  } = {},
+  subsidyData: { userSubsidyApplicableToCourse } = {},
   isUserEnrolled,
   isEnrollable,
   isCourseStarted,
   userHasSubsidyRequestForCourse,
-  subsidyRequestCatalogsApplicableToCourse,
   isExecutiveEducation2UCourse,
+  userCanRequestSubsidyForCourse,
 }) {
   if (isUserEnrolled) {
     return isCourseStarted ? TO_COURSEWARE_PAGE : VIEW_ON_DASHBOARD;
   }
 
   // Hide enroll button if browse and request is turned on and the user has no applicable subsidy
-  const userCanRequestSubsidyForCourse = (
-    subsidyRequestConfiguration?.subsidyRequestsEnabled
-    && subsidyRequestCatalogsApplicableToCourse.size > 0
-    && !userSubsidyApplicableToCourse
-  );
   if (userHasSubsidyRequestForCourse || userCanRequestSubsidyForCourse) {
     return HIDE_BUTTON;
   }

--- a/src/components/course/enrollment/utils.js
+++ b/src/components/course/enrollment/utils.js
@@ -15,6 +15,20 @@ const {
   HIDE_BUTTON,
 } = enrollButtonTypes;
 
+/**
+ * Determines whether a user can request a subsidy for a course, by checking whether
+ * the subsidy request feautre is enabled, there are more than 1 subsidy request
+ * catalogs applicable to the course, and whether the learner already has a subsidy
+ * applicable to the course.
+ *
+ * @param {object} args
+ * @param {object} args.subsidyRequestConfiguration Contains a property whether subsidy requests are enabled
+ * @param {Set} args.subsidyRequestCatalogsApplicableToCourse Set representing the subsidy catalogs
+ *  applicable to the course
+ * @param {boolean} args.userSubsidyApplicableToCourse Subsidy applicable to the course
+ *
+ * @returns True if the user can request a subsidy for the course, false otherwise.
+ */
 export function canUserRequestSubsidyForCourse({
   subsidyRequestConfiguration,
   subsidyRequestCatalogsApplicableToCourse,

--- a/src/components/course/enrollment/utils.js
+++ b/src/components/course/enrollment/utils.js
@@ -47,7 +47,8 @@ export function determineEnrollmentType({
     return isCourseStarted ? TO_COURSEWARE_PAGE : VIEW_ON_DASHBOARD;
   }
 
-  // Hide enroll button if browse and request is turned on and the user has no applicable subsidy
+  // Hide enroll button if learner can request a subsidy for the course, or
+  // already has an pending subsidy request for the course.
   if (userHasSubsidyRequestForCourse || userCanRequestSubsidyForCourse) {
     return HIDE_BUTTON;
   }

--- a/src/components/course/enrollment/utils.js
+++ b/src/components/course/enrollment/utils.js
@@ -17,7 +17,7 @@ const {
 
 /**
  * Determines whether a user can request a subsidy for a course, by checking whether
- * the subsidy request feautre is enabled, there are more than 1 subsidy request
+ * the subsidy request feature is enabled, there are more than 1 subsidy request
  * catalogs applicable to the course, and whether the learner already has a subsidy
  * applicable to the course.
  *

--- a/src/components/course/tests/CourseContextProvider.test.jsx
+++ b/src/components/course/tests/CourseContextProvider.test.jsx
@@ -1,13 +1,7 @@
-import PropTypes from 'prop-types';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
-import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import { CourseContextProvider, CourseContext } from '../CourseContextProvider';
-
-const baseSubsidyRequestContextValue = {
-  catalogsForSubsidyRequests: [],
-};
 
 const baseInitialCourseState = {
   course: {},
@@ -19,27 +13,19 @@ const baseInitialCourseState = {
 };
 
 const CourseContextProviderWrapper = ({
-  subsidyRequestsContextValue,
-  initialCourseState,
+  subsidyRequestCatalogsApplicableToCourse = new Set(),
+  userCanRequestSubsidyForCourse = false,
+  initialCourseState = baseInitialCourseState,
   children,
 }) => (
-  <SubsidyRequestsContext.Provider value={subsidyRequestsContextValue}>
-    <CourseContextProvider initialCourseState={initialCourseState}>
-      {children}
-    </CourseContextProvider>
-  </SubsidyRequestsContext.Provider>
+  <CourseContextProvider
+    initialCourseState={initialCourseState}
+    subsidyRequestCatalogsApplicableToCourse={subsidyRequestCatalogsApplicableToCourse}
+    userCanRequestSubsidyForCourse={userCanRequestSubsidyForCourse}
+  >
+    {children}
+  </CourseContextProvider>
 );
-
-CourseContextProviderWrapper.propTypes = {
-  children: PropTypes.node.isRequired,
-  subsidyRequestsContextValue: PropTypes.shape(),
-  initialCourseState: PropTypes.shape(),
-};
-
-CourseContextProviderWrapper.defaultProps = {
-  subsidyRequestsContextValue: baseSubsidyRequestContextValue,
-  initialCourseState: baseInitialCourseState,
-};
 
 describe('<CourseContextProvider>', () => {
   test('has 0 subsidy request catalogs applicable to course', () => {
@@ -55,28 +41,39 @@ describe('<CourseContextProvider>', () => {
     expect(screen.getByText('Count: 0'));
   });
 
-  test('has 1 catalog for configured subsidy type applicable to course', () => {
+  test.each([
+    { canRequestEnrollment: true },
+    { canRequestEnrollment: false },
+  ])('has 1 catalog for configured subsidy type applicable to course', ({ canRequestEnrollment }) => {
     const testCatalogUUID = 'test-catalog-uuid';
     const courseState = {
       ...baseInitialCourseState,
       catalog: { catalogList: [testCatalogUUID] },
     };
-    const subsidyRequestContextValue = {
-      ...baseSubsidyRequestContextValue,
-      catalogsForSubsidyRequests: [testCatalogUUID],
-    };
+    const requestCatalogsForCourse = canRequestEnrollment ? [testCatalogUUID] : [];
     render(
       <CourseContextProviderWrapper
-        subsidyRequestsContextValue={subsidyRequestContextValue}
+        subsidyRequestCatalogsApplicableToCourse={new Set(requestCatalogsForCourse)}
         initialCourseState={courseState}
+        userCanRequestSubsidyForCourse={canRequestEnrollment}
       >
         <CourseContext.Consumer>
-          {({ subsidyRequestCatalogsApplicableToCourse }) => (
-            <p>Count: {subsidyRequestCatalogsApplicableToCourse.size}</p>
+          {({ subsidyRequestCatalogsApplicableToCourse, userCanRequestSubsidyForCourse }) => (
+            <>
+              <p>Count: {subsidyRequestCatalogsApplicableToCourse.size}</p>
+              <p>Can request enrollment: {userCanRequestSubsidyForCourse ? 'true' : 'false'}</p>
+            </>
           )}
         </CourseContext.Consumer>
       </CourseContextProviderWrapper>,
     );
-    expect(screen.getByText('Count: 1'));
+
+    if (canRequestEnrollment) {
+      expect(screen.getByText('Count: 1'));
+      expect(screen.getByText('Can request enrollment: true'));
+    } else {
+      expect(screen.getByText('Count: 0'));
+      expect(screen.getByText('Can request enrollment: false'));
+    }
   });
 });


### PR DESCRIPTION
# Description

## Before

Disabled enroll button and message saying "No funds" when user can also "Request enrollment" (only 1 CTA should be visible at a time).

![image](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/12075ac8-3511-45a8-afb8-0f07a971bb77)

## After

Hides enroll button and message, only showing "Request enrollment" button below the course run cards.

![image](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/ed80754a-329e-42e7-97b7-e08423aac001)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
