### PR TITLE
feat: Filters courseRuns for canRedeem endpoint

### DIFF
--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -28,6 +28,7 @@ import {
   getCourseTypeConfig,
   getEntitlementPrice,
   findHighestLevelEntitlementSku,
+  getAvailableCourseRunKeysFromCourseData,
 } from './data/utils';
 import { canUserRequestSubsidyForCourse } from './enrollment/utils';
 import NotFoundPage from '../NotFoundPage';
@@ -97,9 +98,7 @@ const CoursePage = () => {
   } = useAllCourseData({ courseService, activeCatalogs });
   const isEMETRedemptionEnabled = getConfig().FEATURE_ENABLE_EMET_REDEMPTION || hasFeatureFlagEnabled('ENABLE_EMET_REDEMPTION');
 
-  const validCourseRunKeys = courseData?.courseDetails.courseRuns
-    ? getAvailableCourseRuns(courseData?.courseDetails).map(courseRun => courseRun.key)
-    : [];
+  const validCourseRunKeys = getAvailableCourseRunKeysFromCourseData(courseData);
 
   const {
     isInitialLoading: isLoadingAccessPolicyRedemptionStatus,

--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -95,14 +95,18 @@ const CoursePage = () => {
     courseReviews,
     isLoadingCourseData,
   } = useAllCourseData({ courseService, activeCatalogs });
-
   const isEMETRedemptionEnabled = getConfig().FEATURE_ENABLE_EMET_REDEMPTION || hasFeatureFlagEnabled('ENABLE_EMET_REDEMPTION');
+  
+  const validCourseRunKeys = courseData?.courseDetails.courseRuns 
+    ? getAvailableCourseRuns(courseData?.courseDetails).map(courseRun => courseRun.key)
+    : [];
+
   const {
     isInitialLoading: isLoadingAccessPolicyRedemptionStatus,
     data: subsidyAccessPolicyRedeemabilityData,
   } = useCheckSubsidyAccessPolicyRedeemability({
     enterpriseUuid: enterpriseUUID,
-    courseRunKeys: courseData?.courseDetails.courseRunKeys || [],
+    courseRunKeys: validCourseRunKeys,
     activeCourseRunKey: courseService.activeCourseRun?.key,
     isQueryEnabled: isEMETRedemptionEnabled,
     queryOptions: {

--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -96,8 +96,8 @@ const CoursePage = () => {
     isLoadingCourseData,
   } = useAllCourseData({ courseService, activeCatalogs });
   const isEMETRedemptionEnabled = getConfig().FEATURE_ENABLE_EMET_REDEMPTION || hasFeatureFlagEnabled('ENABLE_EMET_REDEMPTION');
-  
-  const validCourseRunKeys = courseData?.courseDetails.courseRuns 
+
+  const validCourseRunKeys = courseData?.courseDetails.courseRuns
     ? getAvailableCourseRuns(courseData?.courseDetails).map(courseRun => courseRun.key)
     : [];
 

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -97,7 +97,6 @@ export function useAllCourseData({
     };
     fetchData();
   }, [courseService, activeCatalogs]);
-
   return {
     courseData,
     courseRecommendations,
@@ -580,7 +579,6 @@ const checkRedemptionEligibility = async ({ queryKey }) => {
   const courseService = new CourseService({ enterpriseUuid });
   const response = await courseService.fetchCanRedeem({ courseRunKeys });
   const transformedResponse = camelCaseObject(response.data);
-
   const redeemabilityForActiveCourseRun = transformedResponse.find(r => r.contentKey === activeCourseRunKey);
   const missingSubsidyAccessPolicyReason = redeemabilityForActiveCourseRun?.reasons[0];
   const preferredSubsidyAccessPolicy = redeemabilityForActiveCourseRun?.redeemableSubsidyAccessPolicy;
@@ -630,7 +628,6 @@ export const useCheckSubsidyAccessPolicyRedeemability = ({
 }) => {
   const { id: lmsUserId } = getAuthenticatedUser();
   const isEnabled = !!(isQueryEnabled && activeCourseRunKey && courseRunKeys.length > 0);
-
   return useQuery({
     ...queryOptions,
     queryKey: ['policy', enterpriseUuid, 'can-redeem', { lmsUserId, courseRunKeys, activeCourseRunKey }],

--- a/src/components/course/data/service.js
+++ b/src/components/course/data/service.js
@@ -59,7 +59,6 @@ export default class CourseService {
         courseDetails.advertisedCourseRunUuid = courseDetails.courseRuns[0].uuid;
       }
     }
-
     return {
       courseDetails,
       userEnrollments: courseData[1],

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -1,5 +1,7 @@
 import moment from 'moment';
-import { COUPON_CODE_SUBSIDY_TYPE, COURSE_AVAILABILITY_MAP, ENTERPRISE_OFFER_SUBSIDY_TYPE, LICENSE_SUBSIDY_TYPE } from '../constants';
+import {
+  COUPON_CODE_SUBSIDY_TYPE, COURSE_AVAILABILITY_MAP, ENTERPRISE_OFFER_SUBSIDY_TYPE, LICENSE_SUBSIDY_TYPE,
+} from '../constants';
 import {
   courseUsesEntitlementPricing,
   findCouponCodeForCourse,
@@ -406,44 +408,49 @@ describe('getAvailableCourseRuns', () => {
           title: 'Demo Course',
           isMarketable: true,
           isEnrollable: true,
-          availability: 'Current'
+          // availability: 'Current',
         },
-                {
+        {
           key: 'course-v1:edX+DemoX+Demo_Course',
           title: 'Demo Course',
-          isMarketable : false,
+          isMarketable: false,
           isEnrollable: true,
-          availability: 'Current'
+          // availability: 'Current',
         },
-                {
+        {
           key: 'course-v1:edX+DemoX+Demo_Course',
           title: 'Demo Course',
-          isMarketable : true,
+          isMarketable: true,
           isEnrollable: false,
-          availability: 'Current'
+          // availability: 'Current',
         },
-                {
+        {
           key: 'course-v1:edX+DemoX+Demo_Course',
           title: 'Demo Course',
-          isMarketable : false,
+          isMarketable: false,
           isEnrollable: false,
-          availability: 'Current'
+          // availability: 'Current',
         },
-      ]
-    }
-  }
+      ],
+    },
+  };
   it('returns object with available course runs', () => {
-    for(var i = 0; i < COURSE_AVAILABILITY_MAP.length; i++) {
+    for (let i = 0; i < COURSE_AVAILABILITY_MAP.length; i++) {
       sampleCourseRunData.courseData.courseRuns.forEach((courseRun) => {
+        // eslint-disable-next-line no-param-reassign
         courseRun.availability = COURSE_AVAILABILITY_MAP[i];
-        if(COURSE_AVAILABILITY_MAP[i] === 'Archived') {
-          expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length).toEqual(0);
-          expect(getAvailableCourseRuns(sampleCourseRunData.courseData)).toEqual([]);
+        if (COURSE_AVAILABILITY_MAP[i] === 'Archived') {
+          expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length)
+            .toEqual(0);
+          expect(getAvailableCourseRuns(sampleCourseRunData.courseData))
+            .toEqual([]);
         } else {
-          expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length).toEqual(1);
-          expect(getAvailableCourseRuns(sampleCourseRunData.courseData)).toEqual(sampleCourseRunData.courseData.courseRuns.slice(0,1));
+          expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length)
+            .toEqual(1);
+          expect(getAvailableCourseRuns(sampleCourseRunData.courseData))
+            .toEqual(sampleCourseRunData.courseData.courseRuns.slice(0, 1));
         }
-      })
+      });
     }
   });
-})
+});

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -453,4 +453,9 @@ describe('getAvailableCourseRuns', () => {
       });
     }
   });
