### PR TITLE
fix: use start date from addtl metadata for exec ed course above enroll cta

### DIFF
--- a/src/components/course/course-header/CourseRunCard.jsx
+++ b/src/components/course/course-header/CourseRunCard.jsx
@@ -18,6 +18,7 @@ const CourseRunCard = ({
 }) => {
   const {
     state: {
+      course,
       userEnrollments,
     },
     missingUserSubsidyReason,
@@ -34,6 +35,7 @@ const CourseRunCard = ({
     subHeading,
     action,
   } = useCourseRunCardData({
+    course,
     courseRun,
     userEnrollment: userEnrollmentForCourseRun,
     courseRunUrl: userEnrollmentForCourseRun?.courseRunUrl,

--- a/src/components/course/course-header/data/hooks/useCourseRunCardData.js
+++ b/src/components/course/course-header/data/hooks/useCourseRunCardData.js
@@ -9,6 +9,7 @@ import { getExternalCourseEnrollmentUrl } from '../../../enrollment/utils';
 /**
  * Gathers the data needed to render the `CourseRunCard` component.
  * @param {object} args
+ * @param {object} args.course The course metadata.
  * @param {object} args.courseRun The course run metadata, including the key, availability,
  *  start date, pacing type, and enrollment count.
  * @param {object} args.userEnrollment The user's enrollment in the course run, if any.
@@ -18,6 +19,7 @@ import { getExternalCourseEnrollmentUrl } from '../../../enrollment/utils';
  * @returns An object containing the `heading, `subHeading`, and `action` data needed to render the `CourseRunCard`.
  */
 const useCourseRunCardData = ({
+  course,
   courseRun,
   userEnrollment,
   courseRunUrl,
@@ -39,6 +41,7 @@ const useCourseRunCardData = ({
   // Get and return course run card data for display
   const heading = useCourseRunCardHeading({
     isCourseRunCurrent,
+    course,
     courseRun,
     isUserEnrolled,
   });

--- a/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
+++ b/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 
-import { hasTimeToComplete, isCourseSelfPaced } from '../../../data/utils';
+import { getCourseStartDate, hasTimeToComplete, isCourseSelfPaced } from '../../../data/utils';
 import { DATE_FORMAT } from '../constants';
 
 const messages = defineMessages({
@@ -26,16 +26,21 @@ const messages = defineMessages({
  * Determines the heading to display on the course run card.
  * @param {object} args
  * @param {boolean} args.isCourseRunCurrent Whether the course run is current.
+ * @param {object} args.course Data about the course for the course run card.
  * @param {object} args.courseRun Data about the course run for the course run card.
  * @param {boolean} args.isUserEnrolled Whether the user is already enrolled in the course run.
  * @returns {string} The heading to display on the course run card.
  */
 const useCourseRunCardHeading = ({
   isCourseRunCurrent,
+  course,
   courseRun,
   isUserEnrolled,
 }) => {
   const intl = useIntl();
+
+  const courseStartDate = getCourseStartDate({ contentMetadata: course, courseRun });
+
   if (isCourseRunCurrent) {
     if (isUserEnrolled) {
       return intl.formatMessage(messages.courseStarted);
@@ -48,15 +53,15 @@ const useCourseRunCardHeading = ({
         });
       }
       return intl.formatMessage(messages.courseStartedDate, {
-        startDate: moment(courseRun.start).format(DATE_FORMAT),
+        startDate: moment(courseStartDate).format(DATE_FORMAT),
       });
     }
     return intl.formatMessage(messages.courseStartedDate, {
-      startDate: moment(courseRun.start).format(DATE_FORMAT),
+      startDate: moment(courseStartDate).format(DATE_FORMAT),
     });
   }
   return intl.formatMessage(messages.courseStartDate, {
-    startDate: moment(courseRun.start).format(DATE_FORMAT),
+    startDate: moment(courseStartDate).format(DATE_FORMAT),
   });
 };
 

--- a/src/components/course/course-header/deprecated/CourseRunCard.jsx
+++ b/src/components/course/course-header/deprecated/CourseRunCard.jsx
@@ -17,6 +17,7 @@ import {
   hasCourseStarted,
   findHighestLevelSku,
   pathContainsCourseTypeSlug,
+  getCourseStartDate,
 } from '../../data/utils';
 import { formatStringAsNumber } from '../../../../utils/common';
 import { useSubsidyDataForCourse } from '../../enrollment/hooks';
@@ -43,7 +44,6 @@ const CourseRunCard = ({
     pacingType,
     courseUuid,
     enrollmentCount,
-    start,
     key,
     seats,
     isEnrollable,
@@ -51,11 +51,18 @@ const CourseRunCard = ({
 
   const location = useLocation();
   const { enterpriseConfig } = useContext(AppContext);
-  const { userCanRequestSubsidyForCourse } = useContext(CourseContext);
+  const {
+    state: {
+      course,
+    },
+    userCanRequestSubsidyForCourse,
+  } = useContext(CourseContext);
+
+  const courseStartDate = getCourseStartDate({ contentMetadata: course, courseRun });
 
   const isCourseStarted = useMemo(
-    () => hasCourseStarted(start),
-    [start],
+    () => hasCourseStarted(courseStartDate),
+    [courseStartDate],
   );
 
   const {
@@ -133,12 +140,12 @@ const CourseRunCard = ({
     if (!isEnrollable) {
       if (
         (availability === COURSE_AVAILABILITY_MAP.UPCOMING || availability === COURSE_AVAILABILITY_MAP.STARTING_SOON)
-        && start
+        && courseStartDate
       ) {
         // Course will be available in the future
         return [
           'Coming soon',
-          `Enroll after ${moment(start).format(DATE_FORMAT)}`,
+          `Enroll after ${moment(courseStartDate).format(DATE_FORMAT)}`,
           DEFAULT_BUTTON_LABEL,
         ];
       }
@@ -154,7 +161,7 @@ const CourseRunCard = ({
       // User is enrolled
       return [
         !isCourseStarted
-          ? `Starts ${moment(start).format(DATE_FORMAT)}`
+          ? `Starts ${moment(courseStartDate).format(DATE_FORMAT)}`
           : 'Course started',
         'You are enrolled',
         'View course',
@@ -173,7 +180,7 @@ const CourseRunCard = ({
       ? `${formatStringAsNumber(enrollmentCount)} recently enrolled!`
       : 'Be the first to enroll!';
 
-    let tempHeading = `${isCourseStarted ? 'Started' : 'Starts'} ${moment(start).format(DATE_FORMAT)}`;
+    let tempHeading = `${isCourseStarted ? 'Started' : 'Starts'} ${moment(courseStartDate).format(DATE_FORMAT)}`;
 
     if (isCourseSelfPaced(pacingType)) {
       if (isCourseStarted) {
@@ -193,7 +200,7 @@ const CourseRunCard = ({
     courseUuid,
     enrollmentCount,
     isCourseStarted,
-    start,
+    courseStartDate,
     pacingType,
     availability,
     courseRun,

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -455,7 +455,7 @@ export const useTrackSearchConversionClickHandler = ({ href = undefined, eventNa
  * @returns Click handler function for clicks on enrollment buttons.
  */
 export const useOptimizelyEnrollmentClickHandler = ({ href, courseRunKey, userEnrollments }) => {
-  const hasNoExistingEnrollments = userEnrollments.length === 0;
+  const hasNoExistingEnrollments = userEnrollments?.length === 0 || true;
   const handleClick = useCallback(
     (e) => {
       // If tracking is on a link with an external href destination, we must intentionally delay the default click
@@ -856,7 +856,7 @@ export const useMinimalCourseMetadata = () => {
     organizationImage: organizationDetails.organizationLogo,
     organizationName: organizationDetails.organizationName,
     title: course.title,
-    startDate: getCourseStartDate({ contentMetadata: course, activeCourseRun }),
+    startDate: getCourseStartDate({ contentMetadata: course, courseRun: activeCourseRun }),
     duration: getDuration(),
     priceDetails: {
       price: coursePrice.list,

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -523,15 +523,15 @@ describe('getCourseStartDate tests', () => {
     const startDate = getCourseStartDate({
       contentMetadata: {
         additionalMetadata: {
-          startDate: '2023-06-07T00:00:00Z',
+          startDate: '2023-06-10T12:00:00Z',
         },
         courseType: 'executive-education-2u',
       },
-      activeCourseRun: {
-        start: '2022-06-08T00:00:00Z',
+      courseRun: {
+        start: '2022-03-08T12:00:00Z',
       },
     });
-    expect(startDate).toMatch('Jun 7, 2023');
+    expect(startDate).toMatch('Jun 10, 2023');
   });
 
   it('Validate active course run\'s start date is used when additionalMetadata is null.', async () => {
@@ -540,16 +540,16 @@ describe('getCourseStartDate tests', () => {
         additionalMetadata: null,
         courseType: 'executive-education-2u',
       },
-      activeCourseRun: {
-        start: '2022-06-08T00:00:00Z',
+      courseRun: {
+        start: '2022-03-08T12:00:00Z',
       },
     });
-    expect(startDate).toMatch('Jun 8, 2022');
+    expect(startDate).toMatch('Mar 8, 2022');
   });
 
   it('Validate getCourseDate handles empty data for course run and course metadata.', async () => {
     const startDate = getCourseStartDate(
-      { contentMetadata: null, activeCourseRun: null },
+      { contentMetadata: null, courseRun: null },
     );
     expect(startDate).toBe(undefined);
   });

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -661,14 +661,25 @@ export const getCourseOrganizationDetails = (courseData) => {
   return organizationDetails;
 };
 
-export const getCourseStartDate = ({ contentMetadata, activeCourseRun }) => {
+/**
+ * Determines the start date for the the course run, pulling the appropriate date
+ * from either `contentMetadata.additionalMetadata.startDate` or `courseRun.start`
+ * based on the course type configuration.
+ *
+ * @param {Object} args
+ * @param {Object} args.contentMetadata
+ * @param {Object} args.courseRun
+ *
+ * @returns {string|undefined} Formatted date if a start date was found; otherwise, undefined.
+ */
+export const getCourseStartDate = ({ contentMetadata, courseRun }) => {
   let startDate;
   const courseTypeConfig = contentMetadata && getCourseTypeConfig(contentMetadata);
 
   if (courseTypeConfig?.usesAdditionalMetadata && contentMetadata?.additionalMetadata) {
     startDate = contentMetadata.additionalMetadata.startDate;
   } else {
-    startDate = activeCourseRun?.start;
+    startDate = courseRun?.start;
   }
 
   if (startDate) {

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
@@ -74,7 +74,7 @@ const ExecutiveEducation2UPage = () => {
         organizationImage: organizationDetails.organizationLogo,
         organizationName: organizationDetails.organizationName,
         title: contentMetadata.title,
-        startDate: getCourseStartDate({ contentMetadata, activeCourseRun }),
+        startDate: getCourseStartDate({ contentMetadata, courseRun: activeCourseRun }),
         duration: getDuration(),
         priceDetails: getExecutiveEducationCoursePrice(contentMetadata),
         activeCourseRun,


### PR DESCRIPTION
Uses a recently introduced `getCourseStartDate` function that takes into account course type, pulling the course start date from either the course run or additional metadata when appropriate.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
