### PR TITLE
fix: ensure redeemable subsidy access policies are included in search catalogs

### DIFF
--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -53,6 +53,7 @@ const CoursePage = () => {
     enterpriseOffers,
     canEnrollWithEnterpriseOffers,
     customerAgreementConfig,
+    redeemableLearnerCreditPolicies,
   } = useContext(UserSubsidyContext);
   const { catalogsForSubsidyRequests, subsidyRequestConfiguration } = useContext(SubsidyRequestsContext);
 
@@ -78,6 +79,7 @@ const CoursePage = () => {
     couponCodes,
     enterpriseOffers,
     catalogsForSubsidyRequests,
+    redeemableLearnerCreditPolicies,
   });
 
   // extract search queryId and objectId that led to this course page view from

--- a/src/components/dashboard/sidebar/SubsidiesSummary.jsx
+++ b/src/components/dashboard/sidebar/SubsidiesSummary.jsx
@@ -20,13 +20,6 @@ function getLearnerCreditSummaryCardData({ enterpriseOffers, redeemableLearnerCr
   const learnerCreditPolicyExpiringFirst = getPolicyExpiringFirst(redeemableLearnerCreditPolicies);
   const enterpriseOfferExpiringFirst = getOfferExpiringFirst(enterpriseOffers);
 
-  console.log('ruh roh', {
-    enterpriseOffers,
-    redeemableLearnerCreditPolicies,
-    learnerCreditPolicyExpiringFirst,
-    enterpriseOfferExpiringFirst,
-  });
-
   if (!learnerCreditPolicyExpiringFirst && !enterpriseOfferExpiringFirst) {
     return undefined;
   }
@@ -65,7 +58,6 @@ const SubsidiesSummary = ({
     enterpriseOffers,
     redeemableLearnerCreditPolicies,
   });
-  console.log('learnerCreditSummaryCardData', learnerCreditSummaryCardData);
 
   const {
     requestsBySubsidyType,

--- a/src/components/dashboard/sidebar/SubsidiesSummary.jsx
+++ b/src/components/dashboard/sidebar/SubsidiesSummary.jsx
@@ -17,11 +17,24 @@ import { SubsidyRequestsContext, SUBSIDY_TYPE } from '../../enterprise-subsidy-r
 import { getOfferExpiringFirst, getPolicyExpiringFirst } from './utils';
 
 function getLearnerCreditSummaryCardData({ enterpriseOffers, redeemableLearnerCreditPolicies }) {
-  const enterpriseOfferExpiringFirst = getOfferExpiringFirst(enterpriseOffers);
   const learnerCreditPolicyExpiringFirst = getPolicyExpiringFirst(redeemableLearnerCreditPolicies);
+  const enterpriseOfferExpiringFirst = getOfferExpiringFirst(enterpriseOffers);
+
+  console.log('ruh roh', {
+    enterpriseOffers,
+    redeemableLearnerCreditPolicies,
+    learnerCreditPolicyExpiringFirst,
+    enterpriseOfferExpiringFirst,
+  });
+
+  if (!learnerCreditPolicyExpiringFirst && !enterpriseOfferExpiringFirst) {
+    return undefined;
+  }
+
   return {
-    expirationDate: learnerCreditPolicyExpiringFirst?.subsidyExpirationDate
-        || enterpriseOfferExpiringFirst?.endDatetime,
+    expirationDate: (
+      learnerCreditPolicyExpiringFirst?.subsidyExpirationDate || enterpriseOfferExpiringFirst?.endDatetime
+    ),
   };
 }
 
@@ -52,6 +65,7 @@ const SubsidiesSummary = ({
     enterpriseOffers,
     redeemableLearnerCreditPolicies,
   });
+  console.log('learnerCreditSummaryCardData', learnerCreditSummaryCardData);
 
   const {
     requestsBySubsidyType,

--- a/src/components/dashboard/sidebar/SubsidiesSummary.jsx
+++ b/src/components/dashboard/sidebar/SubsidiesSummary.jsx
@@ -32,7 +32,11 @@ function getLearnerCreditSummaryCardData({ enterpriseOffers, redeemableLearnerCr
 }
 
 const SubsidiesSummary = ({
-  className, showSearchCoursesCta, totalCoursesEligibleForCertificate, courseEndDate, programProgressPage,
+  className,
+  showSearchCoursesCta,
+  totalCoursesEligibleForCertificate,
+  courseEndDate,
+  programProgressPage,
 }) => {
   const {
     enterpriseConfig: {
@@ -78,8 +82,9 @@ const SubsidiesSummary = ({
   const hasAssignedCodesOrCodeRequests = couponCodesCount > 0 || couponCodeRequests.length > 0;
   const hasAvailableLearnerCreditPolicies = redeemableLearnerCreditPolicies?.length > 0;
 
-  const hasAvailableSubsidyOrRequests = hasActiveLicenseOrLicenseRequest
-   || hasAssignedCodesOrCodeRequests || canEnrollWithEnterpriseOffers || hasAvailableLearnerCreditPolicies;
+  const hasAvailableSubsidyOrRequests = (
+    hasActiveLicenseOrLicenseRequest || hasAssignedCodesOrCodeRequests || learnerCreditSummaryCardData
+  );
 
   if (!hasAvailableSubsidyOrRequests) {
     return null;

--- a/src/components/dashboard/sidebar/utils.js
+++ b/src/components/dashboard/sidebar/utils.js
@@ -1,5 +1,11 @@
 export const getOfferExpiringFirst = (offers) => offers?.filter(offer => offer.isCurrent)
   .sort((a, b) => new Date(a.endDatetime) - new Date(b.endDatetime))[0];
 
-export const getPolicyExpiringFirst = (policies) => policies?.filter(policy => policy.active)
-  .sort((a, b) => new Date(a.subsidyExpirationDate) - new Date(b.subsidyExpirationDate))[0];
+export const getPolicyExpiringFirst = (policies) => {
+  if (!policies) {
+    return undefined;
+  }
+  return policies
+    .filter(policy => policy.active)
+    .sort((a, b) => new Date(a.subsidyExpirationDate) - new Date(b.subsidyExpirationDate))[0];
+};

--- a/src/components/dashboard/sidebar/utils.js
+++ b/src/components/dashboard/sidebar/utils.js
@@ -1,5 +1,11 @@
-export const getOfferExpiringFirst = (offers) => offers?.filter(offer => offer.isCurrent)
-  .sort((a, b) => new Date(a.endDatetime) - new Date(b.endDatetime))[0];
+export const getOfferExpiringFirst = (offers) => {
+  if (!offers) {
+    return undefined;
+  }
+  return offers
+    .filter(offer => offer.isCurrent)
+    .sort((a, b) => new Date(a.endDatetime) - new Date(b.endDatetime))[0];
+};
 
 export const getPolicyExpiringFirst = (policies) => {
   if (!policies) {

--- a/src/components/dashboard/sidebar/utils.test.js
+++ b/src/components/dashboard/sidebar/utils.test.js
@@ -1,0 +1,57 @@
+import { getOfferExpiringFirst, getPolicyExpiringFirst } from './utils';
+
+describe('getOfferExpiringFirst', () => {
+  it.each([
+    { offers: undefined },
+    { offers: [] },
+  ])('returns undefined if no offers', ({ offers }) => {
+    expect(getOfferExpiringFirst(offers)).toBeUndefined();
+  });
+
+  it('returns undefined if no current offers', () => {
+    const offers = [{ isCurrent: false }];
+    expect(getOfferExpiringFirst(offers)).toBeUndefined();
+  });
+
+  it('returns current, offer expiring first', () => {
+    const offers = [{
+      endDatetime: '2022-01-01T00:00:00Z',
+      isCurrent: true,
+    }, {
+      endDatetime: '2021-01-01T00:00:00Z',
+      isCurrent: true,
+    }, {
+      endDatetime: '2020-01-01T00:00:00Z',
+      isCurrent: false,
+    }];
+    expect(getOfferExpiringFirst(offers)).toEqual(offers[1]);
+  });
+});
+
+describe('getPolicyExpiringFirst', () => {
+  it.each([
+    { policies: undefined },
+    { policies: [] },
+  ])('returns undefined if no policies', ({ policies }) => {
+    expect(getPolicyExpiringFirst(policies)).toBeUndefined();
+  });
+
+  it('returns undefined if no current policies', () => {
+    const policies = [{ active: false }];
+    expect(getPolicyExpiringFirst(policies)).toBeUndefined();
+  });
+
+  it('returns policy expiring first', () => {
+    const policies = [{
+      subsidyExpirationDate: '2022-01-01T00:00:00Z',
+      active: true,
+    }, {
+      subsidyExpirationDate: '2021-01-01T00:00:00Z',
+      active: true,
+    }, {
+      subsidyExpirationDate: '2020-01-01T00:00:00Z',
+      active: false,
+    }];
+    expect(getPolicyExpiringFirst(policies)).toEqual(policies[1]);
+  });
+});

--- a/src/components/enterprise-user-subsidy/UserSubsidy.jsx
+++ b/src/components/enterprise-user-subsidy/UserSubsidy.jsx
@@ -35,6 +35,8 @@ const UserSubsidy = ({ children }) => {
     isLoading: isLoadingRedeemablePolicies,
   } = useRedeemableLearnerCreditPolicies(enterpriseConfig.uuid, userId);
 
+  console.log('useRedeemableLearnerCreditPolicies', redeemableLearnerCreditPolicies);
+
   // Coupon Codes
   const [couponCodes, isLoadingCouponCodes] = useCouponCodes(enterpriseConfig.uuid);
 

--- a/src/components/enterprise-user-subsidy/UserSubsidy.jsx
+++ b/src/components/enterprise-user-subsidy/UserSubsidy.jsx
@@ -30,12 +30,11 @@ const UserSubsidy = ({ children }) => {
     activateUserLicense,
   } = useSubscriptions({ enterpriseConfig, authenticatedUser });
 
+  // Subsidy Access Policies
   const {
     data: redeemableLearnerCreditPolicies,
     isLoading: isLoadingRedeemablePolicies,
   } = useRedeemableLearnerCreditPolicies(enterpriseConfig.uuid, userId);
-
-  console.log('useRedeemableLearnerCreditPolicies', redeemableLearnerCreditPolicies);
 
   // Coupon Codes
   const [couponCodes, isLoadingCouponCodes] = useCouponCodes(enterpriseConfig.uuid);

--- a/src/components/my-career/SkillsRecommendationCourses.jsx
+++ b/src/components/my-career/SkillsRecommendationCourses.jsx
@@ -16,7 +16,11 @@ import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 const SkillsRecommendationCourses = ({ index, subCategoryName, subCategorySkills }) => {
   const { enterpriseConfig } = useContext(AppContext);
   const {
-    subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes }, enterpriseOffers,
+    subscriptionPlan,
+    subscriptionLicense,
+    couponCodes: { couponCodes },
+    enterpriseOffers,
+    redeemableLearnerCreditPolicies,
   } = useContext(UserSubsidyContext);
   const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
   const history = useHistory();
@@ -27,6 +31,7 @@ const SkillsRecommendationCourses = ({ index, subCategoryName, subCategorySkills
     couponCodes,
     enterpriseOffers,
     catalogsForSubsidyRequests,
+    redeemableLearnerCreditPolicies,
   });
 
   const { filters } = useDefaultSearchFilters({

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -51,6 +51,7 @@ const Search = () => {
     canEnrollWithEnterpriseOffers,
     hasLowEnterpriseOffersBalance,
     hasNoEnterpriseOffersBalance,
+    redeemableLearnerCreditPolicies,
   } = useContext(UserSubsidyContext);
   const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
   const searchCatalogs = useSearchCatalogs({
@@ -59,6 +60,7 @@ const Search = () => {
     couponCodes,
     enterpriseOffers,
     catalogsForSubsidyRequests,
+    redeemableLearnerCreditPolicies,
   });
   const { filters } = useDefaultSearchFilters({
     enterpriseConfig,

--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -16,12 +16,18 @@ export const useSearchCatalogs = ({
   couponCodes,
   enterpriseOffers,
   catalogsForSubsidyRequests,
+  redeemableLearnerCreditPolicies,
 }) => {
   const searchCatalogs = useMemo(() => {
     // Track catalog uuids to include in search with a Set to avoid duplicates.
     const catalogUUIDs = new Set();
 
-    // Scope to catalogs from coupons, enterprise offers, or subscription plan associated with learner's license
+    // Scope to catalogs from redeemable subsidy access policies, coupons,
+    // enterprise offers, or subscription plan associated with learner's license.
+    if (redeemableLearnerCreditPolicies) {
+      const activePolicies = redeemableLearnerCreditPolicies.filter(policy => policy.active);
+      activePolicies.forEach((policy) => catalogUUIDs.add(policy.catalogUuid));
+    }
     if (subscriptionPlan?.isCurrent && subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED) {
       catalogUUIDs.add(subscriptionPlan.enterpriseCatalogUuid);
     }
@@ -40,6 +46,7 @@ export const useSearchCatalogs = ({
     // Convert Set back to array
     return Array.from(catalogUUIDs);
   }, [
+    redeemableLearnerCreditPolicies,
     subscriptionPlan,
     subscriptionLicense,
     couponCodes,
@@ -58,6 +65,7 @@ export const useDefaultSearchFilters = ({
   const showAllRefinement = refinements[SHOW_ALL_NAME];
 
   useEffect(() => {
+    console.log('useDefaultSearchFilters!!!', searchCatalogs);
     // default to showing all catalogs if there are no confined search catalogs
     if (searchCatalogs.length === 0 && !showAllRefinement) {
       dispatch(setRefinementAction(SHOW_ALL_NAME, 1));

--- a/src/components/search/data/hooks.js
+++ b/src/components/search/data/hooks.js
@@ -65,7 +65,6 @@ export const useDefaultSearchFilters = ({
   const showAllRefinement = refinements[SHOW_ALL_NAME];
 
   useEffect(() => {
-    console.log('useDefaultSearchFilters!!!', searchCatalogs);
     // default to showing all catalogs if there are no confined search catalogs
     if (searchCatalogs.length === 0 && !showAllRefinement) {
       dispatch(setRefinementAction(SHOW_ALL_NAME, 1));

--- a/src/components/search/data/tests/hooks.test.jsx
+++ b/src/components/search/data/tests/hooks.test.jsx
@@ -32,6 +32,7 @@ describe('useSearchCatalogs', () => {
   const mockSubscriptionCatalog = 'test-subscription-catalog-uuid';
   const mockCouponCodeCatalog = 'test-coupon-code-catalog-uuid';
   const mockEnterpriseOfferCatalog = 'test-enterprise-offer-catalog-uuid';
+  const mockPolicyCatalog = 'test-policy-catalog-uuid';
 
   it.each([
     { isSubscriptionPlanExpired: true },
@@ -46,6 +47,7 @@ describe('useSearchCatalogs', () => {
       couponCodes: [],
       enterpriseOffers: [],
       catalogsForSubsidyRequests: [],
+      redeemableLearnerCreditPolicies: [],
     }));
     if (isSubscriptionPlanExpired) {
       expect(result.current).toEqual([]);
@@ -71,6 +73,7 @@ describe('useSearchCatalogs', () => {
       }],
       enterpriseOffers: [],
       catalogsForSubsidyRequests: [],
+      redeemableLearnerCreditPolicies: [],
     }));
     if (isCouponExpired) {
       expect(result.current).toEqual([]);
@@ -90,6 +93,7 @@ describe('useSearchCatalogs', () => {
       }],
       enterpriseOffers: [],
       catalogsForSubsidyRequests: [],
+      redeemableLearnerCreditPolicies: [],
     }));
     expect(result.current).toEqual([]);
   });
@@ -111,6 +115,7 @@ describe('useSearchCatalogs', () => {
         isCurrent: !isExpiredOffer,
       }],
       catalogsForSubsidyRequests: [],
+      redeemableLearnerCreditPolicies: [],
     }));
     if (isExpiredOffer) {
       expect(result.current).toEqual([]);
@@ -130,6 +135,7 @@ describe('useSearchCatalogs', () => {
         enterpriseCatalogUuid: mockEnterpriseOfferCatalog,
       }],
       catalogsForSubsidyRequests: [],
+      redeemableLearnerCreditPolicies: [],
     }));
     expect(result.current).toEqual([]);
   });
@@ -143,8 +149,47 @@ describe('useSearchCatalogs', () => {
       couponCodes: [],
       enterpriseOffers: [],
       catalogsForSubsidyRequests,
+      redeemableLearnerCreditPolicies: [],
     }));
     expect(result.current).toEqual(catalogsForSubsidyRequests);
+  });
+
+  it.each([
+    {
+      hasDefinedPolicies: false,
+      isPolicyExpired: false,
+    },
+    {
+      hasDefinedPolicies: true,
+      isPolicyExpired: false,
+    },
+    {
+      hasDefinedPolicies: true,
+      isPolicyExpired: true,
+    },
+  ])('should include catalogs for redeemable subsidy access policies', ({
+    hasDefinedPolicies,
+    isPolicyExpired,
+  }) => {
+    const redeemableLearnerCreditPolicies = hasDefinedPolicies ? [{
+      active: !isPolicyExpired,
+      catalogUuid: mockPolicyCatalog,
+    }] : undefined;
+
+    const { result } = renderHook(() => useSearchCatalogs({
+      subscriptionPlan: undefined,
+      subscriptionLicense: undefined,
+      couponCodes: [],
+      enterpriseOffers: [],
+      catalogsForSubsidyRequests: [],
+      redeemableLearnerCreditPolicies,
+    }));
+
+    if (!hasDefinedPolicies || isPolicyExpired) {
+      expect(result.current).toEqual([]);
+    } else {
+      expect(result.current).toEqual([mockPolicyCatalog]);
+    }
   });
 });
 

--- a/src/components/search/popular-results/PopularResultsIndex.jsx
+++ b/src/components/search/popular-results/PopularResultsIndex.jsx
@@ -13,7 +13,11 @@ import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 const PopularResultsIndex = ({ title, numberResultsToDisplay }) => {
   const { enterpriseConfig } = useContext(AppContext);
   const {
-    subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes }, enterpriseOffers,
+    subscriptionPlan,
+    subscriptionLicense,
+    couponCodes: { couponCodes },
+    enterpriseOffers,
+    redeemableLearnerCreditPolicies,
   } = useContext(UserSubsidyContext);
 
   const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
@@ -23,6 +27,7 @@ const PopularResultsIndex = ({ title, numberResultsToDisplay }) => {
     couponCodes,
     enterpriseOffers,
     catalogsForSubsidyRequests,
+    redeemableLearnerCreditPolicies,
   });
 
   const { filters } = useDefaultSearchFilters({

--- a/src/components/skills-quiz/SearchCourseCard.jsx
+++ b/src/components/skills-quiz/SearchCourseCard.jsx
@@ -20,7 +20,11 @@ import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 const SearchCourseCard = ({ index }) => {
   const { enterpriseConfig } = useContext(AppContext);
   const {
-    subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes }, enterpriseOffers,
+    subscriptionPlan,
+    subscriptionLicense,
+    couponCodes: { couponCodes },
+    enterpriseOffers,
+    redeemableLearnerCreditPolicies,
   } = useContext(UserSubsidyContext);
   const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
 
@@ -30,6 +34,7 @@ const SearchCourseCard = ({ index }) => {
     couponCodes,
     enterpriseOffers,
     catalogsForSubsidyRequests,
+    redeemableLearnerCreditPolicies,
   });
 
   const { filters } = useDefaultSearchFilters({

--- a/src/components/skills-quiz/SearchPathways.jsx
+++ b/src/components/skills-quiz/SearchPathways.jsx
@@ -17,7 +17,11 @@ import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 const SearchPathways = ({ index }) => {
   const { enterpriseConfig } = useContext(AppContext);
   const {
-    subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes }, enterpriseOffers,
+    subscriptionPlan,
+    subscriptionLicense,
+    couponCodes: { couponCodes },
+    enterpriseOffers,
+    redeemableLearnerCreditPolicies,
   } = useContext(UserSubsidyContext);
   const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
 
@@ -27,6 +31,7 @@ const SearchPathways = ({ index }) => {
     couponCodes,
     enterpriseOffers,
     catalogsForSubsidyRequests,
+    redeemableLearnerCreditPolicies,
   });
 
   const { filters } = useDefaultSearchFilters({

--- a/src/components/skills-quiz/SearchProgramCard.jsx
+++ b/src/components/skills-quiz/SearchProgramCard.jsx
@@ -38,7 +38,11 @@ const SearchProgramCard = ({ index }) => {
   const { enterpriseConfig } = useContext(AppContext);
   const { slug, uuid } = enterpriseConfig;
   const {
-    subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes }, enterpriseOffers,
+    subscriptionPlan,
+    subscriptionLicense,
+    couponCodes: { couponCodes },
+    enterpriseOffers,
+    redeemableLearnerCreditPolicies,
   } = useContext(UserSubsidyContext);
   const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
 
@@ -48,6 +52,7 @@ const SearchProgramCard = ({ index }) => {
     couponCodes,
     enterpriseOffers,
     catalogsForSubsidyRequests,
+    redeemableLearnerCreditPolicies,
   });
 
   const { filters } = useDefaultSearchFilters({

--- a/src/components/skills-quiz/SkillsCourses.jsx
+++ b/src/components/skills-quiz/SkillsCourses.jsx
@@ -40,7 +40,11 @@ const SkillsCourses = ({ index }) => {
   const allSkills = useSelectedSkillsAndJobSkills({ getAllSkills: true });
 
   const {
-    subscriptionPlan, subscriptionLicense, couponCodes: { couponCodes }, enterpriseOffers,
+    subscriptionPlan,
+    subscriptionLicense,
+    couponCodes: { couponCodes },
+    enterpriseOffers,
+    redeemableLearnerCreditPolicies,
   } = useContext(UserSubsidyContext);
   const { catalogsForSubsidyRequests } = useContext(SubsidyRequestsContext);
 
@@ -50,6 +54,7 @@ const SkillsCourses = ({ index }) => {
     couponCodes,
     enterpriseOffers,
     catalogsForSubsidyRequests,
+    redeemableLearnerCreditPolicies,
   });
 
   const { filters } = useDefaultSearchFilters({


### PR DESCRIPTION
[ENT-7741](https://2u-internal.atlassian.net/browse/ENT-7741)

> Ensure subsidy access policies are recognized across all usages of `useSearchCatalogs` (e.g., course page recommendations, skills quiz course recommendations, and search page).

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
