### PR TITLE
fix: use proper isLoading variable and rely solely on userSubsidyApplicableToCourse throughout

### DIFF
--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -95,7 +95,7 @@ const CoursePage = () => {
     courseRecommendations,
     fetchError: fetchCourseDataError,
     courseReviews,
-    isLoadingCourseData,
+    isLoading: isLoadingCourseData,
   } = useAllCourseData({ courseService, activeCatalogs });
   const isEMETRedemptionEnabled = getConfig().FEATURE_ENABLE_EMET_REDEMPTION || hasFeatureFlagEnabled('ENABLE_EMET_REDEMPTION');
 

--- a/src/components/course/course-header/CourseRunCard.jsx
+++ b/src/components/course/course-header/CourseRunCard.jsx
@@ -12,16 +12,14 @@ import CourseRunCardStatus from './CourseRunCardStatus';
  * React component that displays information about the course run and provides a CTA to allow the learner
  * to enroll in the course run or navigate to courseware.
  */
-const CourseRunCard = ({
-  courseRun,
-  subsidyAccessPolicy,
-}) => {
+const CourseRunCard = ({ courseRun }) => {
   const {
     state: {
       course,
       userEnrollments,
     },
     missingUserSubsidyReason,
+    userSubsidyApplicableToCourse,
     userCanRequestSubsidyForCourse,
   } = useContext(CourseContext);
 
@@ -40,7 +38,7 @@ const CourseRunCard = ({
     userEnrollment: userEnrollmentForCourseRun,
     courseRunUrl: userEnrollmentForCourseRun?.courseRunUrl,
     userCanRequestSubsidyForCourse,
-    subsidyAccessPolicy,
+    subsidyAccessPolicy: userSubsidyApplicableToCourse,
   });
 
   return (
@@ -73,11 +71,6 @@ CourseRunCard.propTypes = {
     pacingType: PropTypes.string,
     enrollmentCount: PropTypes.number,
   }).isRequired,
-  subsidyAccessPolicy: PropTypes.shape(),
-};
-
-CourseRunCard.defaultProps = {
-  subsidyAccessPolicy: undefined,
 };
 
 export default CourseRunCard;

--- a/src/components/course/course-header/tests/CourseRunCard.test.jsx
+++ b/src/components/course/course-header/tests/CourseRunCard.test.jsx
@@ -19,6 +19,8 @@ jest.mock('../data', () => ({
   }),
 }));
 
+const mockUseCourseRunCardData = require('../data').useCourseRunCardData;
+
 const mockCourseRun = {
   key: 'course-v1:edX+DemoX+Demo_Course',
   availability: 'Current',
@@ -51,5 +53,13 @@ describe('<CourseRunCard />', () => {
     expect(screen.getByText('Heading')).toBeInTheDocument();
     expect(screen.getByText('Subheading')).toBeInTheDocument();
     expect(screen.getByText('Action')).toBeInTheDocument();
+
+    expect(mockUseCourseRunCardData).toHaveBeenCalledWith({
+      course: { entitlements: [] },
+      courseRun: mockCourseRun,
+      userEnrollment: undefined,
+      subsidyAccessPolicy: undefined,
+      userCanRequestSubsidyForCourse: undefined,
+    });
   });
 });

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -630,7 +630,6 @@ export const useCheckSubsidyAccessPolicyRedeemability = ({
  * @returns A subsidy that may be redeemed for the course.
  */
 export const useUserSubsidyApplicableToCourse = ({
-  isLoadingAny,
   courseData,
   redeemableSubsidyAccessPolicy,
   missingSubsidyAccessPolicyReason,
@@ -650,7 +649,7 @@ export const useUserSubsidyApplicableToCourse = ({
   const [missingUserSubsidyReason, setMissingUserSubsidyReason] = useState();
 
   useEffect(() => {
-    if (!courseData || !isLoadingAny) {
+    if (!courseData) {
       return;
     }
 
@@ -725,13 +724,14 @@ export const useUserSubsidyApplicableToCourse = ({
       const result = await getApplicableSubsidyForCourse();
       if (result.applicableSubsidy) {
         setUserSubsidyApplicableToCourse(result.applicableSubsidy);
+        setMissingUserSubsidyReason(undefined);
       } else if (result.missingApplicableSubsidyReason) {
         setMissingUserSubsidyReason(result.missingApplicableSubsidyReason);
+        setUserSubsidyApplicableToCourse(undefined);
       }
     };
     fetchApplicableSubsidy();
   }, [
-    isLoadingAny,
     courseService,
     courseData,
     courseListPrice,


### PR DESCRIPTION
# Description

* Exposes proper `isLoading` variable from `useAllCourseData`. Previously, we were never truly working with the legit loading state of all the data returned by `useAllCourseData`...
* Switches `CourseRunCard` component to rely on the `userSubsidyApplicableToCourse` from `CourseContext`, rather than relying on the `subsidyAccessPolicy` derived directly from the API. Rationale: the intent is to rely on a single data structure representing the subsidy applicable to course for the entire course page, rather than relying on disparate data that may be different depending on the component re-rendering lifecycle (i.e.,, enroll button CTA for Learner Credit should rely on same data source as the course sidebar price strikeout).

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
