### PR TITLE
ENT-7186: Style changes for executive education course cards on dashboard.

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -13,7 +13,7 @@ import { MoreVert } from '@edx/paragon/icons';
 
 import { EmailSettingsModal } from './email-settings';
 import { UnenrollModal } from './unenroll';
-import { COURSE_STATUSES, COURSE_PACING } from '../../../../../constants';
+import { COURSE_STATUSES, COURSE_PACING, EXECUTIVE_EDUCATION_COURSE_MODES } from '../../../../../constants';
 
 const BADGE_PROPS_BY_COURSE_STATUS = {
   [COURSE_STATUSES.inProgress]: {
@@ -321,9 +321,11 @@ class BaseCourseCard extends Component {
   };
 
   renderOrganizationName = () => {
-    const { orgName } = this.props;
+    const { orgName, mode } = this.props;
+
+    const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
     if (orgName) {
-      return <p className="mb-0">{orgName}</p>;
+      return <p className="mb-0">{orgName} {isExecutiveEducation2UCourse && <>&#x2022; Executive Education</>}</p>;
     }
     return null;
   };
@@ -381,10 +383,13 @@ class BaseCourseCard extends Component {
       linkToCourse,
       hasViewCertificateLink,
       isLoading,
+      mode,
     } = this.props;
     const dropdownMenuItems = this.getDropdownMenuItems();
+    const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
+
     return (
-      <div className="dashboard-course-card py-4 border-bottom">
+      <div className={`dashboard-course-card py-4 border-bottom ${isExecutiveEducation2UCourse && 'bg-dark-200 rounded-lg p-3 text-light-100'}`}>
         {isLoading ? (
           <>
             <div className="sr-only">Loading...</div>
@@ -398,7 +403,7 @@ class BaseCourseCard extends Component {
                   {this.renderMicroMastersTitle()}
                   <div className="d-flex align-items-start justify-content-between mb-1">
                     <h4 className="course-title mb-0 mr-2">
-                      <a className="h3" href={linkToCourse}>{title}</a>
+                      <a className={`h3 ${isExecutiveEducation2UCourse && 'text-light-100'}`} href={linkToCourse}>{title}</a>
                     </h4>
                     {
                       BADGE_PROPS_BY_COURSE_STATUS[type] && (
@@ -416,7 +421,7 @@ class BaseCourseCard extends Component {
               {this.renderButtons()}
               {this.renderChildren()}
               <div className="course-misc-text row">
-                <div className="col text-gray">
+                <div className={`col ${isExecutiveEducation2UCourse ? 'text-light-900' : 'text-gray' }`}>
                   <small className="mb-0">
                     {this.getCourseMiscText()}
                   </small>
@@ -438,6 +443,7 @@ BaseCourseCard.propTypes = {
   title: PropTypes.string.isRequired,
   linkToCourse: PropTypes.string.isRequired,
   courseRunId: PropTypes.string.isRequired,
+  mode: PropTypes.string.isRequired,
   hasViewCertificateLink: PropTypes.bool,
   buttons: PropTypes.element,
   children: PropTypes.node,

--- a/src/constants/course.js
+++ b/src/constants/course.js
@@ -5,7 +5,16 @@ export const COURSE_MODES = {
   NO_ID_PROFESSIONAL: 'no-id-professional',
   AUDIT: 'audit',
   HONOR: 'honor',
+  EXECUTIVE_EDUCATION: 'executive-education',
+  PAID_EXECUTIVE_EDUCATION: 'paid-executive-education',
+  UNPAID_EXECUTIVE_EDUCATION: 'unpaid-executive-education',
 };
+
+export const EXECUTIVE_EDUCATION_COURSE_MODES = [
+  COURSE_MODES.EXECUTIVE_EDUCATION,
+  COURSE_MODES.PAID_EXECUTIVE_EDUCATION,
+  COURSE_MODES.UNPAID_EXECUTIVE_EDUCATION,
+];
 
 export const COURSE_STATUSES = {
   inProgress: 'in_progress',


### PR DESCRIPTION
__Jira Ticket:__ [ENT-7186](https://2u-internal.atlassian.net/browse/ENT-7186)

__Description:__
This PR updates the style of the course run card component displayed on the learner dashboard for executive education courses. With this change, executive education course cards will have a dark background and light text, visually distinguishing them from other courses on the dashboard.


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
