### PR TITLE
fix: exclude expired subscription plans and coupon codes from search

### DIFF
--- a/src/components/enterprise-user-subsidy/coupons/data/actions.js
+++ b/src/components/enterprise-user-subsidy/coupons/data/actions.js
@@ -8,6 +8,7 @@ import {
 
 import findCouponCodeRedemptionCount from './utils';
 import * as service from './service';
+import { hasValidStartExpirationDates } from '../../../../utils/common';
 
 const fetchCouponCodesRequest = () => ({
   type: FETCH_COUPON_CODES_REQUEST,
@@ -33,7 +34,18 @@ export const fetchCouponCodeAssignments = (queryOptions, dispatch) => {
 
   return service.fetchCouponCodeAssignments(queryOptions)
     .then((response) => {
-      dispatch(fetchCouponCodesSuccess(camelCaseObject(response.data)));
+      const formattedResponse = camelCaseObject(response.data);
+      const transformedResults = formattedResponse.results.map((couponCode) => ({
+        ...couponCode,
+        available: hasValidStartExpirationDates({
+          startDate: couponCode.couponStartDate,
+          endDate: couponCode.couponEndDate,
+        }),
+      }));
+      dispatch(fetchCouponCodesSuccess(camelCaseObject({
+        ...formattedResponse,
+        results: transformedResults,
+      })));
     })
     .catch((error) => {
       dispatch(fetchCouponCodesFailure(error));

--- a/src/components/enterprise-user-subsidy/coupons/data/tests/actions.test.js
+++ b/src/components/enterprise-user-subsidy/coupons/data/tests/actions.test.js
@@ -7,24 +7,57 @@ import {
   fetchCouponCodeAssignments,
 } from '../actions';
 import * as service from '../service';
+import { hasValidStartExpirationDates } from '../../../../../utils/common';
 
 jest.mock('../service');
+jest.mock('../../../../../utils/common', () => ({
+  ...jest.requireActual('../../../../../utils/common'),
+  hasValidStartExpirationDates: jest.fn(),
+}));
 
 describe('fetchCouponCodeAssignments action', () => {
-  it('fetch coupon codes success', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    { couponStartDate: '2020-10-20', couponEndDate: '2021-10-20', expectedAvailability: true },
+    { couponStartDate: '2022-06-12', couponEndDate: '2023-06-12', expectedAvailability: false },
+  ])('fetch coupon codes success (%s)', ({
+    couponStartDate,
+    couponEndDate,
+    expectedAvailability,
+  }) => {
+    hasValidStartExpirationDates.mockReturnValue(expectedAvailability);
     const expectedAction = [
       { type: FETCH_COUPON_CODES_REQUEST },
       {
         type: FETCH_COUPON_CODES_SUCCESS,
         payload: {
-          couponCodes: [{ fooBar: 'foo', redemptionsRemaining: 2 }],
+          couponCodes: [{
+            fooBar: 'foo',
+            redemptionsRemaining: 2,
+            available: expectedAvailability,
+            couponStartDate,
+            couponEndDate,
+          }],
           couponCodesCount: 2,
         },
       },
     ];
 
     service.fetchCouponCodeAssignments.mockImplementation((
-      () => Promise.resolve({ data: { results: [{ foo_bar: 'foo', redemptions_remaining: 2 }], count: 2 } })
+      () => Promise.resolve({
+        data: {
+          results: [{
+            foo_bar: 'foo',
+            redemptions_remaining: 2,
+            coupon_start_date: couponStartDate,
+            coupon_end_date: couponEndDate,
+          }],
+          count: 2,
+        },
+      })
     ));
     const dispatchSpy = jest.fn();
     return fetchCouponCodeAssignments(null, dispatchSpy)

--- a/src/components/enterprise-user-subsidy/data/hooks/useSubscriptions.js
+++ b/src/components/enterprise-user-subsidy/data/hooks/useSubscriptions.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 
 import { useSubscriptionLicense, useCustomerAgreementData } from './hooks';
+import { hasValidStartExpirationDates } from '../../../../utils/common';
 
 /**
  * Given an authenticated user and an enterprise customer config, returns the user's subscription license (if any)
@@ -27,7 +28,15 @@ function useSubscriptions({
 
   useEffect(
     () => {
-      setSubscriptionPlan(subscriptionLicense?.subscriptionPlan);
+      if (subscriptionLicense?.subscriptionPlan) {
+        setSubscriptionPlan({
+          ...subscriptionLicense.subscriptionPlan,
+          isCurrent: hasValidStartExpirationDates({
+            startDate: subscriptionLicense.subscriptionPlan.startDate,
+            expirationDate: subscriptionLicense.subscriptionPlan.expirationDate,
+          }),
+        });
+      }
       setShowExpirationNotifications(!(customerAgreementConfig?.disableExpirationNotifications));
     },
     [subscriptionLicense, customerAgreementConfig],

--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -5,6 +5,11 @@ import {
 import { features } from '../../../config';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 
+/**
+ * Determines the enterprise catalog UUIDs to filter on, if any, based on the subsidies
+ * available to the learner. Enterprise catalogs associated with expired subsidies are
+ * excluded. Ensures no duplicate catalog UUIDs are returned.
+ */
 export const useSearchCatalogs = ({
   subscriptionPlan,
   subscriptionLicense,
@@ -13,23 +18,27 @@ export const useSearchCatalogs = ({
   catalogsForSubsidyRequests,
 }) => {
   const searchCatalogs = useMemo(() => {
-    const catalogs = [];
+    // Track catalog uuids to include in search with a Set to avoid duplicates.
+    const catalogUUIDs = new Set();
+
     // Scope to catalogs from coupons, enterprise offers, or subscription plan associated with learner's license
-    if (subscriptionPlan && subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED) {
-      catalogs.push(subscriptionPlan.enterpriseCatalogUuid);
+    if (subscriptionPlan?.isCurrent && subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED) {
+      catalogUUIDs.add(subscriptionPlan.enterpriseCatalogUuid);
     }
     if (features.ENROLL_WITH_CODES) {
-      catalogs.push(...couponCodes.map((couponCode) => couponCode.catalog));
+      const availableCouponCodes = couponCodes.filter(couponCode => couponCode.available);
+      availableCouponCodes.forEach((couponCode) => catalogUUIDs.add(couponCode.catalog));
     }
     if (features.FEATURE_ENROLL_WITH_ENTERPRISE_OFFERS) {
       const currentOffers = enterpriseOffers.filter(offer => offer.isCurrent);
-      catalogs.push(...currentOffers.map((offer) => offer.enterpriseCatalogUuid));
+      currentOffers.forEach((offer) => catalogUUIDs.add(offer.enterpriseCatalogUuid));
     }
 
     // Scope to catalogs associated with assignable subsidies if browse and request is turned on
-    catalogs.push(...catalogsForSubsidyRequests);
+    catalogsForSubsidyRequests.forEach((catalog) => catalogUUIDs.add(catalog));
 
-    return catalogs;
+    // Convert Set back to array
+    return Array.from(catalogUUIDs);
   }, [
     subscriptionPlan,
     subscriptionLicense,


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-7743

Ensures content contained by catalog uuids associated with expired subscription plans or coupon codes are excluded from search results.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
