### PR TITLE
fix: use correct overrides for exec ed course partner logos on course page

### DIFF
--- a/src/components/course/course-header/CourseHeader.jsx
+++ b/src/components/course/course-header/CourseHeader.jsx
@@ -72,10 +72,9 @@ const CourseHeader = () => {
               </div>
             )}
             {partners.length > 0 && (
-              <div className="mt-4 mb-2">
+              <div className="mt-4 mb-2 course-header__partner-logos">
                 {partners.map(partner => (
                   <a
-                    className="d-inline-block mr-4"
                     href={partner.marketingUrl}
                     key={partner.uuid}
                     target="_blank"

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -30,6 +30,7 @@ import {
   getMissingSubsidyReasonActions,
   getCourseOrganizationDetails,
   getCourseStartDate,
+  getCourseTypeConfig,
 } from './utils';
 import {
   COURSE_PACING_MAP,
@@ -127,21 +128,35 @@ export function useCourseSubjects(course) {
   return { subjects, primarySubject };
 }
 
-// TODO: Refactor away from useEffect useState
 export function useCoursePartners(course) {
-  const [partners, setPartners] = useState([]);
-  const [label, setLabel] = useState('');
+  const partners = [];
+  let label = 'Institution';
 
-  useEffect(() => {
-    if (course?.owners) {
-      setPartners(course.owners);
-      if (course.owners.length > 1) {
-        setLabel('Institutions');
-      } else {
-        setLabel('Institution');
-      }
+  // TODO: this is the externally hosted course path
+  const courseTypeConfig = getCourseTypeConfig(course);
+  const usesOrganizationOverride = courseTypeConfig?.usesOrganizationOverride;
+  if (usesOrganizationOverride) {
+    const orgDetails = getCourseOrganizationDetails(course);
+    const result = [
+      [{
+        key: orgDetails.organizationName,
+        logoImageUrl: orgDetails.organizationLogo,
+        marketingUrl: orgDetails.organizationMarketingUrl,
+      }],
+      label,
+    ];
+    return result;
+  }
+
+  // TODO: this is the OCM course path.
+  if (course?.owners) {
+    course.owners.forEach((owner) => {
+      partners.push(owner);
+    });
+    if (course.owners.length > 1) {
+      label = 'Institutions';
     }
-  }, [course]);
+  }
 
   return [partners, label];
 }

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -128,6 +128,15 @@ export function useCourseSubjects(course) {
   return { subjects, primarySubject };
 }
 
+/**
+ * Determines the course partners associated with the course. Checks whether
+ * it should use the organization override or the `owners` property based on
+ * the course type configuration.
+ *
+ * @param {Object} course Metadata about the course.
+ *
+ * @returns {Array} An array of partners and a label for the partners, e.g. `[[{ name: 'edX' }], 'Institution']`.
+ */
 export function useCoursePartners(course) {
   const partners = [];
   let label = 'Institution';

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -132,14 +132,17 @@ export function useCoursePartners(course) {
   const partners = [];
   let label = 'Institution';
 
-  // TODO: this is the externally hosted course path
+  // Determine whether this course should use the organization override (e.g., for some
+  // externally hosted courses) instead of relying on the `owners` property.
   const courseTypeConfig = getCourseTypeConfig(course);
   const usesOrganizationOverride = courseTypeConfig?.usesOrganizationOverride;
   if (usesOrganizationOverride) {
     const orgDetails = getCourseOrganizationDetails(course);
     const result = [
       [{
-        key: orgDetails.organizationName,
+        uuid: orgDetails.organizationUuid,
+        key: orgDetails.organizationKey,
+        name: orgDetails.organizationName,
         logoImageUrl: orgDetails.organizationLogo,
         marketingUrl: orgDetails.organizationMarketingUrl,
       }],
@@ -148,7 +151,8 @@ export function useCoursePartners(course) {
     return result;
   }
 
-  // TODO: this is the OCM course path.
+  // If the course type does not have a configuration to use the organization override described above,
+  // fallback to relying on the `owners` property for regular Open edX courses.
   if (course?.owners) {
     course.owners.forEach((owner) => {
       partners.push(owner);
@@ -157,7 +161,6 @@ export function useCoursePartners(course) {
       label = 'Institutions';
     }
   }
-
   return [partners, label];
 }
 
@@ -868,8 +871,11 @@ export const useMinimalCourseMetadata = () => {
   };
 
   const courseMetadata = {
-    organizationImage: organizationDetails.organizationLogo,
-    organizationName: organizationDetails.organizationName,
+    organization: {
+      logoImgUrl: organizationDetails.organizationLogo,
+      name: organizationDetails.organizationName,
+      marketingUrl: organizationDetails.organizationMarketingUrl,
+    },
     title: course.title,
     startDate: getCourseStartDate({ contentMetadata: course, courseRun: activeCourseRun }),
     duration: getDuration(),

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -332,6 +332,7 @@ describe('useCourseEnrollmentUrl', () => {
           'executive-education-2u': {
             pathSlug: 'executive-education-2u',
             usesEntitlementListPrice: true,
+            useAdditionalMetadata: true,
           },
         },
       });

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -655,6 +655,11 @@ export const getCourseOrganizationDetails = (courseData) => {
     organizationDetails.organizationLogo = courseData?.owners[0]?.logoImageUrl;
   }
 
+  const marketingUrl = courseData?.owners[0]?.marketingUrl;
+  if (marketingUrl) {
+    organizationDetails.organizationMarketingUrl = marketingUrl;
+  }
+
   return organizationDetails;
 };
 

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -655,10 +655,9 @@ export const getCourseOrganizationDetails = (courseData) => {
     organizationDetails.organizationLogo = courseData?.owners[0]?.logoImageUrl;
   }
 
-  const marketingUrl = courseData?.owners[0]?.marketingUrl;
-  if (marketingUrl) {
-    organizationDetails.organizationMarketingUrl = marketingUrl;
-  }
+  organizationDetails.organizationMarketingUrl = courseData?.owners[0]?.marketingUrl;
+  organizationDetails.organizationKey = courseData?.owners[0]?.key;
+  organizationDetails.organizationUuid = courseData?.owners[0]?.uuid;
 
   return organizationDetails;
 };

--- a/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
+++ b/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
@@ -20,8 +20,11 @@ jest.mock('react-router-dom', () => ({
 jest.mock('../../data/hooks', () => ({
   ...jest.requireActual('../../data/hooks'),
   useMinimalCourseMetadata: () => ({
-    organizationImage: 'https://test.org/logo.png',
-    organizationName: 'Test Org',
+    organization: {
+      name: 'Test Org',
+      logoImgUrl: 'https://test.org/logo.png',
+      marketingUrl: 'https://test.org',
+    },
     title: 'Test Course Title',
     startDate: '2023-03-05',
     duration: '3 Weeks',

--- a/src/components/course/routes/tests/ExternalCourseEnrollmentConfirmation.test.jsx
+++ b/src/components/course/routes/tests/ExternalCourseEnrollmentConfirmation.test.jsx
@@ -18,8 +18,11 @@ jest.mock('@edx/frontend-platform/config', () => ({
 jest.mock('../../data/hooks', () => ({
   ...jest.requireActual('../../data/hooks'),
   useMinimalCourseMetadata: () => ({
-    organizationImage: 'https://test.org/logo.png',
-    organizationName: 'Test Org',
+    organization: {
+      logoImgUrl: 'https://test.org/logo.png',
+      name: 'Test Org',
+      marketingUrl: 'https://test.org',
+    },
     title: 'Test Course Title',
     startDate: '2023-03-05',
     duration: '3 Weeks',

--- a/src/components/course/styles/_CourseHeader.scss
+++ b/src/components/course/styles/_CourseHeader.scss
@@ -1,56 +1,68 @@
 .course-header {
   box-shadow: $box-shadow-sm;
-}
 
-.video-trigger {
-  background: none;
-  position: relative;
-  border: none;
-  padding: 0;
+  .course-header__partner-logos {
+    display: flex;
+    flex-wrap: wrap;
+    gap: map-get($spacers, 4);
 
-  .video-trigger-cta {
-    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.14);
-    text-align: center;
-    width: 150px;
-    position: absolute;
-    top: calc(50% - 15px);
-    left: calc(50% - 75px);
-    padding: 10px 0;
-
-    &.no-thumb {
-      position: relative;
+    a {
+      display: flex;
+      align-items: center;
+      min-height: 80px;
     }
   }
 
-  &:focus,
-  &:hover {
-    cursor: pointer;
-
+  .video-trigger {
+    background: none;
+    position: relative;
+    border: none;
+    padding: 0;
+  
     .video-trigger-cta {
-      border-color: $dark-500;
-
-      &:focus,
-      &:hover {
-        background-color: $dark !important;
-        color: $light;
+      box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.14);
+      text-align: center;
+      width: 150px;
+      position: absolute;
+      top: calc(50% - 15px);
+      left: calc(50% - 75px);
+      padding: 10px 0;
+  
+      &.no-thumb {
+        position: relative;
       }
-
+    }
+  
+    &:focus,
+    &:hover {
+      cursor: pointer;
+  
+      .video-trigger-cta {
+        border-color: $dark-500;
+  
+        &:focus,
+        &:hover {
+          background-color: $dark !important;
+          color: $light;
+        }
+  
+      }
     }
   }
-}
-
-.video-wrapper {
-  position: relative;
-  height: 0;
-  padding: {
-    bottom: 56.25%; /* 16:9 */
-  }
-
-  .video-iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+  
+  .video-wrapper {
+    position: relative;
+    height: 0;
+    padding: {
+      bottom: 56.25%; /* 16:9 */
+    }
+  
+    .video-iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
   }
 }

--- a/src/components/executive-education-2u/EnrollmentCompleted.test.jsx
+++ b/src/components/executive-education-2u/EnrollmentCompleted.test.jsx
@@ -18,8 +18,11 @@ const initialAppContextValue = {
 const mockBaseLocationMetadata = {
   state: {
     data: {
-      organizationImage: 'test-image',
-      organizationName: 'test org',
+      organization: {
+        logoImgUrl: 'test-image',
+        name: 'test org',
+        marketingUrl: 'test-url',
+      },
       title: 'test-title',
       startDate: '2022-09-09',
       duration: '8',

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
@@ -71,8 +71,11 @@ const ExecutiveEducation2UPage = () => {
         return duration;
       };
       return {
-        organizationImage: organizationDetails.organizationLogo,
-        organizationName: organizationDetails.organizationName,
+        organization: {
+          name: organizationDetails.organizationName,
+          logoImgUrl: organizationDetails.organizationLogo,
+          marketingUrl: organizationDetails.organizationMarketingUrl,
+        },
         title: contentMetadata.title,
         startDate: getCourseStartDate({ contentMetadata, courseRun: activeCourseRun }),
         duration: getDuration(),

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.test.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.test.jsx
@@ -66,6 +66,9 @@ const courseData = {
       currency: CURRENCY_USD,
     },
   ],
+  additionalMetadata: {
+    startDate: '2022-01-01T00:00:00Z',
+  },
 };
 
 jest.mock('./data');

--- a/src/components/executive-education-2u/components/CourseSummaryCard.jsx
+++ b/src/components/executive-education-2u/components/CourseSummaryCard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import {
-  Card, Image, Row, Col,
+  Card, Image, Row, Col, Hyperlink,
 } from '@edx/paragon';
 
 import { numberWithPrecision } from '../../course/data/utils';
@@ -30,14 +30,18 @@ const CourseSummaryCard = ({ courseMetadata, enrollmentCompleted }) => {
     >
       <Card.Body>
         <Card.Header
-          title={<Image src={courseMetadata.organizationImage} />}
+          title={(
+            <Hyperlink destination={courseMetadata.organization.marketingUrl}>
+              <Image src={courseMetadata.organization.logoImgUrl} />
+            </Hyperlink>
+          )}
         />
         <Card.Section>
           <Row>
             <Col xs={12} lg={{ span: 8, offset: 0 }} className="vertical">
               <Row>
                 <Col xs={12} lg={{ span: 8, offset: 0 }}>
-                  <p className="small font-weight-light text-gray-500">{courseMetadata.organizationName}</p>
+                  <p className="small font-weight-light text-gray-500">{courseMetadata.organization.name}</p>
                   <p>{courseMetadata.title}</p>
                 </Col>
               </Row>
@@ -76,8 +80,11 @@ CourseSummaryCard.defaultProps = {
 CourseSummaryCard.propTypes = {
   enrollmentCompleted: PropTypes.bool,
   courseMetadata: PropTypes.shape({
-    organizationImage: PropTypes.string.isRequired,
-    organizationName: PropTypes.string.isRequired,
+    organization: PropTypes.shape({
+      name: PropTypes.string,
+      marketingUrl: PropTypes.string,
+      logoImgUrl: PropTypes.string,
+    }).isRequired,
     title: PropTypes.string.isRequired,
     startDate: PropTypes.string.isRequired,
     duration: PropTypes.string.isRequired,


### PR DESCRIPTION
**Description:**

[ENT-7241](https://2u-internal.atlassian.net/browse/ENT-7241)

* Ensures we display the organization name/logo override fields (if set) depending on the course type configuration for the course type in question (e.g., an externally hosted course) on the course about page routes.
* Ensures the organization logo on the `/:enterpriseSlug/:courseType/course/:courseKey/enroll` and `/:enterpriseSlug/:courseType/course/:courseKey/enroll/complete` routes links to the organization's marketing url.
* Cleans up the styles for the organization logo to handle the different logo image heights between the override and non-override logo images on the course about page routes by setting a min-height and vertically centering the logo within it.
* Moves existing SCSS under the `.course-header` class name so it's doesn't have a chance of colliding with elements outside of the `CourseHeader` component.
* Refactors `useCoursePartners` to move away from the unnecessary use of `useState` and `useEffect`.

**Related PR:**
* https://github.com/edx/edx-internal/pull/8602

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
