### PR TITLE
fix: first check customer admin contact email 

### DIFF
--- a/src/components/contact-admin-mailto/index.jsx
+++ b/src/components/contact-admin-mailto/index.jsx
@@ -6,14 +6,14 @@ import PropTypes from 'prop-types';
 const ContactAdminMailto = ({
   children,
 }) => {
-  const { enterpriseConfig: { adminUsers } } = useContext(AppContext);
+  const { enterpriseConfig: { adminUsers, contactEmail } } = useContext(AppContext);
   const adminEmails = adminUsers.map(user => user.email);
 
   if (adminEmails.length > 0) {
     return (
       <MailtoLink
         target="_blank"
-        to={adminEmails}
+        to={contactEmail || adminEmails}
       >
         {children}
       </MailtoLink>

--- a/src/components/contact-admin-mailto/index.jsx
+++ b/src/components/contact-admin-mailto/index.jsx
@@ -2,18 +2,18 @@ import React, { useContext } from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { MailtoLink } from '@edx/paragon';
 import PropTypes from 'prop-types';
+import { getContactEmail } from '../../utils/common';
 
 const ContactAdminMailto = ({
   children,
 }) => {
   const { enterpriseConfig: { adminUsers, contactEmail } } = useContext(AppContext);
-  const adminEmails = adminUsers.map(user => user.email);
-
-  if (adminEmails.length > 0) {
+  const email = getContactEmail(contactEmail, adminUsers);
+  if (email) {
     return (
       <MailtoLink
         target="_blank"
-        to={contactEmail || adminEmails}
+        to={email}
       >
         {children}
       </MailtoLink>

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -20,7 +20,7 @@ export const SUBSCRIPTION_EXPIRING_MODAL_TITLE = 'Your subscription is expiring'
 
 const SubscriptionExpirationModal = () => {
   const {
-    enterpriseConfig: { uuid: enterpriseId, adminUsers },
+    enterpriseConfig: { adminUsers, contactEmail, uuid: enterpriseId },
     config,
   } = useContext(AppContext);
   const { subscriptionPlan } = useContext(UserSubsidyContext);
@@ -41,9 +41,11 @@ const SubscriptionExpirationModal = () => {
     const adminEmails = adminUsers.map(user => user.email);
     const contactText = 'contact your learning manager';
 
-    if (adminEmails.length > 0) {
+    if (adminEmails.length > 0 || contactEmail) {
       return (
-        <MailtoLink to={adminEmails} className="font-weight-bold">{contactText}</MailtoLink>
+        <MailtoLink to={contactEmail || adminEmails} className="font-weight-bold">
+          {contactText}
+        </MailtoLink>
       );
     }
     return contactText;

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -14,6 +14,8 @@ import {
   SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX,
 } from '../../config/constants';
 
+import { getContactEmail } from '../../utils/common';
+
 export const MODAL_DIALOG_CLASS_NAME = 'subscription-expiration';
 export const SUBSCRIPTION_EXPIRED_MODAL_TITLE = 'Your subscription has expired';
 export const SUBSCRIPTION_EXPIRING_MODAL_TITLE = 'Your subscription is expiring';
@@ -38,12 +40,11 @@ const SubscriptionExpirationModal = () => {
   };
 
   const renderContactText = () => {
-    const adminEmails = adminUsers.map(user => user.email);
     const contactText = 'contact your learning manager';
-
-    if (adminEmails.length > 0 || contactEmail) {
+    const email = getContactEmail(contactEmail, adminUsers);
+    if (email) {
       return (
-        <MailtoLink to={contactEmail || adminEmails} className="font-weight-bold">
+        <MailtoLink to={email} className="font-weight-bold">
           {contactText}
         </MailtoLink>
       );

--- a/src/components/dashboard/sidebar/SupportInformation.jsx
+++ b/src/components/dashboard/sidebar/SupportInformation.jsx
@@ -6,6 +6,7 @@ import { MailtoLink, Hyperlink } from '@edx/paragon';
 import PropTypes from 'prop-types';
 import { SidebarBlock } from '../../layout';
 import { CONTACT_HELP_EMAIL_MESSAGE, NEED_HELP_BLOCK_TITLE } from './data/constants';
+import { getContactEmail } from '../../../utils/common';
 
 const SupportInformation = ({ className }) => {
   const config = getConfig();
@@ -20,14 +21,10 @@ const SupportInformation = ({ className }) => {
 
   const renderContactHelpText = () => {
     const message = CONTACT_HELP_EMAIL_MESSAGE;
-    const adminEmails = adminUsers.map(user => user.email);
-
-    console.log(adminUsers);
-    console.log('adminEmails: ', adminEmails);
-
-    if (adminEmails.length > 0 || contactEmail) {
+    const email = getContactEmail(contactEmail, adminUsers);
+    if (email) {
       return (
-        <MailtoLink to={contactEmail || adminEmails}>
+        <MailtoLink to={email}>
           {message}
         </MailtoLink>
       );

--- a/src/components/dashboard/sidebar/SupportInformation.jsx
+++ b/src/components/dashboard/sidebar/SupportInformation.jsx
@@ -12,8 +12,9 @@ const SupportInformation = ({ className }) => {
   const {
     enterpriseConfig: {
       adminUsers,
-      enableCareerEngagementNetworkOnLearnerPortal,
       careerEngagementNetworkMessage,
+      contactEmail,
+      enableCareerEngagementNetworkOnLearnerPortal,
     },
   } = useContext(AppContext);
 
@@ -21,9 +22,12 @@ const SupportInformation = ({ className }) => {
     const message = CONTACT_HELP_EMAIL_MESSAGE;
     const adminEmails = adminUsers.map(user => user.email);
 
-    if (adminEmails.length > 0) {
+    console.log(adminUsers);
+    console.log('adminEmails: ', adminEmails);
+
+    if (adminEmails.length > 0 || contactEmail) {
       return (
-        <MailtoLink to={adminEmails}>
+        <MailtoLink to={contactEmail || adminEmails}>
           {message}
         </MailtoLink>
       );

--- a/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
+++ b/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
@@ -294,4 +294,22 @@ describe('<DashboardSidebar />', () => {
     expect(screen.queryByText(NEED_HELP_BLOCK_TITLE)).toBeTruthy();
     expect(screen.queryByText(CONTACT_HELP_EMAIL_MESSAGE)).toBeTruthy();
   });
+  test('Uses contact email first', () => {
+    renderWithRouter(
+      <DashboardSidebarWithContext
+        initialAppState={{ enterpriseConfig: { contactEmail: 'edx@example.com', disableSearch: true, adminUsers: [{ email: 'admin@foo.com' }] } }}
+        initialUserSubsidyState={userSubsidyStateWithSubscription}
+      />,
+    );
+    expect(screen.getByText('contact your organization\'s edX administrator').closest('a')).toHaveAttribute('href', 'mailto:edx@example.com');
+  });
+  test('Falls back on admin emails if contact email is null', () => {
+    renderWithRouter(
+      <DashboardSidebarWithContext
+        initialAppState={{ enterpriseConfig: { contactEmail: null, disableSearch: true, adminUsers: [{ email: 'admin@foo.com' }] } }}
+        initialUserSubsidyState={userSubsidyStateWithSubscription}
+      />,
+    );
+    expect(screen.getByText('contact your organization\'s edX administrator').closest('a')).toHaveAttribute('href', 'mailto:admin@foo.com');
+  });
 });

--- a/src/components/enterprise-user-subsidy/enterprise-offers/EnterpriseOffersBalanceAlert.jsx
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/EnterpriseOffersBalanceAlert.jsx
@@ -15,6 +15,7 @@ import {
   NO_BALANCE_ALERT_TEXT,
   OFFER_BALANCE_CLICK_EVENT,
 } from './data/constants';
+import { getContactEmail } from '../../../utils/common';
 
 const EnterpriseOffersBalanceAlert = ({ hasNoEnterpriseOffersBalance }) => {
   const {
@@ -27,12 +28,11 @@ const EnterpriseOffersBalanceAlert = ({ hasNoEnterpriseOffersBalance }) => {
   const heading = hasNoEnterpriseOffersBalance ? NO_BALANCE_ALERT_HEADING : LOW_BALANCE_ALERT_HEADING;
   const text = hasNoEnterpriseOffersBalance ? NO_BALANCE_ALERT_TEXT : LOW_BALANCE_ALERT_TEXT;
 
-  const adminEmails = adminUsers.map(user => user.email);
-  const hasAdminEmails = adminEmails.length > 0;
+  const email = getContactEmail(contactEmail, adminUsers);
 
-  const actions = hasAdminEmails || contactEmail ? [
+  const actions = email ? [
     <MailtoLink
-      to={contactEmail || adminEmails}
+      to={email}
       target="_blank"
       onClick={() => {
         sendEnterpriseTrackEvent(
@@ -48,7 +48,7 @@ const EnterpriseOffersBalanceAlert = ({ hasNoEnterpriseOffersBalance }) => {
   return (
     <Container size="lg" className="pt-3">
       <Alert
-        className={classNames({ 'balance-alert-with-cta': hasAdminEmails })}
+        className={classNames({ 'balance-alert-with-cta': email })}
         variant={variant}
         icon={icon}
         actions={actions}

--- a/src/components/enterprise-user-subsidy/enterprise-offers/EnterpriseOffersBalanceAlert.jsx
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/EnterpriseOffersBalanceAlert.jsx
@@ -18,7 +18,7 @@ import {
 
 const EnterpriseOffersBalanceAlert = ({ hasNoEnterpriseOffersBalance }) => {
   const {
-    enterpriseConfig: { uuid: enterpriseCustomerUUID, adminUsers },
+    enterpriseConfig: { adminUsers, contactEmail, uuid: enterpriseCustomerUUID },
   } = useContext(AppContext);
 
   const adminText = hasNoEnterpriseOffersBalance ? NO_BALANCE_CONTACT_ADMIN_TEXT : LOW_BALANCE_CONTACT_ADMIN_TEXT;
@@ -30,9 +30,9 @@ const EnterpriseOffersBalanceAlert = ({ hasNoEnterpriseOffersBalance }) => {
   const adminEmails = adminUsers.map(user => user.email);
   const hasAdminEmails = adminEmails.length > 0;
 
-  const actions = hasAdminEmails ? [
+  const actions = hasAdminEmails || contactEmail ? [
     <MailtoLink
-      to={adminEmails}
+      to={contactEmail || adminEmails}
       target="_blank"
       onClick={() => {
         sendEnterpriseTrackEvent(

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -83,3 +83,8 @@ export const getPrimaryPartnerLogo = (partnerDetails) => {
     alt: partnerDetails.primaryPartner.name,
   };
 };
+
+export const getContactEmail = (contactEmail, adminUsers) => {
+  const adminEmails = adminUsers.map(user => user.email);
+  return contactEmail || adminEmails;
+};


### PR DESCRIPTION
Changing the current behavior (just using admin emails) to first check if there is anything in the Customer admin contact email field, and if not fallback to the list of admins on the customer.

https://2u-internal.atlassian.net/browse/ENT-7777

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