+  it('returns empty array if course runs are not available', () => {
+    sampleCourseRunData.courseData.courseRuns = [];
+    expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length).toEqual(0);
+    expect(getAvailableCourseRuns(sampleCourseRunData.courseData)).toEqual([]);
+  });
 });

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -6,6 +6,7 @@ import {
   courseUsesEntitlementPricing,
   findCouponCodeForCourse,
   findEnterpriseOfferForCourse,
+  getAvailableCourseRunKeysFromCourseData,
   getAvailableCourseRuns,
   getSubsidyToApplyForCourse,
   linkToCourse,
@@ -408,28 +409,24 @@ describe('getAvailableCourseRuns', () => {
           title: 'Demo Course',
           isMarketable: true,
           isEnrollable: true,
-          // availability: 'Current',
         },
         {
           key: 'course-v1:edX+DemoX+Demo_Course',
           title: 'Demo Course',
           isMarketable: false,
           isEnrollable: true,
-          // availability: 'Current',
         },
         {
           key: 'course-v1:edX+DemoX+Demo_Course',
           title: 'Demo Course',
           isMarketable: true,
           isEnrollable: false,
-          // availability: 'Current',
         },
         {
           key: 'course-v1:edX+DemoX+Demo_Course',
           title: 'Demo Course',
           isMarketable: false,
           isEnrollable: false,
-          // availability: 'Current',
         },
       ],
     },
