### PR TITLE
fix: ensure multiple subs work properly when 1 has previously expired

### DIFF
--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -692,7 +692,6 @@ describe('getSubscriptionDisabledEnrollmentReasonType', () => {
         },
       ],
     };
-
     const reasonType = getSubscriptionDisabledEnrollmentReasonType({
       customerAgreementConfig,
       catalogsWithCourse,

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -679,12 +679,14 @@ export const getSubscriptionDisabledEnrollmentReasonType = ({
   const subscriptionsApplicableToCourse = customerAgreementConfig?.subscriptions?.filter(
     subscription => catalogsWithCourse.includes(subscription?.enterpriseCatalogUuid),
   );
-  const hasExpiredSubscriptions = subscriptionsApplicableToCourse?.filter(
+  const hasApplicableSubscriptions = subscriptionsApplicableToCourse.length > 0;
+
+  const hasExpiredSubscriptions = hasApplicableSubscriptions && subscriptionsApplicableToCourse.every(
     subscription => subscription.daysUntilExpirationIncludingRenewals < 0,
-  )?.length > 0;
-  const hasExhaustedSubscriptions = subscriptionsApplicableToCourse?.filter(
+  );
+  const hasExhaustedSubscriptions = hasApplicableSubscriptions && subscriptionsApplicableToCourse.every(
     subscription => subscription?.licenses?.unassigned === 0,
-  )?.length > 0;
+  );
   const applicableSubscriptionNonExpiredNonExhausted = subscriptionsApplicableToCourse?.find(
     subscription => subscription.daysUntilExpirationIncludingRenewals >= 0 && subscription?.licenses?.unassigned > 0,
   );


### PR DESCRIPTION
During stage QA, noticed a customer having 2 active, subs plan where 1 is expired. The current logic thinks all applicable subscription plans are expired, which isn't true for this test customer; it has 1 active, current subscription plan applicable to the course.

<img width="274" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/a99d7f54-7065-4893-9c7d-4b174206f7a4">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
