### PR TITLE
chore: transaction_status_api_url from transaction create response

### DIFF
--- a/src/components/course/data/tests/service.test.js
+++ b/src/components/course/data/tests/service.test.js
@@ -110,7 +110,8 @@ describe('CourseService', () => {
   });
 
   it('fetches transaction status', async () => {
-    const response = await retrieveTransactionStatus({ transactionUUID: TRANSACTION_UUID });
+    const transactionStatusApiUrl = TRANSACTION_ENDPOINT;
+    const response = await retrieveTransactionStatus({ transactionStatusApiUrl });
     expect(axiosMock.history.get[0].url).toBe(TRANSACTION_ENDPOINT);
     expect(response).toEqual(mockTransactionResponse);
   });

--- a/src/components/stateful-enroll/StatefulEnroll.jsx
+++ b/src/components/stateful-enroll/StatefulEnroll.jsx
@@ -50,7 +50,7 @@ const StatefulEnroll = ({
 }) => {
   const intl = useIntl();
   const [enrollButtonState, setEnrollButtonState] = useState('default');
-  const [transactionUUID, setTransactionUUID] = useState();
+  const [transactionStatusApiUrl, setTransactionStatusApiUrl] = useState();
 
   const buttonLabels = {
     default: intl.formatMessage(messages.buttonLabelEnroll),
@@ -73,7 +73,7 @@ const StatefulEnroll = ({
       setEnrollButtonState('pending');
     },
     onSuccess: (transaction) => {
-      setTransactionUUID(transaction.uuid);
+      setTransactionStatusApiUrl(transaction.transactionStatusApiUrl);
     },
     onError: () => {
       handleRedemptionError();
@@ -82,7 +82,7 @@ const StatefulEnroll = ({
 
   useTransactionStatus({
     contentKey,
-    transactionUUID,
+    transactionStatusApiUrl,
     onSuccess: (transaction) => {
       if (transaction.state === 'committed') {
         setEnrollButtonState('complete');

--- a/src/components/stateful-enroll/StatefulEnroll.test.jsx
+++ b/src/components/stateful-enroll/StatefulEnroll.test.jsx
@@ -42,10 +42,10 @@ const mockCallbackProps = {
 };
 
 const MOCK_COURSE_RUN_KEY = 'course-v1:edX+S2023+1T2023';
-const MOCK_TRANSACTION_UUID = 'test-transaction-uuid';
 const MOCK_SUBSIDY_ACCESS_POLICY = {
   policyRedemptionUrl: 'http://policy-redemption.url',
 };
+const MOCK_TRANSACTION_STATUS_API_URL = 'http://transaction-status.url';
 
 const StatefulEnrollWrapper = (props) => (
   <QueryClientProvider client={queryClient}>
@@ -106,7 +106,7 @@ describe('StatefulEnroll', () => {
     const onSuccessSpy = jest.spyOn(mockCallbackProps, 'onSuccess');
     const onErrorSpy = jest.spyOn(mockCallbackProps, 'onError');
     submitRedemptionRequest.mockResolvedValueOnce({
-      uuid: MOCK_TRANSACTION_UUID,
+      transactionStatusApiUrl: MOCK_TRANSACTION_STATUS_API_URL,
     });
     retrieveTransactionStatus.mockResolvedValueOnce({
       state: 'committed',
@@ -128,7 +128,7 @@ describe('StatefulEnroll', () => {
     const onSuccessSpy = jest.spyOn(mockCallbackProps, 'onSuccess');
     const onErrorSpy = jest.spyOn(mockCallbackProps, 'onError');
     submitRedemptionRequest.mockResolvedValueOnce({
-      uuid: MOCK_TRANSACTION_UUID,
+      transactionStatusApiUrl: MOCK_TRANSACTION_STATUS_API_URL,
     });
     retrieveTransactionStatus.mockResolvedValueOnce({
       state: 'pending',
@@ -156,7 +156,7 @@ describe('StatefulEnroll', () => {
     const onSuccessSpy = jest.spyOn(mockCallbackProps, 'onSuccess');
     const onErrorSpy = jest.spyOn(mockCallbackProps, 'onError');
     submitRedemptionRequest.mockResolvedValueOnce({
-      uuid: MOCK_TRANSACTION_UUID,
+      transactionStatusApiUrl: MOCK_TRANSACTION_STATUS_API_URL,
     });
     retrieveTransactionStatus.mockResolvedValueOnce({
       state: 'failed',
@@ -173,7 +173,7 @@ describe('StatefulEnroll', () => {
     const onSuccessSpy = jest.spyOn(mockCallbackProps, 'onSuccess');
     const onErrorSpy = jest.spyOn(mockCallbackProps, 'onError');
     submitRedemptionRequest.mockResolvedValueOnce({
-      uuid: MOCK_TRANSACTION_UUID,
+      transactionStatusApiUrl: MOCK_TRANSACTION_STATUS_API_URL,
     });
     retrieveTransactionStatus.mockRejectedValueOnce();
     await clickEnrollButton();

--- a/src/components/stateful-enroll/data/hooks/useTransactionStatus.js
+++ b/src/components/stateful-enroll/data/hooks/useTransactionStatus.js
@@ -16,8 +16,7 @@ import { retrieveTransactionStatus } from '../service';
  * @returns
  */
 const useTransactionStatus = ({
-  contentKey,
-  transactionUUID,
+  transactionStatusApiUrl,
   onSuccess,
   onError,
 }) => {
@@ -34,13 +33,13 @@ const useTransactionStatus = ({
   };
 
   const checkTransactionStatus = async () => {
-    const response = await retrieveTransactionStatus({ transactionUUID, contentKey });
+    const response = await retrieveTransactionStatus({ transactionStatusApiUrl });
     return response;
   };
 
   return useQuery({
-    queryKey: ['transaction-status', transactionUUID],
-    enabled: !!transactionUUID,
+    queryKey: ['transaction-status', transactionStatusApiUrl],
+    enabled: !!transactionStatusApiUrl,
     queryFn: checkTransactionStatus,
     refetchInterval: getRefetchInterval,
     onSuccess,

--- a/src/components/stateful-enroll/data/service.js
+++ b/src/components/stateful-enroll/data/service.js
@@ -1,6 +1,5 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
-import { getConfig } from '@edx/frontend-platform/config';
 
 /**
  * Makes an API request to retrieve the most recent payload for the
@@ -10,12 +9,8 @@ import { getConfig } from '@edx/frontend-platform/config';
  * @param {string} args.transactionUUID The uuid (primary key) of the subsidy from which transactions should be listed.
  * @returns The payload for the specified transaction.
  */
-export const retrieveTransactionStatus = async ({ transactionUUID }) => {
-  const config = getConfig();
-
-  const url = `${config.ENTERPRISE_SUBSIDY_BASE_URL}/api/v1/transactions/${transactionUUID}/`;
-  const response = await getAuthenticatedHttpClient().get(url);
-
+export const retrieveTransactionStatus = async ({ transactionStatusApiUrl }) => {
+  const response = await getAuthenticatedHttpClient().get(transactionStatusApiUrl);
   return camelCaseObject(response.data);
 };
 


### PR DESCRIPTION
This PR uses the new `transaction_status_api_url` field from the transaction create response instead of constructing the API url with the transaction UUID.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
