### PR TITLE
fix: ordinal bug with dayjs

### DIFF
--- a/docs/decisions/0009-moment-to-dayjs.rst
+++ b/docs/decisions/0009-moment-to-dayjs.rst
@@ -27,6 +27,10 @@ just need to replace the package name and nothing else
 
 ``moment(date).format('MMMM D, YYYY') -> dayjs(date).format('MMMM D, YYYY')``
 
+To use plugins in dayjs, the best practice is to add all the needed plugins in the utils/dayjs.js file so that then
+whenever we need to use any plugins, we can just import the version of dayjs from that file to avoid having individual
+imports scattered throughout the project. 
+
 Consequences
 ************
 

--- a/src/components/course/course-header/data/hooks/tests/useCourseRunCardHeading.test.jsx
+++ b/src/components/course/course-header/data/hooks/tests/useCourseRunCardHeading.test.jsx
@@ -11,6 +11,10 @@ jest.mock('dayjs', () => jest.fn(
   (...args) => jest.requireActual('dayjs')(args.filter((arg) => arg).length > 0 ? args : '2023-03-20'),
 ));
 
+jest.mock('../../../../../../utils/dayjs', () => jest.fn(
+  (...args) => jest.requireActual('../../../../../../utils/dayjs')(args.filter((arg) => arg).length > 0 ? args : '2023-03-20'),
+));
+
 jest.mock('../../../../data/utils', () => ({
   ...jest.requireActual('../../../../data/utils'),
   hasTimeToComplete: jest.fn().mockReturnValue(true),

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -3,8 +3,7 @@ import { ensureConfig, getConfig } from '@edx/frontend-platform';
 import { hasFeatureFlagEnabled } from '@edx/frontend-enterprise-utils';
 import { Button, Hyperlink, MailtoLink } from '@edx/paragon';
 import isNil from 'lodash.isnil';
-import dayjs from 'dayjs';
-import isBetween from 'dayjs/plugin/isBetween';
+import dayjs from '../../../utils/dayjs';
 
 import {
   COURSE_AVAILABILITY_MAP,
@@ -682,15 +681,12 @@ const parseReasonTypeBasedOnEnterpriseAdmins = ({ hasEnterpriseAdminUsers, reaso
   return reasonTypes.hasNoAdmins;
 };
 
-export const isCurrentCoupon = (coupon) => {
-  dayjs.extend(isBetween);
-  return dayjs(Date.now()).isBetween(
-    coupon.startDate,
-    coupon.endDate,
-    'day',
-    '[]',
-  );
-};
+export const isCurrentCoupon = (coupon) => dayjs(Date.now()).isBetween(
+  coupon.startDate,
+  coupon.endDate,
+  'day',
+  '[]',
+);
 
 export const getCouponCodesDisabledEnrollmentReasonType = ({
   catalogsWithCourse,

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -1,11 +1,10 @@
 import React, { useContext } from 'react';
 import Cookies from 'universal-cookie';
-import dayjs from 'dayjs';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
 import { Modal, MailtoLink } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
+import dayjs from '../../utils/dayjs';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 
 import {
@@ -24,7 +23,6 @@ const SubscriptionExpirationModal = () => {
     enterpriseConfig: { uuid: enterpriseId, adminUsers },
     config,
   } = useContext(AppContext);
-  dayjs.extend(advancedFormat);
   const { subscriptionPlan } = useContext(UserSubsidyContext);
   const { daysUntilExpiration, expirationDate, uuid: subscriptionPlanId } = subscriptionPlan;
 

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import Cookies from 'universal-cookie';
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import { Modal, MailtoLink } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
@@ -23,6 +24,7 @@ const SubscriptionExpirationModal = () => {
     enterpriseConfig: { uuid: enterpriseId, adminUsers },
     config,
   } = useContext(AppContext);
+  dayjs.extend(advancedFormat);
   const { subscriptionPlan } = useContext(UserSubsidyContext);
   const { daysUntilExpiration, expirationDate, uuid: subscriptionPlanId } = subscriptionPlan;
 

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import dayjs from 'dayjs';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
 import {
   Dropdown, Badge, IconButton, Icon, Skeleton,
 } from '@edx/paragon';
@@ -12,6 +10,7 @@ import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
 import { MoreVert } from '@edx/paragon/icons';
 
+import dayjs from '../../../../../utils/dayjs';
 import { EmailSettingsModal } from './email-settings';
 import { UnenrollModal } from './unenroll';
 import { COURSE_STATUSES, COURSE_PACING, EXECUTIVE_EDUCATION_COURSE_MODES } from '../../../../../constants';
@@ -326,7 +325,6 @@ class BaseCourseCard extends Component {
   };
 
   renderCourseStartDate = () => {
-    dayjs.extend(advancedFormat);
     const { startDate, mode } = this.props;
     const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
     const formattedStartDate = startDate ? dayjs(startDate).format('MMMM Do, YYYY') : null;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import {
   Dropdown, Badge, IconButton, Icon, Skeleton,
 } from '@edx/paragon';
@@ -325,6 +326,7 @@ class BaseCourseCard extends Component {
   };
 
   renderCourseStartDate = () => {
+    dayjs.extend(advancedFormat);
     const { startDate, mode } = this.props;
     const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
     const formattedStartDate = startDate ? dayjs(startDate).format('MMMM Do, YYYY') : null;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
@@ -1,10 +1,9 @@
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
-import dayjs from 'dayjs';
-import isBetween from 'dayjs/plugin/isBetween';
 import { AppContext } from '@edx/frontend-platform/react';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
+import dayjs from '../../../../../utils/dayjs';
 import BaseCourseCard from './BaseCourseCard';
 import { MarkCompleteModal } from './mark-complete-modal';
 import ContinueLearningButton from './ContinueLearningButton';
@@ -30,8 +29,6 @@ export const InProgressCourseCard = ({
     licenseUpgradeUrl,
     couponUpgradeUrl,
   } = useContext(UpgradeableCourseEnrollmentContext);
-
-  dayjs.extend(isBetween);
 
   // The upgrade button is only for upgrading via coupon, upgrades via license are automatic through the course link.
   const shouldShowUpgradeButton = !!couponUpgradeUrl;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/Notification.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/Notification.jsx
@@ -1,39 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
 
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
+import dayjs from '../../../../../utils/dayjs';
 
-const Notification = props => {
-  dayjs.extend(relativeTime);
-  return (
-    <li>
-      <div className="notification p-2 mb-2 border rounded">
-        <div className="row no-gutters">
-          <div className="col-12">
-            <a
-              href={props.url}
-              onClick={() => sendEnterpriseTrackEvent(
-                props.enterpriseUUID,
-                'edx.ui.enterprise.learner_portal.notification.clicked',
-                { course_run_id: props.courseRunId, name: props.name },
-              )}
-            >
-              {props.name}
-            </a>
-            {' is due '}
-            <span className="font-weight-bold">
-              {dayjs(props.date).fromNow()}
-            </span>
-            {' on '}
-            {dayjs(props.date).format('ddd MMMM D, YYYY')}
-          </div>
+const Notification = props => (
+  <li>
+    <div className="notification p-2 mb-2 border rounded">
+      <div className="row no-gutters">
+        <div className="col-12">
+          <a
+            href={props.url}
+            onClick={() => sendEnterpriseTrackEvent(
+              props.enterpriseUUID,
+              'edx.ui.enterprise.learner_portal.notification.clicked',
+              { course_run_id: props.courseRunId, name: props.name },
+            )}
+          >
+            {props.name}
+          </a>
+          {' is due '}
+          <span className="font-weight-bold">
+            {dayjs(props.date).fromNow()}
+          </span>
+          {' on '}
+          {dayjs(props.date).format('ddd MMMM D, YYYY')}
         </div>
       </div>
-    </li>
-  );
-};
+    </div>
+  </li>
+);
 
 Notification.propTypes = {
   name: PropTypes.string.isRequired,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Skeleton } from '@edx/paragon';
@@ -107,6 +109,7 @@ describe('<BaseCourseCard />', () => {
     });
 
     it('renders with different startDate values', () => {
+      dayjs.extend(advancedFormat);
       const today = new Date().toISOString();
       const yesterday = new Date();
       yesterday.setDate(yesterday.getDate() - 1);
@@ -114,6 +117,7 @@ describe('<BaseCourseCard />', () => {
       tomorrow.setDate(tomorrow.getDate() + 1);
 
       [today, yesterday, tomorrow].forEach(startDate => {
+        const formattedStartDate = dayjs(startDate).format('MMMM Do, YYYY');
         wrapper = mount((
           <AppContext.Provider value={{ enterpriseConfig }}>
             <BaseCourseCard
@@ -134,6 +138,7 @@ describe('<BaseCourseCard />', () => {
 
         const hasCourseStarted = wrapper.instance().renderCourseStartDate();
         expect(hasCourseStarted).toBeTruthy();
+        expect(hasCourseStarted.props.children).toContain(formattedStartDate);
       });
     });
   });

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import dayjs from 'dayjs';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Skeleton } from '@edx/paragon';
 
+import dayjs from '../../../../../../utils/dayjs';
 import BaseCourseCard from '../BaseCourseCard';
 import { CourseEnrollmentsContext } from '../../CourseEnrollmentsContextProvider';
 import { ToastsContext } from '../../../../../Toasts';
@@ -109,7 +108,6 @@ describe('<BaseCourseCard />', () => {
     });
 
     it('renders with different startDate values', () => {
-      dayjs.extend(advancedFormat);
       const today = new Date().toISOString();
       const yesterday = new Date();
       yesterday.setDate(yesterday.getDate() - 1);

--- a/src/components/dashboard/sidebar/SubscriptionSummaryCard.jsx
+++ b/src/components/dashboard/sidebar/SubscriptionSummaryCard.jsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Badge, useToggle } from '@edx/paragon';
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import { WarningFilled } from '@edx/paragon/icons';
 import { SUBSCRIPTION_DAYS_REMAINING_SEVERE, SUBSCRIPTION_EXPIRED } from '../../../config/constants';
 import SidebarCard from './SidebarCard';
@@ -25,6 +26,7 @@ import SubscriptionExpirationWarningModal from '../../program-progress/Subscript
 const SubscriptionSummaryCard = ({
   subscriptionPlan, licenseRequest, className, courseEndDate, programProgressPage,
 }) => {
+  dayjs.extend(advancedFormat);
   const [
     isSubscriptionExpiringWarningModalOpen,
     subscriptionExpiringWarningModalOpen,

--- a/src/components/dashboard/sidebar/SubscriptionSummaryCard.jsx
+++ b/src/components/dashboard/sidebar/SubscriptionSummaryCard.jsx
@@ -1,8 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Badge, useToggle } from '@edx/paragon';
-import dayjs from 'dayjs';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
 import { WarningFilled } from '@edx/paragon/icons';
 import { SUBSCRIPTION_DAYS_REMAINING_SEVERE, SUBSCRIPTION_EXPIRED } from '../../../config/constants';
 import SidebarCard from './SidebarCard';
@@ -22,11 +20,11 @@ import {
   SUBSCRIPTION_WARNING_BADGE_VARIANT,
 } from './data/constants';
 import SubscriptionExpirationWarningModal from '../../program-progress/SubscriptionExpiringWarningModal';
+import dayjs from '../../../utils/dayjs';
 
 const SubscriptionSummaryCard = ({
   subscriptionPlan, licenseRequest, className, courseEndDate, programProgressPage,
 }) => {
-  dayjs.extend(advancedFormat);
   const [
     isSubscriptionExpiringWarningModalOpen,
     subscriptionExpiringWarningModalOpen,

--- a/src/components/dashboard/sidebar/tests/SubscriptionSummaryCard.test.jsx
+++ b/src/components/dashboard/sidebar/tests/SubscriptionSummaryCard.test.jsx
@@ -86,6 +86,7 @@ describe('<SubscriptionSummaryCard />', () => {
     );
     expect(screen.queryByText(SUBSCRIPTION_EXPIRED_BADGE_LABEL)).toBeTruthy();
     expect(screen.queryByText(SUBSCRIPTION_EXPIRED_DATE_PREFIX, { exact: false })).toBeTruthy();
+    expect(screen.queryByText('October 25th, 2021')).toBeTruthy();
     expect(screen.queryByTestId('subscription-status-badge')).toHaveClass(`badge-${SUBSCRIPTION_EXPIRED_BADGE_VARIANT}`);
   });
   test('Expiring soon and modal warning badge is displayed when 60 >= daysUntilExpiration > 0 and programProgressPage=true', () => {

--- a/src/components/pathway-progress/SubscriptionStatusCard.jsx
+++ b/src/components/pathway-progress/SubscriptionStatusCard.jsx
@@ -1,14 +1,12 @@
 import React, { useContext } from 'react';
 import { Card, Badge } from '@edx/paragon';
-import dayjs from 'dayjs';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
 
+import dayjs from '../../utils/dayjs';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import { LICENSE_STATUS } from '../enterprise-user-subsidy/data/constants';
 import { SubsidyRequestsContext, SUBSIDY_TYPE } from '../enterprise-subsidy-requests';
 
 const SubscriptionStatusCard = () => {
-  dayjs.extend(advancedFormat);
   const {
     subscriptionPlan,
     subscriptionLicense: userSubscriptionLicense,

--- a/src/components/pathway-progress/SubscriptionStatusCard.jsx
+++ b/src/components/pathway-progress/SubscriptionStatusCard.jsx
@@ -1,12 +1,14 @@
 import React, { useContext } from 'react';
 import { Card, Badge } from '@edx/paragon';
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import { LICENSE_STATUS } from '../enterprise-user-subsidy/data/constants';
 import { SubsidyRequestsContext, SUBSIDY_TYPE } from '../enterprise-subsidy-requests';
 
 const SubscriptionStatusCard = () => {
+  dayjs.extend(advancedFormat);
   const {
     subscriptionPlan,
     subscriptionLicense: userSubscriptionLicense,

--- a/src/components/program-progress/ProgramProgressCourses.jsx
+++ b/src/components/program-progress/ProgramProgressCourses.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import {
   Form, Col, Row,
 } from '@edx/paragon';
-import dayjs from 'dayjs';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
 import { CheckCircle } from '@edx/paragon/icons';
 import { AppContext } from '@edx/frontend-platform/react';
 
@@ -19,9 +17,9 @@ import {
 } from './data/utils';
 import { NotCurrentlyAvailable } from './data/constants';
 import { linkToCourse } from '../course/data/utils';
+import dayjs from '../../utils/dayjs';
 
 const ProgramProgressCourses = ({ courseData }) => {
-  dayjs.extend(advancedFormat);
   const { enterpriseConfig } = useContext(AppContext);
   const {
     subscriptionPlan,

--- a/src/components/program-progress/ProgramProgressCourses.jsx
+++ b/src/components/program-progress/ProgramProgressCourses.jsx
@@ -4,6 +4,7 @@ import {
   Form, Col, Row,
 } from '@edx/paragon';
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import { CheckCircle } from '@edx/paragon/icons';
 import { AppContext } from '@edx/frontend-platform/react';
 
@@ -20,6 +21,7 @@ import { NotCurrentlyAvailable } from './data/constants';
 import { linkToCourse } from '../course/data/utils';
 
 const ProgramProgressCourses = ({ courseData }) => {
+  dayjs.extend(advancedFormat);
   const { enterpriseConfig } = useContext(AppContext);
   const {
     subscriptionPlan,

--- a/src/components/program-progress/SubscriptionExpiringWarningModal.jsx
+++ b/src/components/program-progress/SubscriptionExpiringWarningModal.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import {
   ActionRow, Button, MailtoLink, StandardModal,
 } from '@edx/paragon';
@@ -13,6 +14,7 @@ const SubscriptionExpirationWarningModal = ({
   isSubscriptionExpiringWarningModalOpen,
   onSubscriptionExpiringWarningModalClose,
 }) => {
+  dayjs.extend(advancedFormat);
   const {
     enterpriseConfig: { name, contactEmail },
   } = useContext(AppContext);

--- a/src/components/program-progress/SubscriptionExpiringWarningModal.jsx
+++ b/src/components/program-progress/SubscriptionExpiringWarningModal.jsx
@@ -1,12 +1,11 @@
 import React, { useContext } from 'react';
-import dayjs from 'dayjs';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
+import PropTypes from 'prop-types';
 import {
   ActionRow, Button, MailtoLink, StandardModal,
 } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 
-import PropTypes from 'prop-types';
+import dayjs from '../../utils/dayjs';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import { SUBSCRIPTION_EXPIRING_MODAL_TITLE } from './data/constants';
 
@@ -14,7 +13,6 @@ const SubscriptionExpirationWarningModal = ({
   isSubscriptionExpiringWarningModalOpen,
   onSubscriptionExpiringWarningModalClose,
 }) => {
-  dayjs.extend(advancedFormat);
   const {
     enterpriseConfig: { name, contactEmail },
   } = useContext(AppContext);

--- a/src/components/program-progress/data/utils.jsx
+++ b/src/components/program-progress/data/utils.jsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 
 import { SUBSIDY_TYPE } from '../../enterprise-subsidy-requests';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
@@ -98,6 +99,7 @@ export function getEnrolledCourseRunDetails(courses) {
 }
 
 export function getNotStartedCourseDetails(courses) {
+  dayjs.extend(advancedFormat);
   const courseWithSingleCourseRun = [];
   const courseWithMultipleCourseRun = [];
   const multipleCourseRuns = [];

--- a/src/components/program-progress/data/utils.jsx
+++ b/src/components/program-progress/data/utils.jsx
@@ -1,6 +1,4 @@
-import dayjs from 'dayjs';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
-
+import dayjs from '../../../utils/dayjs';
 import { SUBSIDY_TYPE } from '../../enterprise-subsidy-requests';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 import { PROGRAM_TYPE_MAP } from '../../program/data/constants';
@@ -99,7 +97,6 @@ export function getEnrolledCourseRunDetails(courses) {
 }
 
 export function getNotStartedCourseDetails(courses) {
-  dayjs.extend(advancedFormat);
   const courseWithSingleCourseRun = [];
   const courseWithMultipleCourseRun = [];
   const multipleCourseRuns = [];

--- a/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
+++ b/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen, render } from '@testing-library/react';
-import dayjs from 'dayjs';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
 
 import { AppContext } from '@edx/frontend-platform/react';
+import dayjs from '../../../utils/dayjs';
 import ProgramProgressCourses from '../ProgramProgressCourses';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { NotCurrentlyAvailable } from '../data/constants';
@@ -57,7 +56,6 @@ const ProgramProgressCoursesWithContext = ({
 );
 
 describe('<ProgramProgressCourses />', () => {
-  dayjs.extend(advancedFormat);
   it('displays the completed course with enrolled course run', () => {
     const courseDataCompletedCourse = {
       inProgress: [],

--- a/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
+++ b/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen, render } from '@testing-library/react';
+import dayjs from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 
 import { AppContext } from '@edx/frontend-platform/react';
-import dayjs from 'dayjs';
 import ProgramProgressCourses from '../ProgramProgressCourses';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { NotCurrentlyAvailable } from '../data/constants';
@@ -56,6 +57,7 @@ const ProgramProgressCoursesWithContext = ({
 );
 
 describe('<ProgramProgressCourses />', () => {
+  dayjs.extend(advancedFormat);
   it('displays the completed course with enrolled course run', () => {
     const courseDataCompletedCourse = {
       inProgress: [],

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1,8 +1,7 @@
-import dayjs from 'dayjs';
-import isBetween from 'dayjs/plugin/isBetween';
 import Cookies from 'universal-cookie';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
+import dayjs from './dayjs';
 
 export const isCourseEnded = endDate => dayjs(endDate) < dayjs();
 
@@ -43,7 +42,6 @@ export const hasTruthyValue = (value) => {
 };
 
 export const hasValidStartExpirationDates = ({ startDate, expirationDate, endDate }) => {
-  dayjs.extend(isBetween);
   const now = dayjs();
   // Subscriptions use "expirationDate" while Codes use "endDate"
   const realEndDate = expirationDate || endDate;

--- a/src/utils/dayjs.js
+++ b/src/utils/dayjs.js
@@ -1,0 +1,11 @@
+import dayjs from 'dayjs';
+
+const advancedFormat = require('dayjs/plugin/advancedFormat');
+const isBetween = require('dayjs/plugin/isBetween');
+const relativeTime = require('dayjs/plugin/relativeTime');
+
+dayjs.extend(advancedFormat);
+dayjs.extend(isBetween);
+dayjs.extend(relativeTime);
+
+export default dayjs;


### PR DESCRIPTION
The dayjs implementation needed an additional plugin in order to format using the format('MMMM Do, YYYY')}. string. The 'o' part after the day stands for ordinal, which formats it like 1**st** or 2**nd**. Without this plugin, there's just a random 'o' in the middle of the date.

https://day.js.org/docs/en/plugin/advanced-format
https://2u-internal.atlassian.net/browse/ENT-7495

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
