### PR TITLE
fix: ensure we take into account start date when determining if course run is current

### DIFF
--- a/src/components/course/course-header/data/hooks/tests/useCourseRunCardHeading.test.jsx
+++ b/src/components/course/course-header/data/hooks/tests/useCourseRunCardHeading.test.jsx
@@ -12,6 +12,11 @@ jest.mock('../../../../data/utils', () => ({
   hasTimeToComplete: jest.fn().mockReturnValue(true),
 }));
 
+jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
+  getTodaysDate: jest.fn(() => new Date('2023-10-20')),
+}));
+
 const wrapper = ({ children }) => (
   <IntlProvider locale="en">{children}</IntlProvider>
 );

--- a/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
+++ b/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
@@ -3,6 +3,7 @@ import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 
 import { getCourseStartDate, hasTimeToComplete, isCourseSelfPaced } from '../../../data/utils';
 import { DATE_FORMAT } from '../constants';
+import { getTodaysDate } from '../utils';
 
 const messages = defineMessages({
   courseStartDate: {
@@ -41,7 +42,11 @@ const useCourseRunCardHeading = ({
 
   const courseStartDate = getCourseStartDate({ contentMetadata: course, courseRun });
 
-  if (isCourseRunCurrent) {
+  // check whether the course run is current based on its `availability` or whether
+  // the start date is indeed in the past. As of this implementation, the `availability`
+  // for published, enrollable externally hosted courses is always "Current" even if the
+  // date is upcoming.
+  if (isCourseRunCurrent && moment(courseStartDate).isBefore(moment(getTodaysDate()))) {
     if (isUserEnrolled) {
       return intl.formatMessage(messages.courseStarted);
     }

--- a/src/components/course/course-header/data/utils.js
+++ b/src/components/course/course-header/data/utils.js
@@ -1,0 +1,1 @@
+export const getTodaysDate = () => new Date();

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -1238,6 +1238,7 @@ describe('useMinimalCourseMetadata', () => {
   const mockListPrice = 100;
   const mockCurrency = 'USD';
   const mockCourseTitle = 'Test Course Title';
+  const mockCourseRunStartDate = '2023-04-20T12:00:00Z';
   const baseCourseContextValue = {
     state: {
       course: {
@@ -1247,7 +1248,7 @@ describe('useMinimalCourseMetadata', () => {
         owners: [{ name: mockOrgName, logoImageUrl: mockLogoImageUrl }],
       },
       activeCourseRun: {
-        start: '2023-04-20T12:00:00Z',
+        start: mockCourseRunStartDate,
         weeksToComplete: mockWeeksToComplete,
       },
     },
@@ -1270,7 +1271,7 @@ describe('useMinimalCourseMetadata', () => {
         organizationImage: mockLogoImageUrl,
         organizationName: mockOrgName,
         title: mockCourseTitle,
-        startDate: 'Apr 20, 2023',
+        startDate: mockCourseRunStartDate,
         duration: `${mockWeeksToComplete} Weeks`,
         priceDetails: {
           price: mockListPrice,
@@ -1331,7 +1332,7 @@ describe('useMinimalCourseMetadata', () => {
         organizationImage: mockLogoImageUrl,
         organizationName: mockOrgName,
         title: mockCourseTitle,
-        startDate: 'Apr 20, 2023',
+        startDate: mockCourseRunStartDate,
         duration: '1 Week',
         priceDetails: {
           price: mockListPrice,
@@ -1366,7 +1367,7 @@ describe('useMinimalCourseMetadata', () => {
         organizationImage: mockOrgLogoUrl,
         organizationName: mockOrgShortCode,
         title: mockCourseTitle,
-        startDate: 'Apr 20, 2023',
+        startDate: mockCourseRunStartDate,
         duration: '8 Weeks',
         priceDetails: {
           price: mockListPrice,

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -520,10 +520,11 @@ describe('getAvailableCourseRunKeysFromCourseData', () => {
 
 describe('getCourseStartDate tests', () => {
   it('Validate additionalMetadata gets priority in course start date calculation', async () => {
+    const mockAdditionalMetadataStartDate = '2023-06-10T12:00:00Z';
     const startDate = getCourseStartDate({
       contentMetadata: {
         additionalMetadata: {
-          startDate: '2023-06-10T12:00:00Z',
+          startDate: mockAdditionalMetadataStartDate,
         },
         courseType: 'executive-education-2u',
       },
@@ -531,20 +532,21 @@ describe('getCourseStartDate tests', () => {
         start: '2022-03-08T12:00:00Z',
       },
     });
-    expect(startDate).toMatch('Jun 10, 2023');
+    expect(startDate).toMatch(mockAdditionalMetadataStartDate);
   });
 
   it('Validate active course run\'s start date is used when additionalMetadata is null.', async () => {
+    const mockCourseRuStartDate = '2022-03-08T12:00:00Z';
     const startDate = getCourseStartDate({
       contentMetadata: {
         additionalMetadata: null,
         courseType: 'executive-education-2u',
       },
       courseRun: {
-        start: '2022-03-08T12:00:00Z',
+        start: mockCourseRuStartDate,
       },
     });
-    expect(startDate).toMatch('Mar 8, 2022');
+    expect(startDate).toMatch(mockCourseRuStartDate);
   });
 
   it('Validate getCourseDate handles empty data for course run and course metadata.', async () => {

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -3,8 +3,6 @@ import { ensureConfig, getConfig } from '@edx/frontend-platform';
 import { hasFeatureFlagEnabled } from '@edx/frontend-enterprise-utils';
 import { Button, Hyperlink } from '@edx/paragon';
 import isNil from 'lodash.isnil';
-
-import moment from 'moment/moment';
 import {
   COURSE_AVAILABILITY_MAP,
   COURSE_MODES_MAP,
@@ -15,7 +13,6 @@ import {
   ENROLLMENT_FAILED_QUERY_PARAM,
   ENROLLMENT_COURSE_RUN_KEY_QUERY_PARAM,
   DISABLED_ENROLL_REASON_TYPES,
-  DATE_FORMAT,
 } from './constants';
 import MicroMastersSvgIcon from '../../../assets/icons/micromasters.svg';
 import ProfessionalSvgIcon from '../../../assets/icons/professional.svg';
@@ -682,9 +679,5 @@ export const getCourseStartDate = ({ contentMetadata, courseRun }) => {
     startDate = courseRun?.start;
   }
 
-  if (startDate) {
-    return moment(startDate).format(DATE_FORMAT);
-  }
-
-  return undefined;
+  return startDate;
 };

--- a/src/components/course/routes/tests/ExternalCourseEnrollmentConfirmation.test.jsx
+++ b/src/components/course/routes/tests/ExternalCourseEnrollmentConfirmation.test.jsx
@@ -21,7 +21,7 @@ jest.mock('../../data/hooks', () => ({
     organizationImage: 'https://test.org/logo.png',
     organizationName: 'Test Org',
     title: 'Test Course Title',
-    startDate: 'March 5, 2023',
+    startDate: '2023-03-05',
     duration: '3 Weeks',
     priceDetails: {
       price: 100,
@@ -77,7 +77,7 @@ describe('ExternalCourseEnrollment', () => {
     expect(screen.getByText('Test Course Title')).toBeInTheDocument();
     expect(screen.getByText('Test Org')).toBeInTheDocument();
     expect(screen.getByText('Start date:')).toBeInTheDocument();
-    expect(screen.getByText('March 5, 2023')).toBeInTheDocument();
+    expect(screen.getByText('Mar 5, 2023')).toBeInTheDocument();
     expect(screen.getByText('Course duration:')).toBeInTheDocument();
     expect(screen.getByText('3 Weeks')).toBeInTheDocument();
     expect(screen.getByText('Course total:')).toBeInTheDocument();
@@ -112,7 +112,7 @@ describe('ExternalCourseEnrollment', () => {
     expect(screen.getByText('Test Course Title')).toBeInTheDocument();
     expect(screen.getByText('Test Org')).toBeInTheDocument();
     expect(screen.getByText('Start date:')).toBeInTheDocument();
-    expect(screen.getByText('March 5, 2023')).toBeInTheDocument();
+    expect(screen.getByText('Mar 5, 2023')).toBeInTheDocument();
     expect(screen.getByText('Course duration:')).toBeInTheDocument();
     expect(screen.getByText('3 Weeks')).toBeInTheDocument();
     expect(screen.getByText('Course total:')).toBeInTheDocument();

--- a/src/components/executive-education-2u/components/CourseSummaryCard.jsx
+++ b/src/components/executive-education-2u/components/CourseSummaryCard.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import {
   Card, Image, Row, Col,
 } from '@edx/paragon';
+
 import { numberWithPrecision } from '../../course/data/utils';
+import { DATE_FORMAT } from '../../course/data/constants';
 
 const CourseSummaryCard = ({ courseMetadata, enrollmentCompleted }) => (
   <Card
@@ -28,7 +31,7 @@ const CourseSummaryCard = ({ courseMetadata, enrollmentCompleted }) => (
             <div className="course-details">
               <Row className="align-items-center">
                 <Col className="small font-weight-light text-gray-500 justify-content-start">{enrollmentCompleted ? 'Start date:' : 'Available start date:'}</Col>
-                <Col className="justify-content-end"><Row className="justify-content-end mr-2.5">{courseMetadata.startDate}</Row></Col>
+                <Col className="justify-content-end"><Row className="justify-content-end mr-2.5">{moment(courseMetadata.startDate).format(DATE_FORMAT)}</Row></Col>
               </Row>
               <Row className="align-items-center">
                 <Col className="small font-weight-light text-gray-500 justify-content-start">Course duration:</Col>


### PR DESCRIPTION
Another start date related fix/hack due to exec ed courses always having availability: "Current" in our system, even if start date is upcoming (ensures the course run card says "Starts" vs. "Started" depending on whether exec ed course is already started based on its start date.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
