### PR TITLE
chore: reverting get smarter learner unenrollment redirect

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -199,7 +199,7 @@ class BaseCourseCard extends Component {
 
   renderUnenrollModal = () => {
     const {
-      canUnenroll, courseRunId, type, mode,
+      canUnenroll, courseRunId, type,
     } = this.props;
     const { modals } = this.state;
 
@@ -214,7 +214,6 @@ class BaseCourseCard extends Component {
         onSuccess={this.handleUnenrollModalOnSuccess}
         isOpen={modals.unenroll.open}
         enrollmentType={camelCase(type)}
-        mode={mode}
       />
     );
   };

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.jsx
@@ -8,8 +8,6 @@ import { logError } from '@edx/frontend-platform/logging';
 import { CourseEnrollmentsContext } from '../../CourseEnrollmentsContextProvider';
 import { ToastsContext } from '../../../../../Toasts';
 import { unenrollFromCourse } from './data';
-import { GETSMARTER_BASE_URL } from '../../data/constants';
-import { EXECUTIVE_EDUCATION_COURSE_MODES } from '../../../../../../constants';
 
 const btnLabels = {
   default: 'Unenroll',
@@ -18,7 +16,6 @@ const btnLabels = {
 
 const UnenrollModal = ({
   courseRunId,
-  mode,
   enrollmentType,
   isOpen,
   onClose,
@@ -38,18 +35,13 @@ const UnenrollModal = ({
 
   const handleUnenrollButtonClick = async () => {
     try {
-      const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
-      if (isExecutiveEducation2UCourse) {
-        window.location.href = `${GETSMARTER_BASE_URL}/cancel-defer`;
-      } else {
-        setBtnState('pending');
-        await unenrollFromCourse({
-          courseId: courseRunId,
-        });
-        removeCourseEnrollment({ courseRunId, enrollmentType });
-        addToast('You have been unenrolled from the course.');
-        onSuccess();
-      }
+      setBtnState('pending');
+      await unenrollFromCourse({
+        courseId: courseRunId,
+      });
+      removeCourseEnrollment({ courseRunId, enrollmentType });
+      addToast('You have been unenrolled from the course.');
+      onSuccess();
     } catch (err) {
       logError(err);
       setError(err);
@@ -104,11 +96,6 @@ UnenrollModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onSuccess: PropTypes.func.isRequired,
-  mode: PropTypes.string,
-};
-
-UnenrollModal.defaultProps = {
-  mode: null,
 };
 
 export default UnenrollModal;


### PR DESCRIPTION
partial revert of https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/783 as EE learner unenrollment has been fully implemented

https://2u-internal.atlassian.net/browse/ENT-7514

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
