### PR TITLE
fix: add isLoadingAny to useUserSubsidyApplicableToCourse

### DIFF
--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -188,6 +188,7 @@ const CoursePage = () => {
     userSubsidyApplicableToCourse,
     missingUserSubsidyReason,
   } = useUserSubsidyApplicableToCourse({
+    isLoadingAny,
     courseData,
     redeemableSubsidyAccessPolicy,
     isPolicyRedemptionEnabled,

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -630,6 +630,7 @@ export const useCheckSubsidyAccessPolicyRedeemability = ({
  * @returns A subsidy that may be redeemed for the course.
  */
 export const useUserSubsidyApplicableToCourse = ({
+  isLoadingAny,
   courseData,
   redeemableSubsidyAccessPolicy,
   missingSubsidyAccessPolicyReason,
@@ -649,7 +650,7 @@ export const useUserSubsidyApplicableToCourse = ({
   const [missingUserSubsidyReason, setMissingUserSubsidyReason] = useState();
 
   useEffect(() => {
-    if (!courseData) {
+    if (!courseData || !isLoadingAny) {
       return;
     }
 
@@ -724,14 +725,13 @@ export const useUserSubsidyApplicableToCourse = ({
       const result = await getApplicableSubsidyForCourse();
       if (result.applicableSubsidy) {
         setUserSubsidyApplicableToCourse(result.applicableSubsidy);
-        setMissingUserSubsidyReason(null);
       } else if (result.missingApplicableSubsidyReason) {
         setMissingUserSubsidyReason(result.missingApplicableSubsidyReason);
-        setUserSubsidyApplicableToCourse(null);
       }
     };
     fetchApplicableSubsidy();
   }, [
+    isLoadingAny,
     courseService,
     courseData,
     courseListPrice,

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -724,8 +724,10 @@ export const useUserSubsidyApplicableToCourse = ({
       const result = await getApplicableSubsidyForCourse();
       if (result.applicableSubsidy) {
         setUserSubsidyApplicableToCourse(result.applicableSubsidy);
+        setMissingUserSubsidyReason(null);
       } else if (result.missingApplicableSubsidyReason) {
         setMissingUserSubsidyReason(result.missingApplicableSubsidyReason);
+        setUserSubsidyApplicableToCourse(null);
       }
     };
     fetchApplicableSubsidy();

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -1073,7 +1073,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
       userSubsidyApplicableToCourse: expect.objectContaining({
         subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE,
       }),
-      missingUserSubsidyReason: undefined,
+      missingUserSubsidyReason: null,
     });
   });
 
@@ -1099,7 +1099,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: undefined,
+      userSubsidyApplicableToCourse: null,
       missingUserSubsidyReason: {
         reason: DISABLED_ENROLL_REASON_TYPES.CONTENT_NOT_IN_CATALOG,
         userMessage: DISABLED_ENROLL_USER_MESSAGES[DISABLED_ENROLL_REASON_TYPES.CONTENT_NOT_IN_CATALOG],
@@ -1138,7 +1138,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     }
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: undefined,
+      userSubsidyApplicableToCourse: null,
       missingUserSubsidyReason: {
         reason: expectedReasonType,
         userMessage: DISABLED_ENROLL_USER_MESSAGES[expectedReasonType],
@@ -1162,7 +1162,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: undefined,
+      userSubsidyApplicableToCourse: null,
       missingUserSubsidyReason: expectedTransformedMissingUserSubsidyReason,
     });
   });
@@ -1194,7 +1194,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
       userSubsidyApplicableToCourse: expect.objectContaining({
         subsidyType: LICENSE_SUBSIDY_TYPE,
       }),
-      missingUserSubsidyReason: undefined,
+      missingUserSubsidyReason: null,
     });
   });
 
@@ -1222,7 +1222,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: undefined,
+      userSubsidyApplicableToCourse: null,
       missingUserSubsidyReason: {
         reason: DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_EXPIRED_NO_ADMINS,
         userMessage: REASON_USER_MESSAGES.SUBSCRIPTION_EXPIRED_NO_ADMINS,
@@ -1241,7 +1241,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: undefined,
+      userSubsidyApplicableToCourse: null,
       missingUserSubsidyReason: {
         reason: DISABLED_ENROLL_REASON_TYPES.COUPON_CODE_NOT_ASSIGNED,
         userMessage: REASON_USER_MESSAGES.COUPON_CODE_NOT_ASSIGNED,
@@ -1290,7 +1290,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
       userSubsidyApplicableToCourse: expect.objectContaining({
         subsidyType: COUPON_CODE_SUBSIDY_TYPE,
       }),
-      missingUserSubsidyReason: undefined,
+      missingUserSubsidyReason: null,
     });
   });
 
@@ -1325,7 +1325,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
       userSubsidyApplicableToCourse: expect.objectContaining({
         subsidyType: ENTERPRISE_OFFER_SUBSIDY_TYPE,
       }),
