### PR TITLE
feat: identify EE courses on base of mode instead of course_type and …

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -14,7 +14,6 @@ import { MoreVert } from '@edx/paragon/icons';
 import { EmailSettingsModal } from './email-settings';
 import { UnenrollModal } from './unenroll';
 import { COURSE_STATUSES, COURSE_PACING, EXECUTIVE_EDUCATION_COURSE_MODES } from '../../../../../constants';
-import { EXEC_ED_COURSE_TYPE, PRODUCT_SOURCE_2U } from '../data/constants';
 
 const BADGE_PROPS_BY_COURSE_STATUS = {
   [COURSE_STATUSES.inProgress]: {
@@ -51,12 +50,12 @@ class BaseCourseCard extends Component {
 
   getDropdownMenuItems = () => {
     const {
-      hasEmailsEnabled, title, dropdownMenuItems, canUnenroll, courseType, productSource,
+      hasEmailsEnabled, title, dropdownMenuItems, canUnenroll, mode,
     } = this.props;
     const firstMenuItems = [];
     const lastMenuItems = [];
-
-    if (hasEmailsEnabled !== null && (productSource !== PRODUCT_SOURCE_2U && courseType !== EXEC_ED_COURSE_TYPE)) {
+    const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
+    if (hasEmailsEnabled !== null && !isExecutiveEducation2UCourse) {
       firstMenuItems.push({
         key: 'email-settings',
         type: 'button',
@@ -200,7 +199,7 @@ class BaseCourseCard extends Component {
 
   renderUnenrollModal = () => {
     const {
-      canUnenroll, courseRunId, type, courseType, productSource,
+      canUnenroll, courseRunId, type, mode,
     } = this.props;
     const { modals } = this.state;
 
@@ -211,12 +210,11 @@ class BaseCourseCard extends Component {
     return (
       <UnenrollModal
         courseRunId={courseRunId}
-        courseType={courseType}
-        productSource={productSource}
         onClose={this.handleUnenrollModalOnClose}
         onSuccess={this.handleUnenrollModalOnSuccess}
         isOpen={modals.unenroll.open}
         enrollmentType={camelCase(type)}
+        mode={mode}
       />
     );
   };
@@ -244,8 +242,9 @@ class BaseCourseCard extends Component {
   };
 
   renderSettingsDropdown = (menuItems) => {
-    const { title, courseType, productSource } = this.props;
-    const execEdClass = courseType === EXEC_ED_COURSE_TYPE && productSource === PRODUCT_SOURCE_2U ? 'text-light-100' : '';
+    const { title, mode } = this.props;
+    const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
+    const execEdClass = isExecutiveEducation2UCourse ? 'text-light-100' : '';
     if (menuItems && menuItems.length > 0) {
       return (
         <div className="ml-auto">
@@ -325,14 +324,14 @@ class BaseCourseCard extends Component {
     return null;
   };
 
-  renderIsCourseStarted = () => {
-    const { startDate, courseType, productSource } = this.props;
+  renderCourseStartDate = () => {
+    const { startDate, mode } = this.props;
+    const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
     const formattedStartDate = startDate ? moment(startDate).format('MMMM Do, YYYY') : null;
 
-    if (courseType === EXEC_ED_COURSE_TYPE && productSource === PRODUCT_SOURCE_2U) {
+    if (isExecutiveEducation2UCourse && formattedStartDate) {
       return <>&#x2022; Start date: {formattedStartDate}</>;
     }
-
     return null;
   };
 
@@ -342,7 +341,7 @@ class BaseCourseCard extends Component {
     const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
     const execEdClass = isExecutiveEducation2UCourse ? 'text-light-300' : '';
     if (orgName) {
-      return <p className={`mb-0 ${execEdClass}`}>{orgName} {isExecutiveEducation2UCourse && <>&#x2022; Executive Education</>} {this.renderIsCourseStarted()}</p>;
+      return <p className={`mb-0 ${execEdClass}`}>{orgName} {isExecutiveEducation2UCourse && <>&#x2022; Executive Education</>} {this.renderCourseStartDate()}</p>;
     }
     return null;
   };
@@ -465,8 +464,6 @@ BaseCourseCard.propTypes = {
   buttons: PropTypes.element,
   children: PropTypes.node,
   startDate: PropTypes.string,
-  courseType: PropTypes.string,
-  productSource: PropTypes.string,
   endDate: PropTypes.string,
   hasEmailsEnabled: PropTypes.bool,
   canUnenroll: PropTypes.bool,
@@ -488,8 +485,6 @@ BaseCourseCard.contextType = AppContext;
 BaseCourseCard.defaultProps = {
   children: null,
   startDate: null,
-  courseType: null,
-  productSource: null,
   endDate: null,
   hasEmailsEnabled: null,
   canUnenroll: null,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/CompletedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/CompletedCourseCard.jsx
@@ -18,8 +18,7 @@ const CompletedCourseCard = (props) => {
     courseRunId,
     startDate,
     endDate,
-    courseType,
-    productSource,
+    mode,
   } = props;
   const config = getConfig();
 
@@ -33,8 +32,7 @@ const CompletedCourseCard = (props) => {
         linkToCourse={linkToCourse}
         title={title}
         courseRunId={courseRunId}
-        courseType={courseType}
-        productSource={productSource}
+        mode={mode}
         startDate={startDate}
       />
     );
@@ -70,8 +68,7 @@ const CompletedCourseCard = (props) => {
       buttons={renderButtons()}
       type="completed"
       hasViewCertificateLink={false}
-      courseType={courseType}
-      productSource={productSource}
+      mode={mode}
       startDate={startDate}
       {...props}
     >
@@ -88,16 +85,14 @@ CompletedCourseCard.propTypes = {
   courseRunStatus: PropTypes.string.isRequired,
   endDate: PropTypes.string,
   startDate: PropTypes.string,
-  courseType: PropTypes.string,
-  productSource: PropTypes.string,
+  mode: PropTypes.string,
 };
 
 CompletedCourseCard.defaultProps = {
   linkToCertificate: null,
   endDate: null,
   startDate: null,
-  courseType: null,
-  productSource: null,
+  mode: null,
 };
 
 export default CompletedCourseCard;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/ContinueLearningButton.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/ContinueLearningButton.jsx
@@ -5,8 +5,7 @@ import classNames from 'classnames';
 
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import moment from 'moment';
-import { EXEC_ED_COURSE_TYPE, PRODUCT_SOURCE_2U } from '../data/constants';
-
+import { EXECUTIVE_EDUCATION_COURSE_MODES } from '../../../../../constants';
 /**
  * A 'Continue Learning' button with parameters.
  *
@@ -22,9 +21,8 @@ const ContinueLearningButton = ({
   linkToCourse,
   title,
   courseRunId,
-  courseType,
-  productSource,
   startDate,
+  mode,
 }) => {
   const { enterpriseConfig } = useContext(AppContext);
 
@@ -39,11 +37,11 @@ const ContinueLearningButton = ({
   };
 
   const isCourseStarted = () => moment(startDate) <= moment();
-
-  const execClassName = (courseType === EXEC_ED_COURSE_TYPE && productSource === PRODUCT_SOURCE_2U) && (!isCourseStarted()) ? ' disabled btn-outline-secondary' : undefined;
+  const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
+  const execClassName = (isExecutiveEducation2UCourse) && (!isCourseStarted()) ? ' disabled btn-outline-secondary' : undefined;
 
   const renderContent = () => {
-    if ((courseType === EXEC_ED_COURSE_TYPE && productSource === PRODUCT_SOURCE_2U) && !isCourseStarted()) {
+    if (isExecutiveEducation2UCourse && !isCourseStarted() && startDate) {
       const formattedStartDate = moment(startDate).format('MMM D, YYYY');
       return `Available on ${formattedStartDate}`;
     }
@@ -65,8 +63,7 @@ const ContinueLearningButton = ({
 ContinueLearningButton.defaultProps = {
   className: 'btn-outline-primary',
   startDate: null,
-  courseType: null,
-  productSource: null,
+  mode: null,
 };
 
 ContinueLearningButton.propTypes = {
@@ -75,8 +72,7 @@ ContinueLearningButton.propTypes = {
   title: PropTypes.string.isRequired,
   courseRunId: PropTypes.string.isRequired,
   startDate: PropTypes.string,
-  courseType: PropTypes.string,
-  productSource: PropTypes.string,
+  mode: PropTypes.string,
 };
 
 export default ContinueLearningButton;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
@@ -21,8 +21,7 @@ export const InProgressCourseCard = ({
   notifications,
   courseRunStatus,
   startDate,
-  courseType,
-  productSource,
+  mode,
   ...rest
 }) => {
   const {
@@ -48,8 +47,7 @@ export const InProgressCourseCard = ({
         linkToCourse={licenseUpgradeUrl ?? linkToCourse}
         title={title}
         courseRunId={courseRunId}
-        courseType={courseType}
-        productSource={productSource}
+        mode={mode}
         startDate={startDate}
       />
       {shouldShowUpgradeButton && <UpgradeCourseButton className="ml-1" title={title} />}
@@ -158,8 +156,7 @@ export const InProgressCourseCard = ({
       linkToCourse={licenseUpgradeUrl ?? linkToCourse}
       courseRunId={courseRunId}
       isLoading={isLoadingUpgradeUrl}
-      courseType={courseType}
-      productSource={productSource}
+      mode={mode}
       startDate={startDate}
       {...rest}
     >
@@ -187,14 +184,12 @@ InProgressCourseCard.propTypes = {
   title: PropTypes.string.isRequired,
   courseRunStatus: PropTypes.string.isRequired,
   startDate: PropTypes.string,
-  courseType: PropTypes.string,
-  productSource: PropTypes.string,
+  mode: PropTypes.string,
 };
 
 InProgressCourseCard.defaultProps = {
   startDate: null,
-  courseType: null,
-  productSource: null,
+  mode: null,
 };
 
 export default InProgressCourseCard;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/RequestedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/RequestedCourseCard.jsx
@@ -22,8 +22,7 @@ RequestedCourseCard.propTypes = {
   courseRunStatus: PropTypes.string.isRequired,
   endDate: PropTypes.string,
   startDate: PropTypes.string,
-  courseType: PropTypes.string,
-  productSource: PropTypes.string,
+  mode: PropTypes.string,
 };
 
 RequestedCourseCard.defaultProps = {
@@ -31,8 +30,7 @@ RequestedCourseCard.defaultProps = {
   endDate: null,
   isRevoked: false,
   startDate: null,
-  courseType: null,
-  productSource: null,
+  mode: null,
 };
 
 export default RequestedCourseCard;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/SavedForLaterCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/SavedForLaterCourseCard.jsx
@@ -20,8 +20,7 @@ const SavedForLaterCourseCard = (props) => {
     endDate,
     isRevoked,
     startDate,
-    courseType,
-    productSource,
+    mode,
   } = props;
   const {
     updateCourseEnrollmentStatus,
@@ -103,8 +102,7 @@ const SavedForLaterCourseCard = (props) => {
         linkToCourse={linkToCourse}
         title={title}
         courseRunId={courseRunId}
-        courseType={courseType}
-        productSource={productSource}
+        mode={mode}
         startDate={startDate}
       />
     );
@@ -116,8 +114,7 @@ const SavedForLaterCourseCard = (props) => {
       dropdownMenuItems={getDropdownMenuItems()}
       type={COURSE_STATUSES.savedForLater}
       hasViewCertificateLink={false}
-      courseType={courseType}
-      productSource={productSource}
+      mode={mode}
       startDate={startDate}
       {...props}
     >
@@ -142,16 +139,14 @@ SavedForLaterCourseCard.propTypes = {
   courseRunStatus: PropTypes.string.isRequired,
   endDate: PropTypes.string,
   startDate: PropTypes.string,
-  courseType: PropTypes.string,
-  productSource: PropTypes.string,
+  mode: PropTypes.string,
 };
 
 SavedForLaterCourseCard.defaultProps = {
   linkToCertificate: null,
   endDate: null,
   startDate: null,
-  courseType: null,
-  productSource: null,
+  mode: null,
 };
 
 export default SavedForLaterCourseCard;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
@@ -132,7 +132,7 @@ describe('<BaseCourseCard />', () => {
           </AppContext.Provider>
         ));
 
-        const hasCourseStarted = wrapper.instance().renderIsCourseStarted();
+        const hasCourseStarted = wrapper.instance().renderCourseStartDate();
         expect(hasCourseStarted).toBeTruthy();
       });
     });

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.jsx
@@ -8,7 +8,8 @@ import { logError } from '@edx/frontend-platform/logging';
 import { CourseEnrollmentsContext } from '../../CourseEnrollmentsContextProvider';
 import { ToastsContext } from '../../../../../Toasts';
 import { unenrollFromCourse } from './data';
-import { EXEC_ED_COURSE_TYPE, GETSMARTER_BASE_URL, PRODUCT_SOURCE_2U } from '../../data/constants';
+import { GETSMARTER_BASE_URL } from '../../data/constants';
+import { EXECUTIVE_EDUCATION_COURSE_MODES } from '../../../../../../constants';
 
 const btnLabels = {
   default: 'Unenroll',
@@ -17,8 +18,7 @@ const btnLabels = {
 
 const UnenrollModal = ({
   courseRunId,
-  courseType,
-  productSource,
+  mode,
   enrollmentType,
   isOpen,
   onClose,
@@ -38,7 +38,8 @@ const UnenrollModal = ({
 
   const handleUnenrollButtonClick = async () => {
     try {
-      if (courseType === EXEC_ED_COURSE_TYPE && productSource === PRODUCT_SOURCE_2U) {
+      const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
+      if (isExecutiveEducation2UCourse) {
         window.location.href = `${GETSMARTER_BASE_URL}/cancel-defer`;
       } else {
         setBtnState('pending');
@@ -103,13 +104,11 @@ UnenrollModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onSuccess: PropTypes.func.isRequired,
-  courseType: PropTypes.string,
-  productSource: PropTypes.string,
+  mode: PropTypes.string,
 };
 
 UnenrollModal.defaultProps = {
-  courseType: null,
-  productSource: null,
+  mode: null,
 };
 
 export default UnenrollModal;

--- a/src/components/dashboard/main-content/course-enrollments/data/constants.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/constants.js
@@ -15,6 +15,4 @@ export const COURSE_STATUSES = {
   requested: 'requested',
 };
 
-export const EXEC_ED_COURSE_TYPE = 'executive-education-2u';
-export const PRODUCT_SOURCE_2U = '2u';
 export const GETSMARTER_BASE_URL = 'https://www.getsmarter.com';


### PR DESCRIPTION
**Description**
Identify EE (executive-education) courses on the base of course `mode` instead of `course_type` and `product_source`.
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
