### PR TITLE
chore: Refactor useCourseSubject and enrollmentUrl

### DIFF
--- a/src/components/course/CourseSidebar.jsx
+++ b/src/components/course/CourseSidebar.jsx
@@ -21,17 +21,17 @@ import CourseSidebarPrice from './CourseSidebarPrice';
 
 import { isDefinedAndNotNull, hasTruthyValue } from '../../utils/common';
 import {
-  useCourseSubjects,
   useCoursePartners,
   useCourseRunWeeksToComplete,
   useCourseTranscriptLanguages,
   useCoursePacingType,
 } from './data/hooks';
+import { processCourseSubjects } from './data/utils';
 
 const CourseSidebar = () => {
   const { state } = useContext(CourseContext);
   const { course, activeCourseRun } = state;
-  const { primarySubject } = useCourseSubjects(course);
+  const { primarySubject } = processCourseSubjects(course);
   const [partners, institutionLabel] = useCoursePartners(course);
   const [weeksToComplete, weeksLabel] = useCourseRunWeeksToComplete(activeCourseRun);
   const [transcriptLanguages, transcriptLabel] = useCourseTranscriptLanguages(activeCourseRun);

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -32,6 +32,8 @@ import {
   getCourseStartDate,
   getCourseTypeConfig,
   getSubscriptionDisabledEnrollmentReasonType,
+  createEnrollWithCouponCodeUrl,
+  createEnrollWithLicenseUrl,
 } from './utils';
 import {
   COURSE_PACING_MAP,
@@ -105,28 +107,6 @@ export function useAllCourseData({
     fetchError,
     isLoading,
   };
-}
-
-// TODO: Refactor away from useEffect useState
-export function useCourseSubjects(course) {
-  const [subjects, setSubjects] = useState([]);
-  const [primarySubject, setPrimarySubject] = useState(null);
-  const config = getConfig();
-
-  useEffect(() => {
-    if (course?.subjects) {
-      setSubjects(course.subjects);
-      if (course.subjects.length > 0) {
-        const newSubject = {
-          ...course.subjects[0],
-          url: `${config.MARKETING_SITE_BASE_URL}/course/subject/${course.subjects[0].slug}`,
-        };
-        setPrimarySubject(newSubject);
-      }
-    }
-  }, [config.MARKETING_SITE_BASE_URL, course]);
-
-  return { subjects, primarySubject };
 }
 
 /**
@@ -330,21 +310,15 @@ export const useCourseEnrollmentUrl = ({
     [config.LMS_BASE_URL, courseRunKey, baseQueryParams, location.pathname],
   );
 
-  // TODO: use the new helper functions (createEnrollWithLicenseUrl, createEnrollWithCouponCodeUrl) to generate url
   const enrollmentUrl = useMemo(
     () => {
       if (userSubsidyApplicableToCourse?.subsidyType === LICENSE_SUBSIDY_TYPE) {
-        const queryParams = new URLSearchParams({
-          ...baseEnrollmentOptions,
-          license_uuid: userSubsidyApplicableToCourse.subsidyId,
-          course_id: courseRunKey,
-          enterprise_customer_uuid: enterpriseConfig.uuid,
-          // We don't want any sidebar text we show the data consent page from this workflow since
-          // the text on the sidebar is used when a learner is coming from their employer's system.
-          left_sidebar_text_override: '',
-          source: 'enterprise-learner-portal',
+        return createEnrollWithLicenseUrl({
+          courseRunKey,
+          enterpriseId: enterpriseConfig.uuid,
+          licenseUUID: userSubsidyApplicableToCourse.subsidyId,
+          location,
         });
-        return `${config.LMS_BASE_URL}/enterprise/grant_data_sharing_permissions/?${queryParams.toString()}`;
       }
 
       if (!sku) {
@@ -352,15 +326,13 @@ export const useCourseEnrollmentUrl = ({
         return null;
       }
 
-      const queryParams = new URLSearchParams({
-        ...baseEnrollmentOptions,
-        sku,
-        consent_url_param_string: `failure_url=${encodeURIComponent(global.location.href)}?${baseQueryParams.toString()}&left_sidebar_text_override=`,
-      });
-
       if (features.ENROLL_WITH_CODES && userSubsidyApplicableToCourse?.subsidyType === COUPON_CODE_SUBSIDY_TYPE) {
-        queryParams.set('code', userSubsidyApplicableToCourse.code);
-        return `${config.ECOMMERCE_BASE_URL}/coupons/redeem/?${queryParams.toString()}`;
+        return createEnrollWithCouponCodeUrl({
+          courseRunKey,
+          sku,
+          code: userSubsidyApplicableToCourse.code,
+          location,
+        });
       }
 
       if (isExecutiveEducation2UCourse) {
@@ -369,7 +341,11 @@ export const useCourseEnrollmentUrl = ({
         });
         return externalCourseEnrollmentUrl;
       }
-
+      const queryParams = new URLSearchParams({
+        ...baseEnrollmentOptions,
+        sku,
+        consent_url_param_string: `failure_url=${encodeURIComponent(global.location.href)}?${baseQueryParams.toString()}&left_sidebar_text_override=`,
+      });
       // This enrollment url will automatically apply enterprise offers
       return `${config.ECOMMERCE_BASE_URL}/basket/add/?${queryParams.toString()}`;
     },
@@ -379,11 +355,11 @@ export const useCourseEnrollmentUrl = ({
       baseEnrollmentOptions,
       baseQueryParams,
       config.ECOMMERCE_BASE_URL,
-      config.LMS_BASE_URL,
       courseRunKey,
       enterpriseConfig.uuid,
       isExecutiveEducation2UCourse,
       routeMatch.url,
+      location,
     ],
   );
 

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -19,7 +19,6 @@ import {
   useCoursePacingType,
   useCoursePriceForUserSubsidy,
   useExtractAndRemoveSearchParamsFromURL,
-  useCourseSubjects,
   useCheckSubsidyAccessPolicyRedeemability,
   useUserSubsidyApplicableToCourse,
   useMinimalCourseMetadata,
@@ -576,41 +575,6 @@ describe('useTrackSearchConversionClickHandler', () => {
         courseKey: mockCourseState.activeCourseRun.key,
       },
     );
-  });
-});
-
-describe('useCourseSubjects', () => {
-  it('handles null course', async () => {
-    const { result } = renderHook(() => useCourseSubjects());
-    expect(result.current).toEqual({
-      primarySubject: null,
-      subjects: [],
-    });
-  });
-
-  it('handles empty subjects list', async () => {
-    const course = { subjects: [] };
-    const { result } = renderHook(() => useCourseSubjects(course));
-    expect(result.current).toEqual({
-      primarySubject: null,
-      subjects: [],
-    });
-  });
-
-  it('handles course with subjects', async () => {
-    const mockSubject = {
-      name: 'Subject 1',
-      slug: 'subject-1',
-    };
-    const course = { subjects: [mockSubject] };
-    const { result } = renderHook(() => useCourseSubjects(course));
-    expect(result.current).toEqual({
-      primarySubject: {
-        ...mockSubject,
-        url: `${getConfig().MARKETING_SITE_BASE_URL}/course/subject/${mockSubject.slug}`,
-      },
-      subjects: [mockSubject],
-    });
   });
 });
 

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -2,6 +2,7 @@ import moment from 'moment';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import { getConfig } from '@edx/frontend-platform';
 import {
   COUPON_CODE_SUBSIDY_TYPE,
   COURSE_AVAILABILITY_MAP,
@@ -22,6 +23,7 @@ import {
   getMissingSubsidyReasonActions,
   getSubscriptionDisabledEnrollmentReasonType,
   isActiveSubscriptionLicense,
+  processCourseSubjects,
 } from '../utils';
 
 jest.mock('@edx/frontend-platform/config', () => ({
@@ -880,5 +882,40 @@ describe('isActiveSubscriptionLicense', () => {
   ])('returns expected value given the following inputs: %s', ({ subscriptionLicense, expectedResult }) => {
     const isActive = isActiveSubscriptionLicense(subscriptionLicense);
     expect(isActive).toEqual(expectedResult);
+  });
+});
+
+describe('processCourseSubjects', () => {
+  it('handles null course', () => {
+    const result = processCourseSubjects(null);
+    expect(result).toEqual({
+      primarySubject: null,
+      subjects: [],
+    });
+  });
+
+  it('handles empty subject list', () => {
+    const course = { subjects: [] };
+    const result = processCourseSubjects(course);
+    expect(result).toEqual({
+      primarySubject: null,
+      subjects: [],
+    });
+  });
+
+  it('handles course with subjects', () => {
+    const mockSubject = {
+      name: 'Subject 1',
+      slug: 'subject-1',
+    };
+    const course = { subjects: [mockSubject] };
+    const result = processCourseSubjects(course);
+    expect(result).toEqual({
+      primarySubject: {
+        ...mockSubject,
+        url: `${getConfig().MARKETING_SITE_BASE_URL}/course/subject/${mockSubject.slug}`,
+      },
+      subjects: [mockSubject],
+    });
   });
 });

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -779,3 +779,17 @@ export const getCourseStartDate = ({ contentMetadata, courseRun }) => {
 
   return startDate;
 };
+
+export function processCourseSubjects(course) {
+  const config = getConfig();
+  if (!course?.subjects?.length) {
+    return { subjects: [], primarySubject: null };
+  }
+  return {
+    subjects: course.subjects,
+    primarySubject: {
+      ...course.subjects[0],
+      url: `${config.MARKETING_SITE_BASE_URL}/course/subject/${course.subjects[0].slug}`,
+    },
+  };
+}

--- a/src/components/course/tests/CourseSidebar.test.jsx
+++ b/src/components/course/tests/CourseSidebar.test.jsx
@@ -15,12 +15,6 @@ jest.mock('@edx/frontend-enterprise-utils', () => ({
 
 jest.mock('../data/hooks', () => ({
   ...jest.requireActual('../data/hooks'),
-  useCourseSubjects: jest.fn(() => ({
-    primarySubject: {
-      url: 'https://test.org/subject',
-      name: 'Test Subject',
-    },
-  })),
   useCoursePartners: jest.fn(() => [
     [{
       key: 'Test Partner',
@@ -39,6 +33,16 @@ jest.mock('../data/hooks', () => ({
     'instructor_paced',
     'Instructor Paced',
   ]),
+}));
+
+jest.mock('../data/utils', () => ({
+  ...jest.requireActual('../data/utils'),
+  processCourseSubjects: jest.fn(() => ({
+    primarySubject: {
+      url: 'https://test.org/subject',
+      name: 'Test Subject',
+    },
+  })),
 }));
 
 jest.mock('../CourseSidebarListItem', () => jest.fn(({ content }) => (


### PR DESCRIPTION
Refactor `useCourseSubject` to be a utility function, instead of using `useState` and `useEffect`. Additionally, the enrollmentUrl function can use existing helper functions `createEnrollWithLicenseUrl` and `createEnrollWithCouponCodeUrl`.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
