### PR TITLE
fix: remove caching for fetchUserLicenseSubsidy

### DIFF
--- a/src/components/course/data/service.js
+++ b/src/components/course/data/service.js
@@ -161,7 +161,7 @@ export default class CourseService {
     });
 
     const url = `${this.config.LICENSE_MANAGER_URL}/api/v1/license-subsidy/?${queryParams.toString()}`;
-    return this.cachedAuthenticatedHttpClient.get(url).catch(error => {
+    return this.authenticatedHttpClient.get(url).catch(error => {
       const httpErrorStatus = error.customAttributes?.httpErrorStatus;
       if (httpErrorStatus === 404) {
         // 404 means the user's license is not applicable for the course, return undefined instead of throwing an error


### PR DESCRIPTION
Remove the client side caching for `fetchUserLicenseSubsidy` to account for cases where a subscription is revoked and the subsidy should fall back to other types.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
