### PR TITLE
fix: ensure we count prior redemption as having subsidy available for the course

### DIFF
--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -695,8 +695,12 @@ export const useUserSubsidyApplicableToCourse = ({
 
     let applicableUserSubsidy;
 
-    // if course can be redeemed with a subsidy access policy, return it as the subsidyType.
+    // if course can be redeemed with a subsidy access policy, return `learnerCredit` subsidy type.
     if (isPolicyRedemptionEnabled) {
+      // the enterprise-access `can-redeem` API returns `can_redeem: false` when a learner
+      // has already redeemed a course. This means the course page thinks the learner no
+      // longer has any subsidy available to spend. `isPolicyRedemptionEnabled` is true when
+      // `can_redeem: false && has_successful_redemption: true`, so `redeemableSubsidyAccessPolicy` may now be null.
       applicableUserSubsidy = {
         discountType: 'percentage',
         discountValue: 100,

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -587,16 +587,20 @@ const checkRedemptionEligibility = async ({ queryKey }) => {
   const otherSubsidyAccessPolicy = transformedResponse.find(
     r => r.redeemableSubsidyAccessPolicy,
   )?.redeemableSubsidyAccessPolicy;
+
+  const hasSuccessfulRedemption = transformedResponse.some(r => r.hasSuccessfulRedemption);
+
   // If there is a redeemable subsidy access policy for the active course run, use that. Otherwise, use any other
   // redeemable subsidy access policy for any of the content keys.
   const redeemableSubsidyAccessPolicy = preferredSubsidyAccessPolicy || otherSubsidyAccessPolicy;
-  const isPolicyRedemptionEnabled = !!redeemableSubsidyAccessPolicy;
+  const isPolicyRedemptionEnabled = hasSuccessfulRedemption || !!redeemableSubsidyAccessPolicy;
 
   return {
     isPolicyRedemptionEnabled,
     redeemabilityPerContentKey: transformedResponse,
     redeemableSubsidyAccessPolicy,
     missingSubsidyAccessPolicyReason,
+    hasSuccessfulRedemption,
   };
 };
 
@@ -691,16 +695,15 @@ export const useUserSubsidyApplicableToCourse = ({
 
     let applicableUserSubsidy;
 
-    // if course can be redeemed with EMET system, return
-    // the redeemable subsidy access policy.
-    if (isPolicyRedemptionEnabled && redeemableSubsidyAccessPolicy) {
+    // if course can be redeemed with a subsidy access policy, return it as the subsidyType.
+    if (isPolicyRedemptionEnabled) {
       applicableUserSubsidy = {
         discountType: 'percentage',
         discountValue: 100,
         subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE,
-        perLearnerEnrollmentLimit: redeemableSubsidyAccessPolicy.perLearnerEnrollmentLimit,
-        perLearnerSpendLimit: redeemableSubsidyAccessPolicy.perLearnerSpendLimit,
-        policyRedemptionUrl: redeemableSubsidyAccessPolicy.policyRedemptionUrl,
+        perLearnerEnrollmentLimit: redeemableSubsidyAccessPolicy?.perLearnerEnrollmentLimit,
+        perLearnerSpendLimit: redeemableSubsidyAccessPolicy?.perLearnerSpendLimit,
+        policyRedemptionUrl: redeemableSubsidyAccessPolicy?.policyRedemptionUrl,
       };
     }
 
@@ -910,9 +913,10 @@ export const useExternalEnrollmentFailureReason = () => {
   const {
     userSubsidyApplicableToCourse,
     missingUserSubsidyReason,
+    hasSuccessfulRedemption,
   } = useContext(CourseContext);
   return useMemo(() => {
-    if (userSubsidyApplicableToCourse) {
+    if (userSubsidyApplicableToCourse || hasSuccessfulRedemption) {
       return {};
     }
     let reason;
@@ -940,5 +944,10 @@ export const useExternalEnrollmentFailureReason = () => {
       failureReason: reason,
       failureMessage: createExecutiveEducationFailureMessage({ failureCode: reason, intl }),
     };
-  }, [userSubsidyApplicableToCourse, missingUserSubsidyReason, intl]);
+  }, [
+    userSubsidyApplicableToCourse,
+    missingUserSubsidyReason,
+    intl,
+    hasSuccessfulRedemption,
+  ]);
 };

--- a/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
+++ b/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
@@ -121,4 +121,23 @@ describe('ExternalCourseEnrollment', () => {
     expect(screen.getByText("We're sorry.")).toBeInTheDocument();
     expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
   });
+
+  it('handles successful prior redemption', () => {
+    const courseContextValue = {
+      ...baseCourseContextValue,
+      userSubsidyApplicableToCourse: undefined,
+      hasSuccessfulRedemption: true,
+      missingUserSubsidyReason: { reason: DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY },
+    };
+    renderWithRouter(<ExternalCourseEnrollmentWrapper courseContextValue={courseContextValue} />);
+    expect(screen.getByText('Your registration(s)')).toBeInTheDocument();
+    expect(screen.getByText('Test Course Title')).toBeInTheDocument();
+    expect(screen.getByText('Available start date:')).toBeInTheDocument();
+    expect(screen.getByText('Course duration:')).toBeInTheDocument();
+    expect(screen.getByText('Course total:')).toBeInTheDocument();
+    expect(screen.getAllByText('$100.00 USD')).toHaveLength(2);
+    expect(screen.getByText('Registration summary:')).toBeInTheDocument();
+    expect(screen.getByText('Registration total:')).toBeInTheDocument();
+    expect(screen.getByTestId('user-enrollment-form')).toBeInTheDocument();
+  });
 });

--- a/src/components/course/routes/tests/ExternalCourseEnrollmentConfirmation.test.jsx
+++ b/src/components/course/routes/tests/ExternalCourseEnrollmentConfirmation.test.jsx
@@ -84,7 +84,6 @@ describe('ExternalCourseEnrollment', () => {
     expect(screen.getByText('$100.00 USD')).toBeInTheDocument();
     expect(screen.getByText('What happens next?')).toBeInTheDocument();
     expect(screen.getByText('Terms and Conditions')).toBeInTheDocument();
-    expect(screen.getByText('Terms and Conditions')).toBeInTheDocument();
   });
 
   it('handles failure reason', () => {
@@ -119,7 +118,6 @@ describe('ExternalCourseEnrollment', () => {
     expect(screen.getByText('Course total:')).toBeInTheDocument();
     expect(screen.getByText('$100.00 USD')).toBeInTheDocument();
     expect(screen.getByText('What happens next?')).toBeInTheDocument();
-    expect(screen.getByText('Terms and Conditions')).toBeInTheDocument();
     expect(screen.getByText('Terms and Conditions')).toBeInTheDocument();
   });
 });

--- a/src/components/course/routes/tests/ExternalCourseEnrollmentConfirmation.test.jsx
+++ b/src/components/course/routes/tests/ExternalCourseEnrollmentConfirmation.test.jsx
@@ -100,4 +100,26 @@ describe('ExternalCourseEnrollment', () => {
     expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
     expect(screen.getByText('No learner credit is available to cover this course.'));
   });
+
+  it('handles successful prior redemption', () => {
+    const courseContextValue = {
+      ...baseCourseContextValue,
+      userSubsidyApplicableToCourse: undefined,
+      hasSuccessfulRedemption: true,
+      missingUserSubsidyReason: { reason: DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY_NO_ADMINS },
+    };
+    render(<ExternalCourseEnrollmentConfirmationWrapper courseContextValue={courseContextValue} />);
+    expect(screen.getByText('Congratulations, you have completed your enrollment for your online course')).toBeInTheDocument();
+    expect(screen.getByText('Test Course Title')).toBeInTheDocument();
+    expect(screen.getByText('Test Org')).toBeInTheDocument();
+    expect(screen.getByText('Start date:')).toBeInTheDocument();
+    expect(screen.getByText('March 5, 2023')).toBeInTheDocument();
+    expect(screen.getByText('Course duration:')).toBeInTheDocument();
+    expect(screen.getByText('3 Weeks')).toBeInTheDocument();
+    expect(screen.getByText('Course total:')).toBeInTheDocument();
+    expect(screen.getByText('$100.00 USD')).toBeInTheDocument();
+    expect(screen.getByText('What happens next?')).toBeInTheDocument();
+    expect(screen.getByText('Terms and Conditions')).toBeInTheDocument();
+    expect(screen.getByText('Terms and Conditions')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Ticket: [ENT-7206](https://2u-internal.atlassian.net/browse/ENT-7206)

<img width="1197" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/c813ff12-a53c-44d5-b843-abd212bbc3b1">

The `/:enterpriseSlug/:courseType/course/:courseKey/enroll` and `/:enterpriseSlug/:courseType/course/:courseKey/enroll/complete` routes also take this into account now when determining whether to show an error screen.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
