### PR TITLE
fix: remove balance remaining for user in legacy learner credit

### DIFF
--- a/src/components/dashboard/sidebar/EnterpriseOffersSummaryCard.jsx
+++ b/src/components/dashboard/sidebar/EnterpriseOffersSummaryCard.jsx
@@ -9,14 +9,16 @@ import {
 } from './data/constants';
 import SidebarCard from './SidebarCard';
 
+function getOfferExpiringFirst(offers) {
+  return offers
+    .filter(offer => offer.isCurrent)
+    .sort((a, b) => new Date(a.endDatetime) - new Date(b.endDatetime))[0];
+}
+
 const EnterpriseOffersSummaryCard = ({
   className, offers, searchCoursesCta,
 }) => {
-  const totalRemainingBalanceForUser = offers.reduce(
-    (accumulator, currentOffer) => accumulator + (currentOffer.remainingBalanceForUser || 0),
-    0,
-  );
-  const offerExpiringFirst = offers.sort((a, b) => new Date(a.endDatetime) - new Date(b.endDatetime))[0];
+  const offerExpiringFirst = getOfferExpiringFirst(offers);
 
   return (
     <SidebarCard
@@ -36,25 +38,14 @@ const EnterpriseOffersSummaryCard = ({
       }
       cardClassNames={className}
     >
-      {totalRemainingBalanceForUser
-        ? (
-          <p data-testid="offer-summary-text-detailed">
-            Apply your <b>${totalRemainingBalanceForUser}</b>{' '}
-            balance to enroll into courses.
-          </p>
-        )
-        : (
-          <p data-testid="offer-summary-text">
-            Apply your organization&apos;s learner credit balance to enroll into courses with no out of pocket cost.
-          </p>
-        )}
-
+      <p data-testid="offer-summary-text">
+        Apply your organization&apos;s learner credit balance to enroll into courses with no out of pocket cost.
+      </p>
       {offerExpiringFirst.endDatetime && (
         <p data-testid="offer-summary-end-date-text">
           Available until <b>{dayjs(offerExpiringFirst.endDatetime).format('MMM D, YYYY')}</b>
         </p>
       )}
-
       {searchCoursesCta && (
         <Row className="mt-3 d-flex justify-content-end">
           <Col xl={12}>{searchCoursesCta}</Col>

--- a/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
+++ b/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
@@ -19,6 +19,12 @@ import CourseEnrollmentsContextProvider from '../../main-content/course-enrollme
 import { SubsidyRequestsContext } from '../../../enterprise-subsidy-requests';
 import { SUBSIDY_REQUEST_STATE, SUBSIDY_TYPE } from '../../../enterprise-subsidy-requests/constants';
 
+const mockEnterpriseOffer = {
+  isCurrent: true,
+  uuid: 'enterprise-offer-id',
+  endDatetime: '2021-10-25',
+};
+
 const DashboardSidebarWithContext = ({
   initialAppState = { fakeContext: 'foo' },
   initialUserSubsidyState = {},
@@ -174,9 +180,7 @@ describe('<DashboardSidebar />', () => {
         initialUserSubsidyState={{
           ...defaultUserSubsidyState,
           customerAgreementConfig: undefined,
-          enterpriseOffers: [{
-            uuid: 'enterprise-offer-id',
-          }],
+          enterpriseOffers: [mockEnterpriseOffer],
           canEnrollWithEnterpriseOffers: true,
         }}
       />,
@@ -189,9 +193,7 @@ describe('<DashboardSidebar />', () => {
         initialAppState={initialAppState}
         initialUserSubsidyState={{
           ...userSubsidyStateWithSubscription,
-          enterpriseOffers: [{
-            uuid: 'enterprise-offer-id',
-          }],
+          enterpriseOffers: [mockEnterpriseOffer],
           canEnrollWithEnterpriseOffers: true,
         }}
       />,
@@ -208,9 +210,7 @@ describe('<DashboardSidebar />', () => {
         initialUserSubsidyState={{
           ...defaultUserSubsidyState,
           couponCodes: { ...defaultUserSubsidyState.couponCodes, couponCodesCount: 2 },
-          enterpriseOffers: [{
-            uuid: 'enterprise-offer-id',
-          }],
+          enterpriseOffers: [mockEnterpriseOffer],
           canEnrollWithEnterpriseOffers: true,
         }}
       />,

--- a/src/components/dashboard/sidebar/tests/EnterpriseOffersSummaryCard.test.jsx
+++ b/src/components/dashboard/sidebar/tests/EnterpriseOffersSummaryCard.test.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen, render } from '@testing-library/react';
+
 import EnterpriseOffersSummaryCard from '../EnterpriseOffersSummaryCard';
 import { ENTERPRISE_OFFER_SUMMARY_CARD_TITLE } from '../data/constants';
 
 const mockEnterpriseOffer = {
+  isCurrent: true,
   uuid: 'test-enterprise-offer-uuid',
   status: 'Open',
   enterpriseCatalogUuid: 'test-enterprise-catalog-uuid',
@@ -13,11 +15,6 @@ const mockEnterpriseOffer = {
   maxDiscount: 5000,
   remainingBalance: 4500,
   remainingBalanceForUser: null,
-};
-
-const mockEnterpriseOfferMaxUserDiscount = {
-  ...mockEnterpriseOffer,
-  remainingBalanceForUser: 200,
 };
 
 describe('<EnterpriseOffersSummaryCard />', () => {
@@ -46,44 +43,25 @@ describe('<EnterpriseOffersSummaryCard />', () => {
     expect(screen.getByTestId('offer-summary-text')).toBeInTheDocument();
   });
 
-  it('should render detailed summary text if remainingBalanceForUser is not null', () => {
-    const offers = [
-      mockEnterpriseOfferMaxUserDiscount,
-      {
-        ...mockEnterpriseOfferMaxUserDiscount,
-        remainingBalanceForUser: 100,
-      },
-    ];
-    render(
-      <EnterpriseOffersSummaryCard
-        offers={offers}
-      />,
-    );
-    // calculate sum of balance available for user across all offers
-    const expectedMaxUserDiscountSum = offers.reduce((acc, offer) => {
-      if (offer.remainingBalanceForUser) {
-        return acc + offer.remainingBalanceForUser;
-      }
-      return acc;
-    }, 0);
-    expect(screen.getByTestId('offer-summary-text-detailed')).toBeInTheDocument();
-    expect(screen.getByText(`$${expectedMaxUserDiscountSum}`)).toBeInTheDocument();
-  });
-
-  it('should render earliest offer end date, if applicable', () => {
+  it('should render earliest, current offer end date, if applicable', () => {
     render(
       <EnterpriseOffersSummaryCard
         offers={[
           mockEnterpriseOffer,
           {
             ...mockEnterpriseOffer,
-            endDatetime: '2022-04-01T00:00:00Z', // earliest start date
+            isCurrent: false,
+            endDatetime: '2022-04-01T00:00:00Z', // earliest, non-current start date
+          },
+          {
+            ...mockEnterpriseOffer,
+            endDatetime: '2023-12-01T00:00:00Z', // earliest, current start date
           },
         ]}
       />,
     );
 
     expect(screen.getByTestId('offer-summary-end-date-text')).toBeInTheDocument();
-    expect(screen.getByText('2022', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('2023', { exact: false })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Changes**

* No longer displays balance remaining for user (there has been consistent user feedback with concerns about showing the amount) on the dashboard subsidies box for legacy Learner Credit.
* Ensures the expiration date shown for legacy Learner Credit takes into account only non-expired (current) enterprise offers.

<img width="381" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/ce0223e3-ebc7-40af-9787-3318a7285043">

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
