### PR TITLE
fix: add default image to SearchProgramCard ImageCap

### DIFF
--- a/src/components/course/CourseRecommendationCard.jsx
+++ b/src/components/course/CourseRecommendationCard.jsx
@@ -1,6 +1,7 @@
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Truncate from 'react-truncate';
+import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { useHistory } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 import { Card } from '@edx/paragon';
@@ -53,7 +54,8 @@ const CourseRecommendationCard = ({ course, isPartnerRecommendation }) => {
       }}
     >
       <Card.ImageCap
-        src={course.cardImageUrl.src}
+        src={course.cardImageUrl.src || cardFallbackImg}
+        fallbackSrc={cardFallbackImg}
         logoSrc={primaryPartnerLogo?.src}
         logoAlt={primaryPartnerLogo?.alt}
       />

--- a/src/components/pathway-progress/PathwayProgressCard.jsx
+++ b/src/components/pathway-progress/PathwayProgressCard.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { Card } from '@edx/paragon';
 import Truncate from 'react-truncate';
 import PropTypes from 'prop-types';
+import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { useHistory } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getProgressFromSteps } from './data/utils';
@@ -21,7 +22,8 @@ const PathwayProgressCard = ({ pathway: { learnerPathwayProgress } }) => {
       onClick={redirectToProgressDetailPage}
     >
       <Card.ImageCap
-        src={learnerPathwayProgress.cardImage}
+        src={learnerPathwayProgress.cardImage || cardFallbackImg}
+        fallbackSrc={cardFallbackImg}
         className="banner-image"
         data-testid="pathway-card-image"
         srcAlt="dug"

--- a/src/components/pathway/SearchPathwayCard.jsx
+++ b/src/components/pathway/SearchPathwayCard.jsx
@@ -1,6 +1,7 @@
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Truncate from 'react-truncate';
+import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { useHistory } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform/config';
@@ -106,7 +107,8 @@ const SearchPathwayCard = ({
       {...rest}
     >
       <Card.ImageCap
-        src={pathway?.cardImageUrl}
+        src={pathway?.cardImageUrl || cardFallbackImg}
+        fallbackSrc={cardFallbackImg}
         alt=""
       />
       <Card.Header

--- a/src/components/program-progress/ProgramListingCard.jsx
+++ b/src/components/program-progress/ProgramListingCard.jsx
@@ -3,6 +3,7 @@ import {
 } from '@edx/paragon';
 import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { useHistory } from 'react-router-dom';
 
 import { AppContext } from '@edx/frontend-platform/react';
@@ -61,7 +62,8 @@ const ProgramListingCard = ({ program }) => {
       onClick={handleCardClick}
     >
       <Card.ImageCap
-        src={getBannerImageURL()}
+        src={getBannerImageURL() || cardFallbackImg}
+        fallbackSrc={cardFallbackImg}
         logoSrc={authoringOrganization?.src}
         logoAlt={authoringOrganization?.alt}
         data-testid="program-banner-image"

--- a/src/components/search/SearchCourseCard.jsx
+++ b/src/components/search/SearchCourseCard.jsx
@@ -1,6 +1,7 @@
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Truncate from 'react-truncate';
+import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { useHistory } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform/config';
@@ -100,7 +101,8 @@ const SearchCourseCard = ({
       {...rest}
     >
       <Card.ImageCap
-        src={course.cardImageUrl || course.originalImageUrl}
+        src={course.cardImageUrl || course.originalImageUrl || cardFallbackImg}
+        fallbackSrc={cardFallbackImg}
         srcAlt=""
         logoSrc={primaryPartnerLogo?.src}
         logoAlt={primaryPartnerLogo?.alt}

--- a/src/components/search/SearchProgramCard.jsx
+++ b/src/components/search/SearchProgramCard.jsx
@@ -1,6 +1,7 @@
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Truncate from 'react-truncate';
+import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { useHistory } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
@@ -79,7 +80,6 @@ const SearchProgramCard = ({ hit, isLoading, ...rest }) => {
   };
 
   const primaryPartnerLogo = getPrimaryPartnerLogo(partnerDetails);
-  const defaultImage = 'https://prod-discovery.edx-cdn.org/media/programs/card_images/2f69f430-7a9a-4100-b349-40d4787c0af2-494a6fcbed02.jpg';
   const { userId } = getAuthenticatedUser();
 
   const handleCardClick = () => {
@@ -104,7 +104,8 @@ const SearchProgramCard = ({ hit, isLoading, ...rest }) => {
       {...rest}
     >
       <Card.ImageCap
-        src={program.cardImageUrl || defaultImage}
+        src={program.cardImageUrl || cardFallbackImg}
+        fallbackSrc={cardFallbackImg}
         alt=""
         logoSrc={primaryPartnerLogo?.src}
         logoAlt={primaryPartnerLogo?.alt}

--- a/src/components/search/SearchProgramCard.jsx
+++ b/src/components/search/SearchProgramCard.jsx
@@ -79,7 +79,7 @@ const SearchProgramCard = ({ hit, isLoading, ...rest }) => {
   };
 
   const primaryPartnerLogo = getPrimaryPartnerLogo(partnerDetails);
-
+  const defaultImage = 'https://prod-discovery.edx-cdn.org/media/programs/card_images/2f69f430-7a9a-4100-b349-40d4787c0af2-494a6fcbed02.jpg';
   const { userId } = getAuthenticatedUser();
 
   const handleCardClick = () => {
@@ -104,7 +104,7 @@ const SearchProgramCard = ({ hit, isLoading, ...rest }) => {
       {...rest}
     >
       <Card.ImageCap
-        src={program.cardImageUrl}
+        src={program.cardImageUrl || defaultImage}
         alt=""
         logoSrc={primaryPartnerLogo?.src}
         logoAlt={primaryPartnerLogo?.alt}

--- a/src/components/skills-quiz/SearchProgramCard.jsx
+++ b/src/components/skills-quiz/SearchProgramCard.jsx
@@ -25,6 +25,7 @@ import { useDefaultSearchFilters, useSearchCatalogs } from '../search/data/hooks
 import { ProgramType } from '../search/SearchProgramCard';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
+import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 
 const linkToProgram = (program, slug, enterpriseUUID, programUuid) => {
   if (!Object.keys(program).length) {
@@ -189,7 +190,8 @@ const SearchProgramCard = ({ index }) => {
               data-testid="search-program-card"
             >
               <Card.ImageCap
-                src={program.cardImageUrl}
+                src={program.cardImageUrl || cardFallbackImg}
+                fallbackSrc={cardFallbackImg}
                 srcAlt=""
                 logoSrc={primaryPartnerLogo?.src}
                 logoAlt={primaryPartnerLogo?.alt}

--- a/src/components/skills-quiz/SearchProgramCard.jsx
+++ b/src/components/skills-quiz/SearchProgramCard.jsx
@@ -14,6 +14,7 @@ import {
 import { Program, ZoomOut } from '@edx/paragon/icons';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
+import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { SkillsContext } from './SkillsContextProvider';
 import { isDefinedAndNotNull, getPrimaryPartnerLogo } from '../../utils/common';
 import { ELLIPSIS_STR } from '../course/data/constants';
@@ -25,7 +26,6 @@ import { useDefaultSearchFilters, useSearchCatalogs } from '../search/data/hooks
 import { ProgramType } from '../search/SearchProgramCard';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
-import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 
 const linkToProgram = (program, slug, enterpriseUUID, programUuid) => {
   if (!Object.keys(program).length) {


### PR DESCRIPTION
When the ImageCap is null, the card component formatting looks like this _(before screenshot):_
![image](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/129111440/f842c0b9-64f8-4bed-bdcb-d371f00e69db)

Setting a default image that is accessible in the front end will provide a fallback for the image, even if it's null _(after screenshot):_

<img width="1468" alt="Screenshot 2023-09-27 at 3 11 00 PM" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/129111440/95bcc71c-e168-49a8-b90d-c8d97efc2424">

I also added the fallback image to other `Card.ImageCap` instances.
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