@@ -457,5 +454,54 @@ describe('getAvailableCourseRuns', () => {
     sampleCourseRunData.courseData.courseRuns = [];
     expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length).toEqual(0);
     expect(getAvailableCourseRuns(sampleCourseRunData.courseData)).toEqual([]);
+  });
+});
+describe('getAvailableCourseRunKeysFromCourseData', () => {
+  const sampleCourseDataData = {
+    courseData: {
+      courseDetails: {
+        courseRuns: [
+          {
+            key: 'course-v1:edX+DemoX+Demo_Course',
+            title: 'Demo Course',
+            isMarketable: true,
+            isEnrollable: true,
+            availability: 'Current',
+          },
+          {
+            key: 'course-v1:edX+DemoX+Demo_Course',
+            title: 'Demo Course',
+            isMarketable: false,
+            isEnrollable: true,
+            availability: 'Upcoming',
+          },
+          {
+            key: 'course-v1:edX+DemoX+Demo_Course',
+            title: 'Demo Course',
+            isMarketable: true,
+            isEnrollable: false,
+            availability: 'Current',
+          },
+          {
+            key: 'course-v1:edX+DemoX+Demo_Course',
+            title: 'Demo Course',
+            isMarketable: false,
+            isEnrollable: false,
+            availability: 'Archived',
+          },
+        ],
+      },
+    },
+  };
+  it('returns array with available course run keys', () => {
+    const output = getAvailableCourseRunKeysFromCourseData(sampleCourseDataData.courseData);
+    expect(output.length).toEqual(1);
+    expect(output).toEqual(['course-v1:edX+DemoX+Demo_Course']);
+  });
+  it('returns empty array if course runs are not available', () => {
+    sampleCourseDataData.courseData.courseDetails = [];
+    const output = getAvailableCourseRunKeysFromCourseData(sampleCourseDataData.courseData);
+    expect(output.length).toEqual(0);
+    expect(output).toEqual([]);
   });
 });

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -1,9 +1,10 @@
 import moment from 'moment';
-import { COUPON_CODE_SUBSIDY_TYPE, ENTERPRISE_OFFER_SUBSIDY_TYPE, LICENSE_SUBSIDY_TYPE } from '../constants';
+import { COUPON_CODE_SUBSIDY_TYPE, COURSE_AVAILABILITY_MAP, ENTERPRISE_OFFER_SUBSIDY_TYPE, LICENSE_SUBSIDY_TYPE } from '../constants';
 import {
   courseUsesEntitlementPricing,
   findCouponCodeForCourse,
   findEnterpriseOfferForCourse,
+  getAvailableCourseRuns,
   getSubsidyToApplyForCourse,
   linkToCourse,
   pathContainsCourseTypeSlug,
@@ -396,3 +397,53 @@ describe('linkToCourse', () => {
     expect(linkToCourse(mockQueryQbjectIdCourse, slug)).toEqual('/testenterprise/course/mock_query_object_id_course?queryId=testqueryid&objectId=testobjectid');
   });
 });
