### PR TITLE
Revert "fix: ensure program card images are pulled from consistent source (#836)

### DIFF
--- a/src/components/program-progress/ProgramListingCard.jsx
+++ b/src/components/program-progress/ProgramListingCard.jsx
@@ -1,6 +1,8 @@
-import React, { useContext } from 'react';
+import {
+  breakpoints, Card,
+} from '@edx/paragon';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Card } from '@edx/paragon';
 import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { useHistory } from 'react-router-dom';
 
@@ -12,10 +14,37 @@ import { ProgressCategoryBubbles } from '../progress-category-bubbles';
 
 const ProgramListingCard = ({ program }) => {
   const { enterpriseConfig } = useContext(AppContext);
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
   const history = useHistory();
 
   const handleCardClick = () => {
     history.push(`/${enterpriseConfig.slug}/program/${program.uuid}/progress`);
+  };
+
+  useEffect(() => {
+    const handleWindowResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+
+    window.addEventListener('resize', handleWindowResize);
+
+    return () => {
+      window.removeEventListener('resize', handleWindowResize);
+    };
+  }, []);
+
+  const getBannerImageURL = () => {
+    let imageURL = '';
+    if (windowWidth >= breakpoints.large.minWidth) {
+      imageURL = program.bannerImage.large.url;
+    } else if (windowWidth >= breakpoints.medium.minWidth) {
+      imageURL = program.bannerImage.medium.url;
+    } else if (windowWidth >= breakpoints.small.minWidth) {
+      imageURL = program.bannerImage.small.url;
+    } else {
+      imageURL = program.bannerImage.xSmall.url;
+    }
+    return imageURL;
   };
 
   let authoringOrganization;
@@ -33,24 +62,25 @@ const ProgramListingCard = ({ program }) => {
       onClick={handleCardClick}
     >
       <Card.ImageCap
-        src={program.cardImageUrl || cardFallbackImg}
+        src={getBannerImageURL() || cardFallbackImg}
         fallbackSrc={cardFallbackImg}
         logoSrc={authoringOrganization?.src}
         logoAlt={authoringOrganization?.alt}
         data-testid="program-banner-image"
         className="banner-image"
       />
+
       <Card.Header
         title={(
           <Truncate lines={2} trimWhitespace>
             {program.title}
           </Truncate>
         )}
-        subtitle={program.authoringOrganizations?.length > 0 && (
+        subtitle={program.authoringOrganizations?.length > 0 ? (
           <Truncate lines={2} trimWhitespace>
             {program.authoringOrganizations.map(org => org.key).join(', ')}
           </Truncate>
-        )}
+        ) : undefined}
       />
       <Card.Section>
         <div className="d-flex align-items-center">
@@ -79,12 +109,35 @@ ProgramListingCard.propTypes = {
     uuid: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
-    cardImageUrl: PropTypes.string,
     progress: PropTypes.shape(
       {
         inProgress: PropTypes.number.isRequired,
         completed: PropTypes.number.isRequired,
         notStarted: PropTypes.number.isRequired,
+      },
+    ),
+    bannerImage: PropTypes.shape(
+      {
+        large: PropTypes.shape({
+          url: PropTypes.string.isRequired,
+          height: PropTypes.number.isRequired,
+          width: PropTypes.number.isRequired,
+        }),
+        medium: PropTypes.shape({
+          url: PropTypes.string.isRequired,
+          height: PropTypes.number.isRequired,
+          width: PropTypes.number.isRequired,
+        }),
+        small: PropTypes.shape({
+          url: PropTypes.string.isRequired,
+          height: PropTypes.number.isRequired,
+          width: PropTypes.number.isRequired,
+        }),
+        xSmall: PropTypes.shape({
+          url: PropTypes.string.isRequired,
+          height: PropTypes.number.isRequired,
+          width: PropTypes.number.isRequired,
+        }),
       },
     ),
     authoringOrganizations: PropTypes.arrayOf(PropTypes.shape({

--- a/src/components/program-progress/tests/ProgramListingCard.test.jsx
+++ b/src/components/program-progress/tests/ProgramListingCard.test.jsx
@@ -36,7 +36,28 @@ const dummyProgramData = {
   uuid: 'test-uuid',
   title: 'Test Program Title',
   type: 'MicroMasters',
-  cardImageUrl: 'https://image.url',
+  bannerImage: {
+    large: {
+      url: 'www.example.com/large',
+      height: 123,
+      width: 455,
+    },
+    medium: {
+      url: 'www.example.com/medium',
+      height: 123,
+      width: 455,
+    },
+    small: {
+      url: 'www.example.com/small',
+      height: 123,
+      width: 455,
+    },
+    xSmall: {
+      url: 'www.example.com/xSmall',
+      height: 123,
+      width: 455,
+    },
+  },
   authoringOrganizations: [
     {
       key: 'test-key',


### PR DESCRIPTION
This reverts commit 451b94b85eeef96e7527968ecfe383fab58e71ff.

In a twist of events after QA'ing on stage, I now realize why the `ProgramListingCard` was using the inconsistent `banner_images` data... I didn't realize the data for those cards wasn't coming from discovery's `/programs/{UUID}` API; instead, it's coming from a LMS API (`https://courses.edx.org/api/dashboard/v0/programs/852eac48-b5a9-4849-8490-743f3f2deabf/)`, which does **not** include `card_image_url`...

This previously merged "fix" will essentially never find a `program.cardImageUrl` and always fallback to the textured fallback image (all programs on the dashboard page are currently showing fallback image, as seen below).

![image](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/b9e2930e-6532-4837-9b7b-62a291655e0b)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
