### PR TITLE
fix: filter out expired offer in search catalogs

### DIFF
--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -22,7 +22,8 @@ export const useSearchCatalogs = ({
       catalogs.push(...couponCodes.map((couponCode) => couponCode.catalog));
     }
     if (features.FEATURE_ENROLL_WITH_ENTERPRISE_OFFERS) {
-      catalogs.push(...enterpriseOffers.map((offer) => offer.enterpriseCatalogUuid));
+      const currentOffers = enterpriseOffers.filter(offer => !!offer.isCurrent);
+      catalogs.push(...currentOffers.map((offer) => offer.enterpriseCatalogUuid));
     }
 
     // Scope to catalogs associated with assignable subsidies if browse and request is turned on

--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -22,7 +22,7 @@ export const useSearchCatalogs = ({
       catalogs.push(...couponCodes.map((couponCode) => couponCode.catalog));
     }
     if (features.FEATURE_ENROLL_WITH_ENTERPRISE_OFFERS) {
-      const currentOffers = enterpriseOffers.filter(offer => !!offer.isCurrent);
+      const currentOffers = enterpriseOffers.filter(offer => offer.isCurrent);
       catalogs.push(...currentOffers.map((offer) => offer.enterpriseCatalogUuid));
     }
 

--- a/src/components/search/data/tests/hooks.test.jsx
+++ b/src/components/search/data/tests/hooks.test.jsx
@@ -74,7 +74,7 @@ describe('useSearchCatalogs', () => {
     expect(result.current).toEqual([]);
   });
 
-  it.only.each([
+  it.each([
     { isExpiredOffer: true },
     { isExpiredOffer: false },
   ])('should include catalogs from enterprise offers if features.FEATURE_ENROLL_WITH_ENTERPRISE_OFFERS = true (%s)', ({

--- a/src/components/search/data/tests/hooks.test.jsx
+++ b/src/components/search/data/tests/hooks.test.jsx
@@ -74,7 +74,12 @@ describe('useSearchCatalogs', () => {
     expect(result.current).toEqual([]);
   });
 
-  it('should include catalogs from enterprise offers if features.FEATURE_ENROLL_WITH_ENTERPRISE_OFFERS = true', () => {
+  it.only.each([
+    { isExpiredOffer: true },
+    { isExpiredOffer: false },
+  ])('should include catalogs from enterprise offers if features.FEATURE_ENROLL_WITH_ENTERPRISE_OFFERS = true (%s)', ({
+    isExpiredOffer,
+  }) => {
     features.FEATURE_ENROLL_WITH_ENTERPRISE_OFFERS = true;
 
     const { result } = renderHook(() => useSearchCatalogs({
@@ -83,10 +88,15 @@ describe('useSearchCatalogs', () => {
       couponCodes: [],
       enterpriseOffers: [{
         enterpriseCatalogUuid: mockEnterpriseOfferCatalog,
+        isCurrent: !isExpiredOffer,
       }],
       catalogsForSubsidyRequests: [],
     }));
-    expect(result.current).toEqual([mockEnterpriseOfferCatalog]);
+    if (isExpiredOffer) {
+      expect(result.current).toEqual([]);
+    } else {
+      expect(result.current).toEqual([mockEnterpriseOfferCatalog]);
+    }
   });
 
   it('should not include catalogs from enterprise offers if features.FEATURE_ENROLL_WITH_ENTERPRISE_OFFERS = false', () => {


### PR DESCRIPTION
Ensure only current (non-expired) enterprise offers are considered in the learner portal search.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