+describe('getAvailableCourseRuns', () => {
+  const sampleCourseRunData = {
+    courseData: {
+      courseRuns: [
+        {
+          key: 'course-v1:edX+DemoX+Demo_Course',
+          title: 'Demo Course',
+          isMarketable: true,
+          isEnrollable: true,
+          availability: 'Current'
+        },
+                {
+          key: 'course-v1:edX+DemoX+Demo_Course',
+          title: 'Demo Course',
+          isMarketable : false,
+          isEnrollable: true,
+          availability: 'Current'
+        },
+                {
+          key: 'course-v1:edX+DemoX+Demo_Course',
+          title: 'Demo Course',
+          isMarketable : true,
+          isEnrollable: false,
+          availability: 'Current'
+        },
+                {
+          key: 'course-v1:edX+DemoX+Demo_Course',
+          title: 'Demo Course',
+          isMarketable : false,
+          isEnrollable: false,
+          availability: 'Current'
+        },
+      ]
+    }
+  }
+  it('returns object with available course runs', () => {
+    for(var i = 0; i < COURSE_AVAILABILITY_MAP.length; i++) {
+      sampleCourseRunData.courseData.courseRuns.forEach((courseRun) => {
+        courseRun.availability = COURSE_AVAILABILITY_MAP[i];
+        if(COURSE_AVAILABILITY_MAP[i] === 'Archived') {
+          expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length).toEqual(0);
+          expect(getAvailableCourseRuns(sampleCourseRunData.courseData)).toEqual([]);
+        } else {
+          expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length).toEqual(1);
+          expect(getAvailableCourseRuns(sampleCourseRunData.courseData)).toEqual(sampleCourseRunData.courseData.courseRuns.slice(0,1));
+        }
+      })
+    }
+  });
+})

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -455,6 +455,11 @@ describe('getAvailableCourseRuns', () => {
     expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length).toEqual(0);
     expect(getAvailableCourseRuns(sampleCourseRunData.courseData)).toEqual([]);
   });
+  it('returns an empty array is courseRuns is not defined', () => {
+    sampleCourseRunData.courseData.courseRuns = undefined;
+    expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length).toEqual(0);
+    expect(getAvailableCourseRuns(sampleCourseRunData.courseData)).toEqual([]);
+  });
 });
 describe('getAvailableCourseRunKeysFromCourseData', () => {
   const sampleCourseDataData = {

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -135,6 +135,9 @@ export function getActiveCourseRun(course) {
  * @returns List of course runs.
  */
 export function getAvailableCourseRuns(course) {
+  if (!course?.courseRuns) {
+    return [];
+  }
   return course.courseRuns
     .filter((courseRun) => (
       courseRun.isMarketable

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -146,6 +146,19 @@ export function getAvailableCourseRuns(course) {
     ));
 }
 
+/**
+ * Returns a filtered list of course run keys that are marketable, enrollable, and not archived.
+ *
+ * @param {object} courseData - Course data object deriving from the useAllCourseData hook response.
+ * @returns List of course run keys.
+*/
+export function getAvailableCourseRunKeysFromCourseData(courseData) {
+  if (!courseData?.courseDetails.courseRuns) {
+    return [];
+  }
+  return getAvailableCourseRuns(courseData?.courseDetails).map(courseRun => courseRun.key);
+}
+
 export function findCouponCodeForCourse(couponCodes, catalogList = []) {
   return couponCodes.find((couponCode) => catalogList?.includes(couponCode.catalog) && hasValidStartExpirationDates({
     startDate: couponCode.couponStartDate,

--- a/src/components/course/tests/CoursePage.test.jsx
+++ b/src/components/course/tests/CoursePage.test.jsx
@@ -20,6 +20,7 @@ const mockGetActiveCourseRun = jest.fn();
 jest.mock('../data/utils', () => ({
   ...jest.requireActual('../data/utils'),
   getActiveCourseRun: () => mockGetActiveCourseRun(),
+  getAvailableCourseRunKeysFromCourseData: () => ['test-course-key'],
 }));
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),

--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -13,7 +13,7 @@ export const useSearchCatalogs = ({
   catalogsForSubsidyRequests,
 }) => {
   const searchCatalogs = useMemo(() => {
-   const catalogs = [];
+    const catalogs = [];
     // Scope to catalogs from coupons, enterprise offers, or subscription plan associated with learner's license
     if (subscriptionPlan && subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED) {
       catalogs.push(subscriptionPlan.enterpriseCatalogUuid);

--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -13,7 +13,7 @@ export const useSearchCatalogs = ({
   catalogsForSubsidyRequests,
 }) => {
   const searchCatalogs = useMemo(() => {
-    const catalogs = [];
+   const catalogs = [];
     // Scope to catalogs from coupons, enterprise offers, or subscription plan associated with learner's license
     if (subscriptionPlan && subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED) {
       catalogs.push(subscriptionPlan.enterpriseCatalogUuid);


### PR DESCRIPTION
Filters `courseRuns` using an existing filter function to reduce number of query params appended to the `canRedeem` endpoint in the `CoursePage`

Wrote tests to cover code changes

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
