### PR TITLE
fix: consolidates IntegrationWarningModal to parent to avoid duplicate calls

### DIFF
--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -19,12 +19,15 @@ import { useInProgressPathwaysData } from '../pathway-progress/data/hooks';
 import CoursesTabComponent from './main-content/CoursesTabComponent';
 import { MyCareerTab } from '../my-career';
 import EnterpriseLearnerFirstVisitRedirect from '../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect';
+import { UserSubsidyContext } from '../enterprise-user-subsidy';
+import { IntegrationWarningModal } from '../integration-warning-modal';
+import SubscriptionExpirationModal from './SubscriptionExpirationModal';
 
 const DashboardPage = () => {
   const { state } = useLocation();
   const history = useHistory();
   const { enterpriseConfig, authenticatedUser } = useContext(AppContext);
-
+  const { subscriptionPlan, showExpirationNotifications } = useContext(UserSubsidyContext);
   // TODO: Create a context provider containing these 2 data fetch hooks to future proof when we need to use this data
   const [learnerProgramsListData, programsFetchError] = useLearnerProgramsListData(enterpriseConfig.uuid);
   const [pathwayProgressData, pathwayFetchError] = useInProgressPathwaysData(enterpriseConfig.uuid);
@@ -79,6 +82,8 @@ const DashboardPage = () => {
             </Tab>
           )}
         </Tabs>
+        {enterpriseConfig.showIntegrationWarning && <IntegrationWarningModal isOpen />}
+        {subscriptionPlan && showExpirationNotifications && <SubscriptionExpirationModal />}
       </Container>
     </>
   );

--- a/src/components/dashboard/main-content/CoursesTabComponent.jsx
+++ b/src/components/dashboard/main-content/CoursesTabComponent.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   useToggle,
@@ -7,24 +7,17 @@ import {
   MediaQuery,
   breakpoints,
 } from '@edx/paragon';
-import { AppContext } from '@edx/frontend-platform/react';
 import PropTypes from 'prop-types';
-import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { CourseEnrollmentsContextProvider } from './course-enrollments';
-import { IntegrationWarningModal } from '../../integration-warning-modal';
 import { MainContent, Sidebar } from '../../layout';
 import CourseEnrollmentFailedAlert, { ENROLLMENT_SOURCE } from '../../course/CourseEnrollmentFailedAlert';
 import DashboardMainContent from './DashboardMainContent';
 import { DashboardSidebar } from '../sidebar';
-import SubscriptionExpirationModal from '../SubscriptionExpirationModal';
 import { LICENSE_ACTIVATION_MESSAGE } from '../data/constants';
 
 const CoursesTabComponent = ({ canOnlyViewHighlightSets }) => {
   const { state } = useLocation();
-  const { enterpriseConfig } = useContext(AppContext);
-  const { subscriptionPlan, showExpirationNotifications } = useContext(UserSubsidyContext);
   const [isActivationAlertOpen, , closeActivationAlert] = useToggle(!!state?.activationSuccess);
-
   return (
     <>
       <Alert
@@ -50,8 +43,6 @@ const CoursesTabComponent = ({ canOnlyViewHighlightSets }) => {
             ) : null)}
           </MediaQuery>
         </CourseEnrollmentsContextProvider>
-        <IntegrationWarningModal isOpen={enterpriseConfig.showIntegrationWarning} />
-        {subscriptionPlan && showExpirationNotifications && <SubscriptionExpirationModal />}
       </Row>
     </>
   );

--- a/src/components/my-career/AddJobRole.jsx
+++ b/src/components/my-career/AddJobRole.jsx
@@ -4,11 +4,8 @@ import {
   Alert, Row, breakpoints, MediaQuery, Hyperlink, Icon, useToggle,
 } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
-import { IntegrationWarningModal } from '../integration-warning-modal';
 import { MainContent, Sidebar } from '../layout';
 import { DashboardSidebar } from '../dashboard/sidebar';
