### PR TITLE
fix: ensure new course data renders when switching between courses

### DIFF
--- a/src/components/course/CourseContextProvider.jsx
+++ b/src/components/course/CourseContextProvider.jsx
@@ -1,6 +1,4 @@
-import React, {
-  createContext, useReducer, useMemo,
-} from 'react';
+import React, { createContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   COUPON_CODE_SUBSIDY_TYPE,
@@ -9,23 +7,13 @@ import {
   ENTERPRISE_OFFER_SUBSIDY_TYPE,
   LEARNER_CREDIT_SUBSIDY_TYPE,
   LICENSE_SUBSIDY_TYPE,
-  SET_COURSE_RUN,
 } from './data/constants';
 
 export const CourseContext = createContext();
 
-const reducer = (state, action) => {
-  switch (action.type) {
-    case SET_COURSE_RUN:
-      return { ...state, activeCourseRun: action.payload };
-    default:
-      return state;
-  }
-};
-
 export const CourseContextProvider = ({
   children,
-  initialCourseState,
+  courseState,
   isPolicyRedemptionEnabled,
   missingUserSubsidyReason,
   userSubsidyApplicableToCourse,
@@ -35,11 +23,8 @@ export const CourseContextProvider = ({
   coursePrice,
   currency,
 }) => {
-  const [state, dispatch] = useReducer(reducer, initialCourseState);
-
   const value = useMemo(() => ({
-    state,
-    dispatch,
+    state: courseState,
     userCanRequestSubsidyForCourse,
     subsidyRequestCatalogsApplicableToCourse,
     isPolicyRedemptionEnabled,
@@ -49,7 +34,7 @@ export const CourseContextProvider = ({
     coursePrice,
     currency,
   }), [
-    state,
+    courseState,
     userCanRequestSubsidyForCourse,
     subsidyRequestCatalogsApplicableToCourse,
     isPolicyRedemptionEnabled,
@@ -69,7 +54,7 @@ export const CourseContextProvider = ({
 
 CourseContextProvider.propTypes = {
   children: PropTypes.node.isRequired,
-  initialCourseState: PropTypes.shape({
+  courseState: PropTypes.shape({
     course: PropTypes.shape({}).isRequired,
     activeCourseRun: PropTypes.shape({}).isRequired,
     userEnrollments: PropTypes.arrayOf(PropTypes.shape({

--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -1,7 +1,9 @@
 import React, {
   useCallback, useContext, useEffect, useMemo, useState,
 } from 'react';
-import { useLocation, useParams, useHistory } from 'react-router-dom';
+import {
+  useLocation, useParams, useHistory,
+} from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import {
   breakpoints, Container, Row, MediaQuery,
@@ -254,7 +256,7 @@ const CoursePage = () => {
       <Helmet title={PAGE_TITLE} />
       <CourseEnrollmentsContextProvider>
         <CourseContextProvider
-          initialCourseState={courseState}
+          courseState={courseState}
           missingUserSubsidyReason={missingUserSubsidyReason}
           userSubsidyApplicableToCourse={userSubsidyApplicableToCourse}
           isPolicyRedemptionEnabled={isPolicyRedemptionEnabled}

--- a/src/components/course/course-header/tests/CourseHeader.test.jsx
+++ b/src/components/course/course-header/tests/CourseHeader.test.jsx
@@ -51,7 +51,7 @@ const defaultCourseEnrollmentsState = {
 const CourseHeaderWrapper = ({
   initialAppState = {},
   initialCourseEnrollmentsState = defaultCourseEnrollmentsState,
-  initialCourseState = {},
+  courseState = {},
   initialUserSubsidyState = {},
   initialSubsidyRequestsState = defaultSubsidyRequestsState,
 }) => (
@@ -59,7 +59,7 @@ const CourseHeaderWrapper = ({
     <UserSubsidyContext.Provider value={initialUserSubsidyState}>
       <SubsidyRequestsContext.Provider value={initialSubsidyRequestsState}>
         <CourseEnrollmentsContext.Provider value={initialCourseEnrollmentsState}>
-          <CourseContextProvider initialCourseState={initialCourseState}>
+          <CourseContextProvider courseState={courseState}>
             <CourseHeader />
           </CourseContextProvider>
         </CourseEnrollmentsContext.Provider>
@@ -74,7 +74,7 @@ describe('<CourseHeader />', () => {
       slug: 'test-enterprise-slug',
     },
   };
-  const initialCourseState = {
+  const courseState = {
     course: {
       subjects: [{
         name: 'Test Subject 1',
@@ -127,36 +127,36 @@ describe('<CourseHeader />', () => {
     render(
       <CourseHeaderWrapper
         initialAppState={initialAppState}
-        initialCourseState={initialCourseState}
+        courseState={courseState}
         initialUserSubsidyState={initialUserSubsidyState}
       />,
     );
     expect(screen.queryByText('Find a Course')).toBeInTheDocument();
-    expect(screen.queryAllByText(initialCourseState.course.title)[0]).toBeInTheDocument();
+    expect(screen.queryAllByText(courseState.course.title)[0]).toBeInTheDocument();
   });
 
   test('does not render breadcrumb when search is disabled for customer', () => {
     render(
       <CourseHeaderWrapper
         initialAppState={{ enterpriseConfig: { disableSearch: true } }}
-        initialCourseState={initialCourseState}
+        courseState={courseState}
         initialUserSubsidyState={initialUserSubsidyState}
       />,
     );
     expect(screen.queryByText('Find a Course')).toBeFalsy();
-    expect(screen.queryAllByText(initialCourseState.course.title)[0]).toBeInTheDocument();
+    expect(screen.queryAllByText(courseState.course.title)[0]).toBeInTheDocument();
   });
 
   test('renders course title and short description', () => {
     render(
       <CourseHeaderWrapper
         initialAppState={initialAppState}
-        initialCourseState={initialCourseState}
+        courseState={courseState}
         initialUserSubsidyState={initialUserSubsidyState}
       />,
     );
 
-    const { title, shortDescription } = initialCourseState.course;
+    const { title, shortDescription } = courseState.course;
     expect(screen.queryAllByText(title)[1]).toBeInTheDocument();
     expect(screen.queryByText(shortDescription)).toBeInTheDocument();
   });
@@ -166,7 +166,7 @@ describe('<CourseHeader />', () => {
     render(
       <CourseHeaderWrapper
         initialAppState={initialAppState}
-        initialCourseState={initialCourseState}
+        courseState={courseState}
         initialUserSubsidyState={initialUserSubsidyState}
       />,
     );
@@ -181,7 +181,7 @@ describe('<CourseHeader />', () => {
     render(
       <CourseHeaderWrapper
         initialAppState={initialAppState}
-        initialCourseState={initialCourseState}
+        courseState={courseState}
         initialUserSubsidyState={initialUserSubsidyState}
       />,
     );
@@ -197,13 +197,13 @@ describe('<CourseHeader />', () => {
 
   test('does not renders course reviews section', () => {
     const courseStateWithNoCourseReviews = {
-      ...initialCourseState,
+      ...courseState,
       courseReviews: null,
     };
     render(
       <CourseHeaderWrapper
         initialAppState={initialAppState}
-        initialCourseState={courseStateWithNoCourseReviews}
+        courseState={courseStateWithNoCourseReviews}
         initialUserSubsidyState={initialUserSubsidyState}
       />,
     );
@@ -214,7 +214,7 @@ describe('<CourseHeader />', () => {
 
   test('does not renders course reviews section if course not part of catalog', () => {
     const courseStateWithNoCourseReviews = {
-      ...initialCourseState,
+      ...courseState,
       catalog: {
         containsContentItems: false,
         catalogList: [],
@@ -223,7 +223,7 @@ describe('<CourseHeader />', () => {
     render(
       <CourseHeaderWrapper
         initialAppState={initialAppState}
-        initialCourseState={courseStateWithNoCourseReviews}
+        courseState={courseStateWithNoCourseReviews}
         initialUserSubsidyState={initialUserSubsidyState}
       />,
     );
@@ -236,7 +236,7 @@ describe('<CourseHeader />', () => {
     render(
       <CourseHeaderWrapper
         initialAppState={initialAppState}
-        initialCourseState={initialCourseState}
+        courseState={courseState}
         initialUserSubsidyState={initialUserSubsidyState}
       />,
     );
@@ -248,18 +248,18 @@ describe('<CourseHeader />', () => {
     render(
       <CourseHeaderWrapper
         initialAppState={initialAppState}
-        initialCourseState={initialCourseState}
+        courseState={courseState}
         initialUserSubsidyState={initialUserSubsidyState}
       />,
     );
 
-    const partner = initialCourseState.course.owners[0];
+    const partner = courseState.course.owners[0];
     expect(screen.queryByAltText(`${partner.name} logo`)).toBeInTheDocument();
   });
 
   test('renders not in catalog messaging', () => {
     const courseStateWithNoCatalog = {
-      ...initialCourseState,
+      ...courseState,
       catalog: {
         containsContentItems: false,
         catalogList: [],
@@ -269,7 +269,7 @@ describe('<CourseHeader />', () => {
     render(
       <CourseHeaderWrapper
         initialAppState={initialAppState}
-        initialCourseState={courseStateWithNoCatalog}
+        courseState={courseStateWithNoCatalog}
         initialUserSubsidyState={initialUserSubsidyState}
       />,
     );
@@ -294,7 +294,7 @@ describe('<CourseHeader />', () => {
       render(
         <CourseHeaderWrapper
           initialAppState={initialAppState}
-          initialCourseState={initialCourseState}
+          courseState={courseState}
           initialUserSubsidyState={initialUserSubsidyState}
         />,
       );
@@ -321,7 +321,7 @@ describe('<CourseHeader />', () => {
       render(
         <CourseHeaderWrapper
           initialAppState={initialAppState}
-          initialCourseState={initialCourseState}
+          courseState={courseState}
           initialUserSubsidyState={initialUserSubsidyState}
         />,
       );
@@ -332,9 +332,9 @@ describe('<CourseHeader />', () => {
 
   describe('renders program messaging', () => {
     const courseStateWithProgramType = (type) => ({
-      ...initialCourseState,
+      ...courseState,
       course: {
-        ...initialCourseState.course,
+        ...courseState.course,
         programs: [{
           type,
         }],
@@ -347,7 +347,7 @@ describe('<CourseHeader />', () => {
       render(
         <CourseHeaderWrapper
           initialAppState={initialAppState}
-          initialCourseState={courseStateWithProgramType(micromasters)}
+          courseState={courseStateWithProgramType(micromasters)}
           initialUserSubsidyState={initialUserSubsidyState}
         />,
       );
@@ -362,7 +362,7 @@ describe('<CourseHeader />', () => {
       render(
         <CourseHeaderWrapper
           initialAppState={initialAppState}
-          initialCourseState={courseStateWithProgramType(profCert)}
+          courseState={courseStateWithProgramType(profCert)}
           initialUserSubsidyState={initialUserSubsidyState}
         />,
       );

--- a/src/components/course/course-header/tests/DeprecatedCourseRunCard.test.jsx
+++ b/src/components/course/course-header/tests/DeprecatedCourseRunCard.test.jsx
@@ -6,7 +6,7 @@ import { AppContext } from '@edx/frontend-platform/react';
 import {
   renderWithRouter,
   initialAppState,
-  initialCourseState,
+  mockCourseState,
 } from '../../../../utils/tests';
 
 import {
@@ -45,7 +45,7 @@ jest.mock('../../data/hooks', () => ({
 }));
 
 const INITIAL_APP_STATE = initialAppState({});
-const defaultCourse = initialCourseState({});
+const defaultCourse = mockCourseState({});
 
 const selfPacedCourseWithoutLicenseSubsidy = {
   ...defaultCourse,
@@ -80,7 +80,7 @@ const renderCard = ({
   userEntitlements = [],
   courseEntitlements = [],
   userEnrollments = [],
-  courseInitState = selfPacedCourseWithoutLicenseSubsidy,
+  courseState = selfPacedCourseWithoutLicenseSubsidy,
   initialUserSubsidyState = {
     subscriptionLicense: null,
     couponCodes: {
@@ -104,7 +104,7 @@ const renderCard = ({
       <SubsidyRequestsContext.Provider value={initialSubsidyRequestsState}>
         <UserSubsidyContext.Provider value={initialUserSubsidyState}>
           <CourseContextProvider
-            initialCourseState={courseInitState}
+            courseState={courseState}
             userSubsidyApplicableToCourse={userSubsidyApplicableToCourse}
             userCanRequestSubsidyForCourse={userCanRequestSubsidyForCourse}
           >

--- a/src/components/course/data/constants.js
+++ b/src/components/course/data/constants.js
@@ -1,7 +1,5 @@
 import GetSmarterLogo from '../../../assets/icons/getsmarter-header-icon.svg';
 
-export const SET_COURSE_RUN = 'SET_COURSE_RUN';
-
 export const COURSE_PACING_MAP = {
   SELF_PACED: 'self_paced',
   INSTRUCTOR_PACED: 'instructor_paced',

--- a/src/components/course/enrollment/tests/EnrollAction.test.jsx
+++ b/src/components/course/enrollment/tests/EnrollAction.test.jsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import {
   renderWithRouter,
   initialAppState,
-  initialCourseState,
+  mockCourseState,
 } from '../../../../utils/tests';
 import { COURSE_MODES_MAP } from '../../data/constants';
 import EnrollAction from '../EnrollAction';
@@ -40,7 +40,7 @@ const {
 } = enrollButtonTypes;
 
 const INITIAL_APP_STATE = initialAppState({});
-const selfPacedCourseWithLicenseSubsidy = initialCourseState({});
+const selfPacedCourseWithLicenseSubsidy = mockCourseState({});
 const verifiedTrackEnrollment = {
   mode: COURSE_MODES_MAP.VERIFIED,
   isActive: true,
@@ -58,7 +58,7 @@ const EnrollLabel = (props) => (
 );
 const renderEnrollAction = ({
   enrollAction,
-  courseInitState = selfPacedCourseWithLicenseSubsidy,
+  courseState = selfPacedCourseWithLicenseSubsidy,
   initialUserSubsidyState = {
     subscriptionLicense,
     couponCodes: {
@@ -79,7 +79,7 @@ const renderEnrollAction = ({
       <UserSubsidyContext.Provider value={initialUserSubsidyState}>
         <SubsidyRequestsContext.Provider value={initialSubsidyRequestsState}>
           <CourseEnrollmentsContext.Provider value={initialCourseEnrollmentsRequestState}>
-            <CourseContextProvider initialCourseState={courseInitState}>
+            <CourseContextProvider courseState={courseState}>
               {enrollAction}
             </CourseContextProvider>
           </CourseEnrollmentsContext.Provider>

--- a/src/components/course/enrollment/tests/hooks.test.jsx
+++ b/src/components/course/enrollment/tests/hooks.test.jsx
@@ -40,14 +40,14 @@ const baseUserSubsidyState = {
 };
 
 const ContextWrapper = ({
-  initialCourseState,
+  courseState,
   initialSubsidyRequestContextValue,
   initialUserSubsidyState,
   children,
 }) => (
   <UserSubsidyContext.Provider value={initialUserSubsidyState}>
     <SubsidyRequestsContext.Provider value={initialSubsidyRequestContextValue}>
-      <CourseContextProvider initialCourseState={initialCourseState}>
+      <CourseContextProvider courseState={courseState}>
         {children}
       </CourseContextProvider>
     </SubsidyRequestsContext.Provider>
@@ -55,14 +55,14 @@ const ContextWrapper = ({
 );
 
 ContextWrapper.propTypes = {
-  initialCourseState: PropTypes.shape(),
+  courseState: PropTypes.shape(),
   initialSubsidyRequestContextValue: PropTypes.shape(),
   initialUserSubsidyState: PropTypes.shape(),
   children: PropTypes.node.isRequired,
 };
 
 ContextWrapper.defaultProps = {
-  initialCourseState: BASE_COURSE_STATE,
+  courseState: BASE_COURSE_STATE,
   initialSubsidyRequestContextValue: baseSubsidyRequestContextValue,
   initialUserSubsidyState: baseUserSubsidyState,
 };
@@ -100,7 +100,7 @@ describe('useEnrollData', () => {
 
     // Needed to render our hook with context initialized
     const wrapper = ({ children }) => (
-      <ContextWrapper initialCourseState={courseState}>
+      <ContextWrapper courseState={courseState}>
         {children}
       </ContextWrapper>
     );
@@ -144,7 +144,7 @@ describe('useSubsidyDataForCourse', () => {
     // Needed to render our hook with context initialized
     const wrapper = ({ children }) => (
       <ContextWrapper
-        initialCourseState={courseState}
+        courseState={courseState}
         initialUserSubsidyState={initialUserSubsidyState}
       >
         {children}

--- a/src/components/course/tests/CourseAssociatedPrograms.test.jsx
+++ b/src/components/course/tests/CourseAssociatedPrograms.test.jsx
@@ -28,7 +28,7 @@ const CourseAssociatedProgramsWithCourseContext = ({
 }) => (
   <AppContext.Provider value={INITIAL_APP_STATE}>
     <SubsidyRequestsContext.Provider value={subsidyRequestContextValue}>
-      <CourseContextProvider initialCourseState={initialState}>
+      <CourseContextProvider courseState={initialState}>
         <CourseAssociatedPrograms />
       </CourseContextProvider>
     </SubsidyRequestsContext.Provider>

--- a/src/components/course/tests/CourseContextProvider.test.jsx
+++ b/src/components/course/tests/CourseContextProvider.test.jsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 
 import { CourseContextProvider, CourseContext } from '../CourseContextProvider';
 
-const baseInitialCourseState = {
+const baseCourseState = {
   course: {},
   activeCourseRun: {},
   userEnrollments: [],
@@ -15,11 +15,11 @@ const baseInitialCourseState = {
 const CourseContextProviderWrapper = ({
   subsidyRequestCatalogsApplicableToCourse = new Set(),
   userCanRequestSubsidyForCourse = false,
-  initialCourseState = baseInitialCourseState,
+  courseState = baseCourseState,
   children,
 }) => (
   <CourseContextProvider
-    initialCourseState={initialCourseState}
+    courseState={courseState}
     subsidyRequestCatalogsApplicableToCourse={subsidyRequestCatalogsApplicableToCourse}
     userCanRequestSubsidyForCourse={userCanRequestSubsidyForCourse}
   >
@@ -47,14 +47,14 @@ describe('<CourseContextProvider>', () => {
   ])('has 1 catalog for configured subsidy type applicable to course', ({ canRequestEnrollment }) => {
     const testCatalogUUID = 'test-catalog-uuid';
     const courseState = {
-      ...baseInitialCourseState,
+      ...baseCourseState,
       catalog: { catalogList: [testCatalogUUID] },
     };
     const requestCatalogsForCourse = canRequestEnrollment ? [testCatalogUUID] : [];
     render(
       <CourseContextProviderWrapper
         subsidyRequestCatalogsApplicableToCourse={new Set(requestCatalogsForCourse)}
-        initialCourseState={courseState}
+        courseState={courseState}
         userCanRequestSubsidyForCourse={canRequestEnrollment}
       >
         <CourseContext.Consumer>

--- a/src/components/course/tests/CoursePage.test.jsx
+++ b/src/components/course/tests/CoursePage.test.jsx
@@ -6,7 +6,7 @@ import { CourseEnrollmentsContext } from '../../dashboard/main-content/course-en
 import { CourseContextProvider } from '../CourseContextProvider';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy/UserSubsidy';
 import { SubsidyRequestsContext, SUBSIDY_TYPE } from '../../enterprise-subsidy-requests';
-import { initialCourseState } from '../../../utils/tests';
+import { mockCourseState } from '../../../utils/tests';
 import CoursePage from '../CoursePage';
 import { useAllCourseData } from '../data/hooks';
 import { LEARNER_CREDIT_SUBSIDY_TYPE as mockLearnerCreditSubsidyType } from '../data/constants';
@@ -168,9 +168,9 @@ const initialSubsidyRequestsState = {
   },
   catalogsForSubsidyRequests: ['test-catalog-subsidy-requests', 'course-run-1'],
 };
-const initialCourseStateDefined = initialCourseState({});
-const updatedInitialCourseStateDefined = {
-  ...initialCourseStateDefined,
+const courseStateDefined = mockCourseState({});
+const updatedCourseStateDefined = {
+  ...courseStateDefined,
   catalog: {
     catalogList: ['test-catalog-subsidy-requests'],
   },
@@ -205,7 +205,7 @@ describe('CoursePage', () => {
         <UserSubsidyContext.Provider value={initialUserSubsidyState}>
           <SubsidyRequestsContext.Provider value={initialSubsidyRequestsState}>
             <CourseEnrollmentsContext.Provider value={initialCourseEnrollmentsState}>
-              <CourseContextProvider initialCourseState={updatedInitialCourseStateDefined}>
+              <CourseContextProvider courseState={updatedCourseStateDefined}>
                 <MemoryRouter>
                   <CoursePage location={mockLocation} match={{ params: mockParams }} />
                 </MemoryRouter>
@@ -238,7 +238,7 @@ describe('CoursePage', () => {
         <UserSubsidyContext.Provider value={initialUserSubsidyState}>
           <SubsidyRequestsContext.Provider value={initialSubsidyRequestsState}>
             <CourseEnrollmentsContext.Provider value={initialCourseEnrollmentsState}>
-              <CourseContextProvider initialCourseState={updatedInitialCourseStateDefined}>
+              <CourseContextProvider courseState={updatedCourseStateDefined}>
                 <MemoryRouter>
                   <CoursePage location={mockLocation} match={{ params: mockParams }} />
                 </MemoryRouter>

--- a/src/components/course/tests/CourseRecommendations.test.jsx
+++ b/src/components/course/tests/CourseRecommendations.test.jsx
@@ -41,7 +41,7 @@ const course = {
   owners: [TEST_OWNER],
 };
 
-const initialCourseState = {
+const defaultCourseState = {
   state: {
     course: {
       owners: [TEST_OWNER],
@@ -55,7 +55,7 @@ const initialCourseState = {
 
 const CourseRecommendationsWithContext = () => (
   <AppContext.Provider value={initialAppState}>
-    <CourseContext.Provider value={initialCourseState}>
+    <CourseContext.Provider value={defaultCourseState}>
       <CourseRecommendations />
     </CourseContext.Provider>
   </AppContext.Provider>

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -57,7 +57,7 @@ const PARTIAL_COUPON_CODE_SUBSIDY = {
 };
 
 const baseCourseContextProps = {
-  initialCourseState: BASE_COURSE_STATE,
+  courseState: BASE_COURSE_STATE,
   userSubsidyApplicableToCourse: null,
   subsidyRequestCatalogsApplicableToCourse: new Set([mockCatalogUUID]),
   coursePrice: { list: 7.5, discounted: 7.5 },
@@ -163,7 +163,7 @@ describe('<CourseSidebarPrice/> ', () => {
         <SidebarWithContext
           initialAppState={appStateWithOrigPriceShowing}
           courseContextProps={{
-            initialCourseState: BASE_COURSE_STATE,
+            courseState: BASE_COURSE_STATE,
             userSubsidyApplicableToCourse: mockEnterpriseOfferSubsidy,
             coursePrice: { list: 7.5, discounted: 0 },
             currency: 'USD',

--- a/src/components/course/tests/CourseSkills.test.jsx
+++ b/src/components/course/tests/CourseSkills.test.jsx
@@ -27,12 +27,12 @@ const baseSubsidyRequestContextValue = {
 
 const CourseSkillsWithContext = ({
   initialAppState,
-  initialCourseState,
+  courseState,
   initialSubsidyRequestContextValue,
 }) => (
   <AppContext.Provider value={initialAppState}>
     <SubsidyRequestsContext.Provider value={initialSubsidyRequestContextValue}>
-      <CourseContextProvider initialCourseState={initialCourseState}>
+      <CourseContextProvider courseState={courseState}>
         <CourseSkills />
       </CourseContextProvider>
     </SubsidyRequestsContext.Provider>
@@ -41,13 +41,13 @@ const CourseSkillsWithContext = ({
 
 CourseSkillsWithContext.propTypes = {
   initialAppState: PropTypes.shape(),
-  initialCourseState: PropTypes.shape(),
+  courseState: PropTypes.shape(),
   initialSubsidyRequestContextValue: PropTypes.shape(),
 };
 
 CourseSkillsWithContext.defaultProps = {
   initialAppState: {},
-  initialCourseState: {},
+  courseState: {},
   initialSubsidyRequestContextValue: baseSubsidyRequestContextValue,
 };
 
@@ -57,7 +57,7 @@ describe('<CourseSkills />', () => {
       slug: 'test-enterprise-slug',
     },
   };
-  const initialCourseState = {
+  const courseState = {
     ...baseCourseState,
     course: {
       skills: generateRandomSkills(MAX_VISIBLE_SKILLS),
@@ -68,32 +68,32 @@ describe('<CourseSkills />', () => {
     renderWithRouter(
       <CourseSkillsWithContext
         initialAppState={initialAppState}
-        initialCourseState={initialCourseState}
+        courseState={courseState}
       />,
     );
-    initialCourseState.course.skills.forEach((skill) => {
+    courseState.course.skills.forEach((skill) => {
       expect(screen.queryByText(skill.name)).toBeVisible();
     });
   });
 
   test('does not render more then max visible skills', () => {
     const skillsCount = MAX_VISIBLE_SKILLS + 2; // random number greater than limit
-    const courseState = {
-      ...initialCourseState,
+    const newCourseState = {
+      ...courseState,
       course: {
-        ...initialCourseState.course,
+        ...courseState.course,
         skills: generateRandomSkills(skillsCount),
       },
     };
     renderWithRouter(
       <CourseSkillsWithContext
         initialAppState={initialAppState}
-        initialCourseState={courseState}
+        courseState={newCourseState}
       />,
     );
 
-    const shownSkills = initialCourseState.course.skills.slice(0, MAX_VISIBLE_SKILLS);
-    const hiddenSkills = initialCourseState.course.skills.slice(MAX_VISIBLE_SKILLS, skillsCount);
+    const shownSkills = courseState.course.skills.slice(0, MAX_VISIBLE_SKILLS);
+    const hiddenSkills = courseState.course.skills.slice(MAX_VISIBLE_SKILLS, skillsCount);
 
     shownSkills.forEach((skill) => {
       expect(screen.queryByText(skill.name)).toBeVisible();
@@ -109,12 +109,12 @@ describe('<CourseSkills />', () => {
     renderWithRouter(
       <CourseSkillsWithContext
         initialAppState={initialAppState}
-        initialCourseState={initialCourseState}
+        courseState={courseState}
       />,
     );
     /* eslint-disable no-await-in-loop */
 
-    for (const skill of initialCourseState.course.skills) { // eslint-disable-line no-restricted-syntax
+    for (const skill of courseState.course.skills) { // eslint-disable-line no-restricted-syntax
       await act(async () => {
         fireEvent.mouseOver(screen.getByText(skill.name));
       });
@@ -125,10 +125,10 @@ describe('<CourseSkills />', () => {
 
   test('renders tooltip text only till maximum cutoff value when skill description is too long', async () => {
     // set a skill description greater than description cutoff limit
-    const courseState = {
-      ...initialCourseState,
+    const defaultCourseState = {
+      ...courseState,
       course: {
-        ...initialCourseState.course,
+        ...courseState.course,
         skills: [
           {
             name: 'Skill with long description',
@@ -141,7 +141,7 @@ describe('<CourseSkills />', () => {
     renderWithRouter(
       <CourseSkillsWithContext
         initialAppState={initialAppState}
-        initialCourseState={courseState}
+        courseState={defaultCourseState}
       />,
     );
     const { skills } = courseState.course;

--- a/src/components/course/tests/CourseSkills.test.jsx
+++ b/src/components/course/tests/CourseSkills.test.jsx
@@ -125,7 +125,7 @@ describe('<CourseSkills />', () => {
 
   test('renders tooltip text only till maximum cutoff value when skill description is too long', async () => {
     // set a skill description greater than description cutoff limit
-    const defaultCourseState = {
+    const newCourseState = {
       ...courseState,
       course: {
         ...courseState.course,
@@ -141,14 +141,14 @@ describe('<CourseSkills />', () => {
     renderWithRouter(
       <CourseSkillsWithContext
         initialAppState={initialAppState}
-        courseState={defaultCourseState}
+        courseState={newCourseState}
       />,
     );
-    const { skills } = courseState.course;
+    const { skills } = newCourseState.course;
     const maxVisibleDesc = shortenString(skills[0].description, SKILL_DESCRIPTION_CUTOFF_LIMIT, ELLIPSIS_STR);
     await act(async () => {
       fireEvent.mouseOver(screen.getByText(skills[0].name));
     });
-    expect(await screen.queryByText(maxVisibleDesc)).toBeVisible();
+    expect(await screen.findByText(maxVisibleDesc)).toBeVisible();
   });
 });

--- a/src/components/course/tests/CreatedBy.test.jsx
+++ b/src/components/course/tests/CreatedBy.test.jsx
@@ -12,9 +12,9 @@ const initialSubsidyRequestsState = {
   catalogsForSubsidyRequests: [],
 };
 
-const CreatedByWithCourseContext = ({ initialCourseState = {} }) => (
+const CreatedByWithCourseContext = ({ courseState = {} }) => (
   <SubsidyRequestsContext.Provider value={initialSubsidyRequestsState}>
-    <CourseContextProvider initialCourseState={initialCourseState}>
+    <CourseContextProvider courseState={courseState}>
       <CreatedBy />
     </CourseContextProvider>
   </SubsidyRequestsContext.Provider>
@@ -52,14 +52,14 @@ describe('<CreatedBy />', () => {
   };
 
   test('renders partner info', () => {
-    render(<CreatedByWithCourseContext initialCourseState={initialState} />);
+    render(<CreatedByWithCourseContext courseState={initialState} />);
     initialState.course.owners.forEach((owner) => {
       expect(screen.queryByText(owner.name)).toBeInTheDocument();
     });
   });
 
   test('renders staff info', () => {
-    render(<CreatedByWithCourseContext initialCourseState={initialState} />);
+    render(<CreatedByWithCourseContext courseState={initialState} />);
     initialState.activeCourseRun.staff.forEach((staffMember) => {
       const fullName = `${staffMember.givenName} ${staffMember.familyName}`;
       expect(screen.queryByText(fullName)).toBeInTheDocument();

--- a/src/components/course/tests/SubsidyRequestButton.test.jsx
+++ b/src/components/course/tests/SubsidyRequestButton.test.jsx
@@ -39,7 +39,7 @@ const initialSubsidyRequestsState = {
 };
 
 const TEST_CATALOG_UUID = 'test-catalog-uuid';
-const initialCourseState = {
+const courseState = {
   course: {
     key: mockCourseKey,
     courseRunKeys: [mockCourseRunKey],
@@ -49,7 +49,7 @@ const initialCourseState = {
 };
 
 const defaultCourseContextValue = {
-  state: initialCourseState,
+  state: courseState,
   userSubsidyApplicableToCourse: undefined,
   subsidyRequestCatalogsApplicableToCourse: new Set([TEST_CATALOG_UUID]),
 };
@@ -60,7 +60,7 @@ const SubsidyRequestButtonWrapper = ({
 }) => (
   <ToastsContext.Provider value={initialToastsState}>
     <SubsidyRequestsContext.Provider value={{ ...initialSubsidyRequestsState, ...subsidyRequestsState }}>
-      <CourseContext.Provider value={{ state: initialCourseState, ...courseContextValue }}>
+      <CourseContext.Provider value={{ state: courseState, ...courseContextValue }}>
         <SubsidyRequestButton />
       </CourseContext.Provider>
     </SubsidyRequestsContext.Provider>

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -118,14 +118,14 @@ let mockLocation = {
 const DashboardWithContext = ({
   initialAppState = defaultAppState,
   initialUserSubsidyState = defaultUserSubsidyState,
-  initialCourseState = defaultCourseState,
+  courseState = defaultCourseState,
   initialSubsidyRequestState = defaultSubsidyRequestState,
 }) => (
   <IntlProvider locale="en">
     <AppContext.Provider value={initialAppState}>
       <UserSubsidyContext.Provider value={initialUserSubsidyState}>
         <SubsidyRequestsContext.Provider value={initialSubsidyRequestState}>
-          <CourseContextProvider initialCourseState={initialCourseState}>
+          <CourseContextProvider courseState={courseState}>
             <DashboardPage />
           </CourseContextProvider>
         </SubsidyRequestsContext.Provider>

--- a/src/utils/tests.jsx
+++ b/src/utils/tests.jsx
@@ -44,7 +44,7 @@ export const initialAppState = ({
  * e.g. <CourseContext.Provider />
  * Returns a self-paced course with a license subsidy, by default.
  */
-export const initialCourseState = ({
+export const mockCourseState = ({
   pacingType = 'self-paced',
   userSubsidyApplicableToCourse = { subsidyType: 'license' },
 }) => ({


### PR DESCRIPTION
# Description

Noticed a bug on local/stage/production where navigating between courses on the course page (e.g., clicking one of the course card recommendations to another related course) makes the expected additional API calls but does not re-render the data once the APIs resolve, leaving the user confused why they're not seeing the other course data. Refreshing the page after clicking the recommendation card shows the correct course.

This issue is due to the `courseState` being used within a `useReducer`, such that it only acts as initial state; not the active, current state representing the latest data available. To mutate the reducer state, you need to dispatch actions, we aren't doing.

To fix this issue, we will no longer use the `useReducer` hook within the `CourseContextProvider`, and simply pass it through to the context value as is. This approach works as the `courseState` is already memoized with `useMemo` in `CoursePage`, so it won't cause course page re-renders unless its data changes.

See below for an example case where this bug is evident (clicking course recommendation card changes the url, but doesn't update the course page UI):

[Course_Page_History_bug.webm](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/164513b3-df21-4971-adf8-fb7deee4aa29)

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
