### PR TITLE
fix: resolve bug with showing price is free when approved

### DIFF
--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -7,6 +7,7 @@ import { CourseContext } from './CourseContextProvider';
 import { numberWithPrecision } from './data/utils';
 import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 import { ENTERPRISE_OFFER_SUBSIDY_TYPE, LEARNER_CREDIT_SUBSIDY_TYPE, LICENSE_SUBSIDY_TYPE } from './data/constants';
+import { canUserRequestSubsidyForCourse } from './enrollment/utils';
 
 export const INCLUDED_IN_SUBSCRIPTION_MESSAGE = 'Included in your subscription';
 export const FREE_WHEN_APPROVED_MESSAGE = 'Free to me\n(when approved)';
@@ -18,6 +19,7 @@ const CourseSidebarPrice = () => {
     userSubsidyApplicableToCourse,
     coursePrice,
     currency,
+    subsidyRequestCatalogsApplicableToCourse,
   } = useContext(CourseContext);
   const { subsidyRequestConfiguration } = useContext(SubsidyRequestsContext);
 
@@ -48,9 +50,13 @@ const CourseSidebarPrice = () => {
   }
 
   const hasDiscountedPrice = coursePrice.discounted < coursePrice.list;
-  // Case 2: No subsidies found but Browse and Request Enabled
-  if (!hasDiscountedPrice && subsidyRequestConfiguration?.subsidyRequestsEnabled
-  ) {
+  const canRequestSubsidy = canUserRequestSubsidyForCourse({
+    subsidyRequestConfiguration,
+    subsidyRequestCatalogsApplicableToCourse,
+    userSubsidyApplicableToCourse,
+  });
+  // Case 2: No subsidies found but learner can request a subsidy
+  if (!hasDiscountedPrice && canRequestSubsidy) {
     return (
       <span style={{ whiteSpace: 'pre-wrap' }} data-testid="browse-and-request-pricing">
         <s>${originalPriceDisplay} {currency}</s><br />

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -29,7 +29,7 @@ const appStateWithOrigPriceShowing = {
     hideCourseOriginalPrice: false,
   },
 };
-
+const mockCatalogUUID = 'test-catalog-uuid';
 const BASE_COURSE_STATE = {
   activeCourseRun: {
     firstEnrollablePaidSeatPrice: 7.50,
@@ -39,7 +39,7 @@ const BASE_COURSE_STATE = {
   userEntitlements: [],
   catalog: {
     containsContentItems: true,
-    catalogList: ['test-catalog-uuid'],
+    catalogList: [mockCatalogUUID],
   },
   courseRecommendations: {},
 };
@@ -59,6 +59,7 @@ const PARTIAL_COUPON_CODE_SUBSIDY = {
 const baseCourseContextProps = {
   initialCourseState: BASE_COURSE_STATE,
   userSubsidyApplicableToCourse: null,
+  subsidyRequestCatalogsApplicableToCourse: new Set([mockCatalogUUID]),
   coursePrice: { list: 7.5, discounted: 7.5 },
   currency: 'USD',
 };
@@ -108,7 +109,7 @@ const SPONSORED_BY_TEXT = 'Sponsored by test-enterprise';
 
 describe('<CourseSidebarPrice/> ', () => {
   describe('Browse and Request', () => {
-    test('Display correct message when browse and request on and no subsidy', () => {
+    test('Display correct message when browse and request on and user has no subsidy', () => {
       render(
         <SidebarWithContext
           courseContextProps={baseCourseContextProps}
@@ -121,6 +122,26 @@ describe('<CourseSidebarPrice/> ', () => {
       expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
       expect(screen.getByText(FREE_WHEN_APPROVED_MESSAGE.replace('\n', ' '))).toBeInTheDocument();
       expect(screen.getByTestId('browse-and-request-pricing')).toBeInTheDocument();
+      expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
+      expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
+    });
+
+    test('Display correct message when browse and request on, course is included in subsidy request catalog(s), and user has no subsidy', () => {
+      render(
+        <SidebarWithContext
+          courseContextProps={{
+            ...baseCourseContextProps,
+            subsidyRequestCatalogsApplicableToCourse: new Set([]),
+          }}
+          subsidyRequestsState={{
+            ...defaultSubsidyRequestsState,
+            subsidyRequestConfiguration: { subsidyRequestsEnabled: true },
+          }}
+        />,
+      );
+      expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
+      expect(screen.queryByText(FREE_WHEN_APPROVED_MESSAGE.replace('\n', ' '))).not.toBeInTheDocument();
+      expect(screen.queryByTestId('browse-and-request-pricing')).not.toBeInTheDocument();
       expect(screen.queryByText(INCLUDED_IN_SUBSCRIPTION_MESSAGE)).not.toBeInTheDocument();
       expect(screen.queryByText(SPONSORED_BY_TEXT)).not.toBeInTheDocument();
     });


### PR DESCRIPTION
# Description

Resolves an existing bug related to showing a "Free to me (when approved)" message in the learner portal course sidebar price when subsidy requests are enabled, the user has no subsidy, and the course is not contained by any catalog(s) associated with the subsidy typ being used for Browse & Request.

This PR adds a check to ensure the course is contained by a catalog(s) associated with the subsidy configured for the browse & request feature.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