-      missingUserSubsidyReason: undefined,
+      missingUserSubsidyReason: null,
     });
   });
   it('returns offer error', async () => {
@@ -1363,7 +1363,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: undefined,
+      userSubsidyApplicableToCourse: null,
       missingUserSubsidyReason: {
         reason: DISABLED_ENROLL_REASON_TYPES.ENTERPRISE_OFFER_EXPIRED,
         userMessage: DISABLED_ENROLL_USER_MESSAGES[DISABLED_ENROLL_REASON_TYPES.ENTERPRISE_OFFER_EXPIRED],

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -1009,6 +1009,7 @@ describe('useCheckSubsidyAccessPolicyRedeemability', () => {
 describe('useUserSubsidyApplicableToCourse', () => {
   const mockCatalogUUID = 'test-enterprise-catalog-uuid';
   const baseArgs = {
+    isLoadingAny: true,
     isPolicyRedemptionEnabled: false,
     courseService: mockCourseService,
     courseData: {
@@ -1073,7 +1074,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
       userSubsidyApplicableToCourse: expect.objectContaining({
         subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE,
       }),
-      missingUserSubsidyReason: null,
+      missingUserSubsidyReason: undefined,
     });
   });
 
@@ -1099,7 +1100,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: null,
+      userSubsidyApplicableToCourse: undefined,
       missingUserSubsidyReason: {
         reason: DISABLED_ENROLL_REASON_TYPES.CONTENT_NOT_IN_CATALOG,
         userMessage: DISABLED_ENROLL_USER_MESSAGES[DISABLED_ENROLL_REASON_TYPES.CONTENT_NOT_IN_CATALOG],
@@ -1138,7 +1139,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     }
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: null,
+      userSubsidyApplicableToCourse: undefined,
       missingUserSubsidyReason: {
         reason: expectedReasonType,
         userMessage: DISABLED_ENROLL_USER_MESSAGES[expectedReasonType],
@@ -1162,7 +1163,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: null,
+      userSubsidyApplicableToCourse: undefined,
       missingUserSubsidyReason: expectedTransformedMissingUserSubsidyReason,
     });
   });
@@ -1194,7 +1195,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
       userSubsidyApplicableToCourse: expect.objectContaining({
         subsidyType: LICENSE_SUBSIDY_TYPE,
       }),
-      missingUserSubsidyReason: null,
+      missingUserSubsidyReason: undefined,
     });
   });
 
@@ -1222,7 +1223,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: null,
+      userSubsidyApplicableToCourse: undefined,
       missingUserSubsidyReason: {
         reason: DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_EXPIRED_NO_ADMINS,
         userMessage: REASON_USER_MESSAGES.SUBSCRIPTION_EXPIRED_NO_ADMINS,
@@ -1241,7 +1242,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: null,
+      userSubsidyApplicableToCourse: undefined,
       missingUserSubsidyReason: {
         reason: DISABLED_ENROLL_REASON_TYPES.COUPON_CODE_NOT_ASSIGNED,
         userMessage: REASON_USER_MESSAGES.COUPON_CODE_NOT_ASSIGNED,
@@ -1290,7 +1291,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
       userSubsidyApplicableToCourse: expect.objectContaining({
         subsidyType: COUPON_CODE_SUBSIDY_TYPE,
       }),
-      missingUserSubsidyReason: null,
+      missingUserSubsidyReason: undefined,
     });
   });
 
@@ -1325,7 +1326,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
       userSubsidyApplicableToCourse: expect.objectContaining({
         subsidyType: ENTERPRISE_OFFER_SUBSIDY_TYPE,
       }),
-      missingUserSubsidyReason: null,
+      missingUserSubsidyReason: undefined,
     });
   });
   it('returns offer error', async () => {
@@ -1363,7 +1364,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      userSubsidyApplicableToCourse: null,
+      userSubsidyApplicableToCourse: undefined,
       missingUserSubsidyReason: {
         reason: DISABLED_ENROLL_REASON_TYPES.ENTERPRISE_OFFER_EXPIRED,
         userMessage: DISABLED_ENROLL_USER_MESSAGES[DISABLED_ENROLL_REASON_TYPES.ENTERPRISE_OFFER_EXPIRED],

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -707,6 +707,7 @@ export const getMissingApplicableSubsidyReason = ({
   if (enterpriseOffersDisabledEnrollmentReasonType) {
     reasonType = enterpriseOffersDisabledEnrollmentReasonType;
   }
+  console.log('[qa]', 'missingSubsidyAccessPolicyReason', missingSubsidyAccessPolicyReason);
   if (missingSubsidyAccessPolicyReason) {
     reasonType = missingSubsidyAccessPolicyReason.reason;
     userMessage = missingSubsidyAccessPolicyReason.userMessage;

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -707,7 +707,6 @@ export const getMissingApplicableSubsidyReason = ({
   if (enterpriseOffersDisabledEnrollmentReasonType) {
     reasonType = enterpriseOffersDisabledEnrollmentReasonType;
   }
-  console.log('[qa]', 'missingSubsidyAccessPolicyReason', missingSubsidyAccessPolicyReason);
   if (missingSubsidyAccessPolicyReason) {
     reasonType = missingSubsidyAccessPolicyReason.reason;
     userMessage = missingSubsidyAccessPolicyReason.userMessage;


### PR DESCRIPTION
Following the changes for subscription priority in [ENT-7663,](https://2u-internal.atlassian.net/browse/ENT-7663) we need to allow the parent CoursePage to load before rendering the content. 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
