### PR TITLE
feat: GetSmarter dashboard opens in a new tab

### DIFF
--- a/src/components/executive-education-2u/EnrollmentCompleted.test.jsx
+++ b/src/components/executive-education-2u/EnrollmentCompleted.test.jsx
@@ -73,7 +73,7 @@ describe('EnrollmentCompleted', () => {
   it('renders get smarter learner dashboard URL on enrollment.', () => {
     renderWithRouter(<EnrollmentCompletedWrapper />);
     expect(
-      screen.getByRole('link', { name: 'GetSmarter learner dashboard' }),
+      screen.getByRole('link', { name: 'GetSmarter learner dashboard in a new tab' }),
     ).toHaveAttribute('href', 'https://getsmarter.example.com/account?org_id=test-enterprise-slug');
   });
 });

--- a/src/components/executive-education-2u/components/EnrollmentCompletedSummaryCard.jsx
+++ b/src/components/executive-education-2u/components/EnrollmentCompletedSummaryCard.jsx
@@ -38,7 +38,10 @@ const EnrollmentCompletedSummaryCard = () => {
               <div className="mb-1.5 text-black-color">Notified by email</div>
               <div className="small mb-2 text-gray-500">
                 GetSmarter will email you when your course starts. Alternatively, you can visit your{' '}
-                <Hyperlink destination={externalDashboardUrl}>
+                <Hyperlink
+                  destination={externalDashboardUrl}
+                  target="_blank"
+                >
                   GetSmarter learner dashboard
                 </Hyperlink>
                 {' '}for course status updates.


### PR DESCRIPTION
GetSmarterDashboard opens in a new tab, updated test to reflect changes

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
