### PR TITLE
fix: ensure HighlightedContentCard and skills quiz course cards have fallback card images

### DIFF
--- a/src/components/search/content-highlights/HighlightedContentCard.jsx
+++ b/src/components/search/content-highlights/HighlightedContentCard.jsx
@@ -61,7 +61,7 @@ const HighlightedContentCard = ({
       {...props}
     >
       <Card.ImageCap
-        src={cardImageUrl}
+        src={cardImageUrl || cardImageCapFallbackSrc}
         fallbackSrc={cardImageCapFallbackSrc}
         srcAlt=""
         logoSrc={authoringOrganizations?.logoImageUrl}

--- a/src/components/skills-quiz/CourseCard.jsx
+++ b/src/components/skills-quiz/CourseCard.jsx
@@ -6,6 +6,8 @@ import { AppContext } from '@edx/frontend-platform/react';
 import PropTypes from 'prop-types';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
+import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
+
 import getCommonSkills from './data/utils';
 import { linkToCourse, shortenString } from '../course/data/utils';
 import { ELLIPSIS_STR } from '../course/data/constants';
@@ -55,7 +57,8 @@ const CourseCard = ({
       data-testid="skills-quiz-course-card"
     >
       <Card.ImageCap
-        src={course.cardImageUrl || course.originalImageUrl}
+        src={course.cardImageUrl || course.originalImageUrl || cardFallbackImg}
+        fallbackSrc={cardFallbackImg}
         srcAlt=""
         logoSrc={primaryPartnerLogo?.src}
         logoAlt={primaryPartnerLogo?.alt}


### PR DESCRIPTION
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
