### PR TITLE
feat: add loading spinner for updated current job on career chart page

### DIFF
--- a/src/components/my-career/VisualizeCareer.jsx
+++ b/src/components/my-career/VisualizeCareer.jsx
@@ -20,7 +20,7 @@ const VisualizeCareer = ({ jobId, submitClickHandler }) => {
   const [showInstructions, , , toggleShowInstructions] = useToggle(false);
   const [isEditable, setIsEditable] = useState(false);
 
-  const [learnerSkillLevels, learnerSkillLevelsFetchError] = useLearnerSkillLevels(jobId);
+  const [learnerSkillLevels, learnerSkillLevelsFetchError, isLoading] = useLearnerSkillLevels(jobId);
 
   const editOnClickHandler = () => {
     setIsEditable(true);
@@ -44,7 +44,7 @@ const VisualizeCareer = ({ jobId, submitClickHandler }) => {
     return <ErrorPage status={learnerSkillLevelsFetchError.status} />;
   }
 
-  if (!learnerSkillLevels) {
+  if (!learnerSkillLevels || isLoading) {
     return (
       <div className="py-5">
         <LoadingSpinner data-testid="loading-spinner" screenReaderText="Visualize Career Tab" />

--- a/src/components/my-career/data/hooks.jsx
+++ b/src/components/my-career/data/hooks.jsx
@@ -33,9 +33,11 @@ export function useLearnerProfileData(username) {
 export function useLearnerSkillLevels(jobId) {
   const [learnerSkillLevels, setLearnerSkillLevels] = useState();
   const [fetchError, setFetchError] = useState();
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
+      setIsLoading(true);
       if (jobId) {
         try {
           const response = await getLearnerSkillLevels(jobId);
@@ -45,11 +47,12 @@ export function useLearnerSkillLevels(jobId) {
           setFetchError(error);
         }
       }
+      setIsLoading(false);
       return undefined;
     };
     fetchData();
   }, [jobId]);
-  return [camelCaseObject(learnerSkillLevels), fetchError];
+  return [camelCaseObject(learnerSkillLevels), fetchError, isLoading];
 }
 
 export function usePlotlySpiderChart(categories) {


### PR DESCRIPTION
**Description**
Display a loading spinner until we get information about the updated current job on the career chart page.

[JIRA-> ENT-7318](https://2u-internal.atlassian.net/browse/ENT-7318)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
