### PR TITLE
fix: refactor strawman for resolving redeemable subsidies applicable to course in correct priority order

### DIFF
--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -713,6 +713,7 @@ export const useUserSubsidyApplicableToCourse = ({
           customerAgreementConfig,
           subscriptionLicense,
           containsContentItems,
+          missingSubsidyAccessPolicyReason,
         });
       }
       return {

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -35,6 +35,7 @@ import {
   createEnrollWithCouponCodeUrl,
   createEnrollWithLicenseUrl,
   getCouponCodesDisabledEnrollmentReasonType,
+  getMissingApplicableSubsidyReason,
 } from './utils';
 import {
   COUPON_CODE_SUBSIDY_TYPE,
@@ -663,51 +664,35 @@ export const useUserSubsidyApplicableToCourse = ({
       courseDetails,
     } = courseData;
 
-    let applicableUserSubsidy;
-
-    // if course can be redeemed with a subsidy access policy, return `learnerCredit` subsidy type.
-    if (isPolicyRedemptionEnabled) {
-      // the enterprise-access `can-redeem` API returns `can_redeem: false` when a learner
-      // has already redeemed a course. This means the course page thinks the learner no
-      // longer has any subsidy available to spend. `isPolicyRedemptionEnabled` is true when
-      // `can_redeem: false && has_successful_redemption: true`, so `redeemableSubsidyAccessPolicy` may now be null.
-      applicableUserSubsidy = {
-        discountType: 'percentage',
-        discountValue: 100,
-        subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE,
-        perLearnerEnrollmentLimit: redeemableSubsidyAccessPolicy?.perLearnerEnrollmentLimit,
-        perLearnerSpendLimit: redeemableSubsidyAccessPolicy?.perLearnerSpendLimit,
-        policyRedemptionUrl: redeemableSubsidyAccessPolicy?.policyRedemptionUrl,
-      };
-    }
-
-    // otherwise, fallback to existing legacy subsidies.
-    const retrieveApplicableLegacySubsidy = async () => {
-      // course isn't contained in any catalog(s), so we can assume there is no applicable user subsidy; do nothing
-      if (!containsContentItems) {
-        return undefined;
+    const getSubscriptionLicenseSubsidy = async () => {
+      if (!subscriptionLicense) {
+        return null;
       }
-      let licenseApplicableToCourse;
-      if (subscriptionLicense) {
-        try {
-          // get subscription license with extra information (i.e. discount type, discount value, subsidy checksum)
-          const fetchLicenseSubsidyResponse = await courseService.fetchUserLicenseSubsidy();
-          if (fetchLicenseSubsidyResponse) {
-            licenseApplicableToCourse = camelCaseObject(fetchLicenseSubsidyResponse.data);
-          }
-        } catch (error) {
-          logError(error);
-          if (onSubscriptionLicenseForCourseValidationError) {
-            onSubscriptionLicenseForCourseValidationError(error);
-          }
+      try {
+        // get subscription license with extra information (i.e. discount type, discount value, subsidy checksum)
+        const fetchLicenseSubsidyResponse = await courseService.fetchUserLicenseSubsidy();
+        if (fetchLicenseSubsidyResponse) {
+          return camelCaseObject(fetchLicenseSubsidyResponse.data);
+        }
+      } catch (error) {
+        logError(error);
+        if (onSubscriptionLicenseForCourseValidationError) {
+          onSubscriptionLicenseForCourseValidationError(error);
         }
       }
-      const coursePrice = getCourseRunPrice({
-        courseDetails,
-        firstEnrollablePaidSeatPrice: courseService?.activeCourseRun?.firstEnrollablePaidSeatPrice,
-      });
-      return getSubsidyToApplyForCourse({
+      return null;
+    };
+
+    const coursePrice = getCourseRunPrice({
+      courseDetails,
+      firstEnrollablePaidSeatPrice: courseService?.activeCourseRun?.firstEnrollablePaidSeatPrice,
+    });
+
+    const getApplicableSubsidyForCourse = async () => {
+      const licenseApplicableToCourse = await getSubscriptionLicenseSubsidy();
+      const applicableSubsidy = getSubsidyToApplyForCourse({
         applicableSubscriptionLicense: licenseApplicableToCourse,
+        applicableSubsidyAccessPolicy: { isPolicyRedemptionEnabled, redeemableSubsidyAccessPolicy },
         applicableCouponCode: findCouponCodeForCourse(couponCodes, catalogsWithCourse),
         applicableEnterpriseOffer: findEnterpriseOfferForCourse({
           enterpriseOffers: canEnrollWithEnterpriseOffers ? enterpriseOffers : [],
@@ -715,135 +700,31 @@ export const useUserSubsidyApplicableToCourse = ({
           coursePrice,
         }),
       });
-    };
-
-    const enterpriseAdminUsers = (
-      missingSubsidyAccessPolicyReason?.metadata?.enterpriseAdministrators || fallbackAdminUsers
-    );
-
-    const handleMissingUserSubsidyReason = () => {
-      setUserSubsidyApplicableToCourse(undefined);
-
-      // Prioritize any subsidy access policy reasons for why the subsidy is not redeemable
-      // for the course (i.e., prefer Learner Credit reasons over legacy subsidy reasons for disabled enrollment).
-      if (missingSubsidyAccessPolicyReason) {
-        setMissingUserSubsidyReason({
-          reason: missingSubsidyAccessPolicyReason.reason,
-          userMessage: missingSubsidyAccessPolicyReason.userMessage,
-          actions: getMissingSubsidyReasonActions({
-            reasonType: missingSubsidyAccessPolicyReason.reason,
-            enterpriseAdminUsers,
-          }),
-        });
-      } else if (!applicableUserSubsidy) {
-        // Default disabled enrollment reason, assumes enterprise customer does not have any administrator users.
-        let reasonType = DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY_NO_ADMINS;
-
-        const hasEnterpriseAdminUsers = enterpriseAdminUsers?.length > 0;
-
-        // If there are admin users, change `reasonType` to use the
-        // `DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY` message.
-        if (hasEnterpriseAdminUsers) {
-          reasonType = DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY;
-        }
-
-        const couponCodesDisabledEnrollmentReasonType = getCouponCodesDisabledEnrollmentReasonType({
+      let missingApplicableSubsidyReason;
+      if (!applicableSubsidy) {
+        const enterpriseAdminUsers = (
+          missingSubsidyAccessPolicyReason?.metadata?.enterpriseAdministrators || fallbackAdminUsers
+        );
+        missingApplicableSubsidyReason = getMissingApplicableSubsidyReason({
+          enterpriseAdminUsers,
           catalogsWithCourse,
           couponCodes,
           couponsOverview,
-          hasEnterpriseAdminUsers,
-        });
-        const subscriptionsDisabledEnrollmentReasonType = getSubscriptionDisabledEnrollmentReasonType({
           customerAgreementConfig,
-          catalogsWithCourse,
           subscriptionLicense,
-          hasEnterpriseAdminUsers,
-        });
-
-        /**
-         * Prioritize the following order of disabled enrollment reasons:
-         * 1. Course not in catalog
-         * 2. Subscriptions related disabled enrollment reason
-         * 3. Coupon codes related disabled enrollment reason
-         */
-        if (couponCodesDisabledEnrollmentReasonType) {
-          reasonType = couponCodesDisabledEnrollmentReasonType;
-        }
-        if (subscriptionsDisabledEnrollmentReasonType) {
-          reasonType = subscriptionsDisabledEnrollmentReasonType;
-        }
-        if (!containsContentItems) {
-          reasonType = DISABLED_ENROLL_REASON_TYPES.CONTENT_NOT_IN_CATALOG;
-        }
-
-        setMissingUserSubsidyReason({
-          reason: reasonType,
-          userMessage: DISABLED_ENROLL_USER_MESSAGES[reasonType],
-          actions: getMissingSubsidyReasonActions({
-            reasonType,
-            enterpriseAdminUsers,
-          }),
+          containsContentItems,
         });
       }
+      return {
+        applicableSubsidy,
+        missingApplicableSubsidyReason,
+      };
     };
-    if (applicableUserSubsidy) {
-      setUserSubsidyApplicableToCourse(applicableUserSubsidy);
-      setMissingUserSubsidyReason(undefined);
-    } else {
-      // If have not yet determined whether there is an applicable subsidy access policy, fallback
-      // to checking against legacy subsidies.
-      retrieveApplicableLegacySubsidy().then((legacyUserSubsidyApplicableToCourse) => {
-        if (legacyUserSubsidyApplicableToCourse) {
-          // check for exceeded remaining spend/enrollments and per-learner limits if it's an enterprise offer
-          if (legacyUserSubsidyApplicableToCourse.subsidyType === ENTERPRISE_OFFER_SUBSIDY_TYPE) {
-            const redeemableOffer = determineOfferRedeemability({
-              offer: legacyUserSubsidyApplicableToCourse,
-              coursePrice: courseListPrice,
-            });
-
-            if (redeemableOffer.isRedeemable) {
-              // Redeemable for this course
-              setUserSubsidyApplicableToCourse(legacyUserSubsidyApplicableToCourse);
-              setMissingUserSubsidyReason(undefined);
-            } else {
-              const {
-                hasRemainingApplicationsForUser,
-                hasRemainingBalanceForUser,
-                hasRemainingBalance,
-                isCurrent,
-              } = redeemableOffer.isRedeemableConditions;
-
-              let ineligibleEnterpriseOfferReasonType = null;
-
-              if (!hasRemainingApplicationsForUser) {
-                ineligibleEnterpriseOfferReasonType = DISABLED_ENROLL_REASON_TYPES.LEARNER_MAX_ENROLLMENTS_REACHED;
-              }
-              if (!hasRemainingBalanceForUser) {
-                ineligibleEnterpriseOfferReasonType = DISABLED_ENROLL_REASON_TYPES.LEARNER_MAX_SPEND_REACHED;
-              }
-              if (!hasRemainingBalance) {
-                ineligibleEnterpriseOfferReasonType = DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY;
-              }
-              if (!isCurrent) {
-                ineligibleEnterpriseOfferReasonType = DISABLED_ENROLL_REASON_TYPES.ENTERPRISE_OFFER_EXPIRED;
-              }
-              setMissingUserSubsidyReason({
-                reason: ineligibleEnterpriseOfferReasonType,
-                userMessage: DISABLED_ENROLL_USER_MESSAGES[ineligibleEnterpriseOfferReasonType],
-                actions: getMissingSubsidyReasonActions({
-                  reasonType: ineligibleEnterpriseOfferReasonType,
-                  enterpriseAdminUsers,
-                }),
-              });
-            }
-          } else {
-            setUserSubsidyApplicableToCourse(legacyUserSubsidyApplicableToCourse);
-            setMissingUserSubsidyReason(undefined);
-          }
-        } else {
-          handleMissingUserSubsidyReason();
-        }
-      });
+    const applicableUserSubsidy = getApplicableSubsidyForCourse();
+    if (applicableUserSubsidy.applicableSubsidy) {
+      setUserSubsidyApplicableToCourse(applicableUserSubsidy.applicableSubsidy);
+    } else if (applicableUserSubsidy.missingApplicableSubsidyReason) {
+      setMissingUserSubsidyReason(applicableUserSubsidy.missingApplicableSubsidyReason);
     }
   }, [
     courseService,

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -544,6 +544,10 @@ export const getSubscriptionDisabledEnrollmentReasonType = ({
   return undefined;
 };
 
+export const getEnterpriseOffersDisabledEnrollmentReasonType = ({}) => {
+  // TODO
+};
+
 /**
  * Determines which CTA button, if any, should be displayed for a given
  * missing subsidy reason.
@@ -639,6 +643,7 @@ export const getMissingApplicableSubsidyReason = ({
   customerAgreementConfig,
   subscriptionLicense,
   containsContentItems,
+  missingSubsidyAccessPolicyReason,
 }) => {
   // Default disabled enrollment reason, assumes enterprise customer does not have any administrator users.
   let reasonType = DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY_NO_ADMINS;
@@ -663,13 +668,23 @@ export const getMissingApplicableSubsidyReason = ({
     subscriptionLicense,
     hasEnterpriseAdminUsers,
   });
+  const enterpriseOffersDisabledEnrollmentReasonType = getEnterpriseOffersDisabledEnrollmentReasonType({});
 
   /**
    * Prioritize the following order of disabled enrollment reasons:
    * 1. Course not in catalog
    * 2. Subscriptions related disabled enrollment reason
    * 3. Coupon codes related disabled enrollment reason
+   * 4. Learner Credit related disabled enrollment reason.
+   * 4. Enterprise offers related disabled enrollment reason
    */
+  if (enterpriseOffersDisabledEnrollmentReasonType) {
+    reasonType = enterpriseOffersDisabledEnrollmentReasonType;
+  }
+  if (missingSubsidyAccessPolicyReason) {
+    // learner credit disabled enroll reason returned by API
+    // TODO
+  }
   if (couponCodesDisabledEnrollmentReasonType) {
     reasonType = couponCodesDisabledEnrollmentReasonType;
   }


### PR DESCRIPTION
Attempts to refactor as a way to collect all known subsidies upfront and compare against each other simulatenously. By doing so, I believe we'd be able to remove some conditional logic throughout `useUserSubsidyApplicableToCourse`.

Rubber ducking against https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/817

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