-import { UserSubsidyContext } from '../enterprise-user-subsidy';
-import SubscriptionExpirationModal from '../dashboard/SubscriptionExpirationModal';
 import { CourseEnrollmentsContextProvider } from '../dashboard/main-content/course-enrollments';
 import CourseEnrollmentFailedAlert, { ENROLLMENT_SOURCE } from '../course/CourseEnrollmentFailedAlert';
 import { LICENSE_ACTIVATION_MESSAGE } from '../dashboard/data/constants';
@@ -16,12 +13,9 @@ import { LICENSE_ACTIVATION_MESSAGE } from '../dashboard/data/constants';
 import SkillsQuizImage from '../../assets/images/skills-quiz/skills-quiz.png';
 
 const AddJobRole = () => {
-  const { enterpriseConfig } = useContext(AppContext);
-  const { subscriptionPlan, showExpirationNotifications } = useContext(UserSubsidyContext);
   const { state } = useLocation();
   const history = useHistory();
   const [isActivationAlertOpen, , closeActivationAlert] = useToggle(!!state?.activationSuccess);
-
   useEffect(() => {
     if (state?.activationSuccess) {
       const updatedLocationState = { ...state };
@@ -89,12 +83,6 @@ const AddJobRole = () => {
             ) : null)}
           </MediaQuery>
         </CourseEnrollmentsContextProvider>
-        <IntegrationWarningModal
-          isOpen={enterpriseConfig.showIntegrationWarning}
-        />
-        {subscriptionPlan && showExpirationNotifications && (
-          <SubscriptionExpirationModal />
-        )}
       </Row>
     </>
   );

--- a/src/components/my-career/SkillsRecommendationCourses.jsx
+++ b/src/components/my-career/SkillsRecommendationCourses.jsx
@@ -79,7 +79,7 @@ const SkillsRecommendationCourses = ({ index, subCategoryName, subCategorySkills
   }
   return (
     <div>
-      {subCategoryName && <h5 className="mb-3 mt-n4">More courses that teach you {subCategoryName} Skills</h5>}
+      <h5 className="mb-3 mt-n4">More courses that teach you {subCategoryName} Skills</h5>
       <CardGrid>
         {courses.map(course => (
           <SearchCourseCard

--- a/src/components/my-career/SkillsRecommendationCourses.jsx
+++ b/src/components/my-career/SkillsRecommendationCourses.jsx
@@ -74,14 +74,12 @@ const SkillsRecommendationCourses = ({ index, subCategoryName, subCategorySkills
     },
     [filters, index, skillsFacetFilter],
   );
-
   if (hitCount === 0) {
     return null;
   }
-
   return (
     <div>
-      <h5 className="mb-3 mt-n4">More courses that teach you {subCategoryName} Skills</h5>
+      {subCategoryName && <h5 className="mb-3 mt-n4">More courses that teach you {subCategoryName} Skills</h5>}
       <CardGrid>
         {courses.map(course => (
           <SearchCourseCard

--- a/src/components/my-career/tests/AddJobRole.test.jsx
+++ b/src/components/my-career/tests/AddJobRole.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { screen } from '@testing-library/react';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import { SUBSIDY_TYPE } from '../../enterprise-subsidy-requests/constants';
@@ -13,6 +14,16 @@ jest.mock('@edx/frontend-platform/i18n', () => ({
   ...jest.requireActual('@edx/frontend-platform/i18n'),
   getLocale: () => 'en',
   getMessages: () => ({}),
+}));
+
+// mock useLocation
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => ({
+    state: {
+      activationSuccess: true,
+    },
+  }),
 }));
 
 // eslint-disable-next-line no-console
@@ -46,19 +57,6 @@ const expiringSubscriptionUserSubsidyState = {
   showExpirationNotifications: false,
 };
 
-const expiredSubscriptionUserSubsidyState = {
-  subsidyRequestConfiguration: null,
-  requestsBySubsidyType: {
-    [SUBSIDY_TYPE.LICENSE]: [],
-    [SUBSIDY_TYPE.COUPON]: [],
-  },
-  catalogsForSubsidyRequests: [],
-  subscriptionPlan: {
-    daysUntilExpiration: 0,
-  },
-  showExpirationNotifications: true,
-};
-
 const AddJobRoleWithContext = ({
   initialAppState = defaultAppState,
   initialSubsidyRequestState = defaultSubsidyRequestState,
@@ -78,9 +76,6 @@ const AddJobRoleWithContext = ({
 describe('<AddJobRole />', () => {
   it('renders the AddJobRole component', () => {
     renderWithRouter(<AddJobRoleWithContext />);
-  });
-
-  it('renders the AddJobRole component show subscription expiring modal', () => {
-    renderWithRouter(<AddJobRoleWithContext initialSubsidyRequestState={expiredSubscriptionUserSubsidyState} />);
+    expect(screen.getAllByText('Add Role')).toBeTruthy();
   });
 });

--- a/src/components/my-career/tests/SkillsRecommendationCourses.test.jsx
+++ b/src/components/my-career/tests/SkillsRecommendationCourses.test.jsx
@@ -157,6 +157,6 @@ describe('<SkillsRecommendationCourses />', () => {
     TEST_SKILLS.forEach(async (skill) => {
       await waitFor(() => expect(screen.getByText(skill)).not.toBeInTheDocument());
     });
-    expect(screen.queryByText('More courses that teach you ', { exact: false })).not.toBeInTheDocument();
+    expect(screen.queryByText('More courses that teach you ', { exact: true })).not.toBeInTheDocument();
   });
 });

--- a/src/components/my-career/tests/SkillsRecommendationCourses.test.jsx
+++ b/src/components/my-career/tests/SkillsRecommendationCourses.test.jsx
@@ -3,6 +3,8 @@ import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import { renderWithRouter } from '../../../utils/tests';
@@ -130,11 +132,31 @@ const SkillsRecommendationCoursesWithContext = ({
 );
 
 describe('<SkillsRecommendationCourses />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders the SkillsRecommendationCourses component with recommendations', () => {
     renderWithRouter(<SkillsRecommendationCoursesWithContext />);
+    TEST_SKILLS.forEach(async (skill) => {
+      await waitFor(() => expect(screen.getByText(skill)).toBeInTheDocument());
+    });
+    userEvent.click(screen.getByText('Show more courses'));
   });
 
   it('renders the SkillsRecommendationCourses component without recommendations', () => {
-    renderWithRouter(<SkillsRecommendationCoursesWithContext subCategorySkills={[]} />);
+    const emptyIndex = {
+      indexName: 'test-index-name',
+      search: jest.fn().mockImplementation(() => Promise.resolve({
+        hits: [],
+        nbHits: 0,
+      })),
+    };
+
+    renderWithRouter(<SkillsRecommendationCoursesWithContext index={emptyIndex} subCategorySkills={[]} subCategoryName="" />);
+    TEST_SKILLS.forEach(async (skill) => {
+      await waitFor(() => expect(screen.getByText(skill)).not.toBeInTheDocument());
+    });
+    expect(screen.queryByText('More courses that teach you ', { exact: false })).not.toBeInTheDocument();
   });
 });

--- a/src/components/skills-quiz/tests/SkillsQuizPage.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsQuizPage.test.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { screen } from '@testing-library/react';
+import { AppContext } from '@edx/frontend-platform/react';
+import { SearchData } from '@edx/frontend-enterprise-catalog-search';
+import { mergeConfig } from '@edx/frontend-platform';
+import { UserSubsidyContext } from '../../enterprise-user-subsidy';
+import { SKILLS_QUIZ_SEARCH_PAGE_MESSAGE } from '../constants';
+
+import {
+  renderWithRouter,
+} from '../../../utils/tests';
+import { SkillsContextProvider } from '../SkillsContextProvider';
+import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
+import SkillsQuizPage from '../SkillsQuizPage';
+
+const mockLocation = {
+  pathname: '/welcome',
+  hash: '',
+  search: '',
+  state: { activationSuccess: true },
+};
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => (mockLocation),
+}));
+
+jest.mock('@edx/frontend-platform/auth', () => ({
+  ...jest.requireActual('@edx/frontend-platform/auth'),
+  getAuthenticatedUser: () => ({ username: 'myspace-tom' }),
+}));
+
+jest.mock('@edx/frontend-enterprise-utils', () => ({
+  ...jest.requireActual('@edx/frontend-enterprise-utils'),
+  sendEnterpriseTrackEvent: jest.fn(),
+}));
+
+const defaultCouponCodesState = {
+  couponCodes: [],
+  loading: false,
+  couponCodesCount: 0,
+};
+
+const defaultAppState = {
+  enterpriseConfig: {
+    name: 'BearsRUs',
+  },
+  config: {
+    LMS_BASE_URL: process.env.LMS_BASE_URL,
+  },
+};
+
+const defaultUserSubsidyState = {
+  couponCodes: defaultCouponCodesState,
+};
+
+const defaultSubsidyRequestState = {
+  catalogsForSubsidyRequests: [],
+};
+const SkillsQuizPageWithContext = ({
+  initialAppState = defaultAppState,
+  initialUserSubsidyState = defaultUserSubsidyState,
+  initialSubsidyRequestState = defaultSubsidyRequestState,
+  enableSkillsQuiz = true,
+}) => {
+  mergeConfig({
+    ENABLE_SKILLS_QUIZ: enableSkillsQuiz,
+  });
+  return (
+    <AppContext.Provider value={initialAppState}>
+      <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+        <SubsidyRequestsContext.Provider value={initialSubsidyRequestState}>
+          <SkillsQuizPage />
+        </SubsidyRequestsContext.Provider>
+      </UserSubsidyContext.Provider>
+    </AppContext.Provider>
+  );
+};
+
+describe('SkillsQuizPage', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  it('should render SkillsQuiz', async () => {
+    renderWithRouter(
+      <SearchData>
+        <SkillsContextProvider>
+          <SkillsQuizPageWithContext enableSkillsQuiz />
+        </SkillsContextProvider>
+      </SearchData>,
+      { route: '/test/skills-quiz/' },
+    );
+    expect(screen.getByText(SKILLS_QUIZ_SEARCH_PAGE_MESSAGE)).toBeInTheDocument();
+  });
+  it('should render null', async () => {
+    renderWithRouter(
+      <SearchData>
+        <SkillsContextProvider>
+          <SkillsQuizPageWithContext enableSkillsQuiz={false} />
+        </SkillsContextProvider>
+      </SearchData>,
+      { route: '/test/skills-quiz/' },
+    );
+    expect(screen.queryByText(SKILLS_QUIZ_SEARCH_PAGE_MESSAGE)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/skills-quiz/tests/utils.test.jsx
+++ b/src/components/skills-quiz/tests/utils.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithSearchContext } from './utils';
+
+describe('SkillsContextProvider', () => {
+  it('should render children', () => {
+    renderWithSearchContext(<div>Test</div>);
+    expect(screen.getByText('Test')).toBeTruthy();
+  });
+});

--- a/src/components/system-wide-banner/SystemWideWarningBanner.test.jsx
+++ b/src/components/system-wide-banner/SystemWideWarningBanner.test.jsx
@@ -1,0 +1,13 @@
+import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { screen } from '@testing-library/react';
+import SystemWideWarningBanner from './SystemWideWarningBanner';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('SystemWideWarningBanner', () => {
+  it('renders correctly', () => {
+    renderWithRouter(
+      <SystemWideWarningBanner>Test</SystemWideWarningBanner>,
+    );
+    expect(screen.getByText('Test')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Moves the `IntegrationWarningModal` and `SubscriptionExpirationModal` to the common parent component `DashboardPage` to avoid rendering from two separate components.
Removes `IntegrationWarningModal` and `SubscriptionExpirationModal` and related dependencies from `CoursesTabComponent` and `AddJobRole` since they are rendered on the same parent component.

Pending Tests.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
