### PR TITLE
fix: refactor EnterprisePage tests and rely on custom ErrorPage component

### DIFF
--- a/src/components/enterprise-page/EnterprisePage.test.jsx
+++ b/src/components/enterprise-page/EnterprisePage.test.jsx
@@ -1,72 +1,99 @@
 import React, { useContext } from 'react';
-import { mount } from 'enzyme';
-import * as auth from '@edx/frontend-platform/auth';
-import { ErrorPage, AppContext } from '@edx/frontend-platform/react';
+import { screen, render, within } from '@testing-library/react';
+import { AppContext } from '@edx/frontend-platform/react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import '@testing-library/jest-dom/extend-expect';
 
 import EnterprisePage from './EnterprisePage';
-import { LoadingSpinner } from '../loading-spinner';
-import NotFoundPage from '../NotFoundPage';
-import * as hooks from './data/hooks';
+import { useEnterpriseCustomerConfig } from './data';
 
+const mockEnterpriseUUID = 'test-enterprise-uuid';
 const mockUser = {
+  roles: [`enterprise_learner:${mockEnterpriseUUID}`],
   profileImage: 'http://fake.image',
 };
-jest.mock('@edx/frontend-platform/auth');
-jest.mock('@edx/frontend-platform/react', () => ({
-  esModule: true,
-  ...jest.requireActual('@edx/frontend-platform/react'),
-  ErrorPage: () => <div data-testid="error-page" />,
-}));
-jest.mock('react-router-dom', () => ({
-  useParams: jest.fn().mockReturnValue({ enterpriseSlug: 'test-enterprise-slug' }),
+
+const defaultAppContextValue = {
+  authenticatedUser: mockUser, // default context value includes already hydrated user metadata
+};
+
+jest.mock('./data', () => ({
+  ...jest.requireActual('./data'),
+  useEnterpriseCustomerConfig: jest.fn().mockReturnValue([
+    { uuid: 'test-enterprise-uuid' },
+    undefined,
+  ]),
 }));
 
-describe('<EnterprisePage />', () => {
+const EnterprisePageWrapper = ({
+  appContextValue = defaultAppContextValue,
+  children,
+}) => (
+  <IntlProvider locale="en">
+    <AppContext.Provider value={appContextValue}>
+      <EnterprisePage>
+        {children || <div className="did-i-render" />}
+      </EnterprisePage>
+    </AppContext.Provider>
+  </IntlProvider>
+);
+
+describe('EnterprisePage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  describe('renders loading state', () => {
-    it('while fetching enterprise config', () => {
-      jest.spyOn(auth, 'getAuthenticatedUser').mockImplementation(() => mockUser);
-      // mock hook as if async call to fetch enterprise config is still resolving
-      jest.spyOn(hooks, 'useEnterpriseCustomerConfig').mockImplementation(() => [undefined, undefined]);
-      const wrapper = mount(<EnterprisePage><div className="did-i-render" /></EnterprisePage>);
-      expect(wrapper.find(LoadingSpinner)).toBeTruthy();
-    });
-    it('while hydrating user metadata', () => {
-      jest.spyOn(auth, 'getAuthenticatedUser').mockImplementation(() => ({}));
-      // mock hook as if async call to fetch enterprise config is fully resolved
-      jest.spyOn(hooks, 'useEnterpriseCustomerConfig').mockImplementation(() => [{}, undefined]);
-      const wrapper = mount(<EnterprisePage><div className="did-i-render" /></EnterprisePage>);
-      expect(wrapper.find(LoadingSpinner)).toBeTruthy();
-    });
+
+  it('renders loading state while fetching enterprise config', () => {
+    useEnterpriseCustomerConfig.mockReturnValue([undefined, undefined]);
+    render(<EnterprisePageWrapper />);
+    const loadingSpinner = within(screen.getByRole('status'));
+    expect(loadingSpinner.getByText('loading organization and user details')).toBeInTheDocument();
   });
+
+  it('renders loading state while hydrating user profile metadata', () => {
+    const appContextValue = {
+      authenticatedUser: {
+        ...mockUser,
+        profileImage: undefined,
+      },
+    };
+    render(<EnterprisePageWrapper appContextValue={appContextValue} />);
+    const loadingSpinner = within(screen.getByRole('status'));
+    expect(loadingSpinner.getByText('loading organization and user details')).toBeInTheDocument();
+  });
+
   it('renders error state when unable to fetch enterprise config', () => {
-    jest.spyOn(auth, 'getAuthenticatedUser').mockImplementation(() => mockUser);
-    // mock hook as if async call to fetch enterprise config is fully resolved
-    jest.spyOn(hooks, 'useEnterpriseCustomerConfig').mockImplementation(() => [null, new Error('test error')]);
-    const wrapper = mount(<EnterprisePage><div className="did-i-render" /></EnterprisePage>);
-    expect(wrapper.find(ErrorPage)).toBeTruthy();
+    const errorMessage = 'test error';
+    useEnterpriseCustomerConfig.mockReturnValue([null, new Error(errorMessage)]);
+    render(<EnterprisePageWrapper />);
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    expect(screen.getByText('Try again', { selector: 'a' })).toBeInTheDocument();
   });
+
   it('renders not found page when no enterprise config is found', () => {
-    jest.spyOn(auth, 'getAuthenticatedUser').mockImplementation(() => mockUser);
-    // mock hook as if async call to fetch enterprise config is fully resolved
-    jest.spyOn(hooks, 'useEnterpriseCustomerConfig').mockImplementation(() => [null, undefined]);
-    const wrapper = mount(<EnterprisePage><div className="did-i-render" /></EnterprisePage>);
-    expect(wrapper.find(NotFoundPage)).toBeTruthy();
+    useEnterpriseCustomerConfig.mockReturnValue([null, undefined]);
+    render(<EnterprisePageWrapper />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('something went wrong', { exact: false })).toBeInTheDocument();
   });
+
   it('populates AppContext with expected values', () => {
-    jest.spyOn(auth, 'getAuthenticatedUser').mockImplementation(() => mockUser);
     const mockEnterpriseConfig = {
       slug: 'test-slug',
     };
-    jest.spyOn(hooks, 'useEnterpriseCustomerConfig').mockImplementation(() => [mockEnterpriseConfig, undefined]);
+    useEnterpriseCustomerConfig.mockReturnValue([mockEnterpriseConfig, undefined]);
     const ChildComponent = () => {
       const contextValue = useContext(AppContext);
-      return <div className="did-i-render" data-contextvalue={contextValue} />;
+      const contextValueAsString = JSON.stringify(contextValue);
+      return <div data-testid="did-i-render" data-contextvalue={contextValueAsString} />;
     };
-    const wrapper = mount(<EnterprisePage><ChildComponent /></EnterprisePage>);
-    const actualContextValue = wrapper.find('.did-i-render').prop('data-contextvalue');
+    render((
+      <EnterprisePageWrapper>
+        <ChildComponent />
+      </EnterprisePageWrapper>
+    ));
+    const child = screen.getByTestId('did-i-render');
+    const actualContextValue = JSON.parse(child.getAttribute('data-contextvalue'));
     expect(actualContextValue).toEqual(
       expect.objectContaining({
         authenticatedUser: mockUser,

--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -99,6 +99,7 @@ export const useEnterpriseCustomerConfig = (enterpriseSlug, useCache = true) => 
       .catch((error) => {
         logError(new Error(`Error occurred while fetching the Enterprise Config: ${error}`));
         setFetchError(error);
+        setEnterpriseConfig(null);
       });
   }, [enterpriseSlug, useCache]);
 

--- a/src/components/enterprise-page/data/index.js
+++ b/src/components/enterprise-page/data/index.js
@@ -1,0 +1,1 @@
+export * from './hooks';


### PR DESCRIPTION
# Description

Follow-up to https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/850 to update the deferred failing tests.

1. Refactors EnterprisePage's tests from Enyzme to React Testing Library.
2. Replaces `ErrorPage` from `@edx/frontend-platform` with the MFE's custom `ErrorPage` component. After refactoring the tests, the error case with the original `ErrorPage` from `@edx/frontend-platform` was throwing an exception where `getLocale` was called before i18n was configured. By using the MFE's custom `ErrorPage` component instead, we avoid the "i18n not configured" JS error. New error page is shown below.

**Current**

<img width="734" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/3b7f9bb7-1b35-422e-8d5b-0419d7b5caf1">

**Updated**

<img width="650" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/d2212c47-86be-4c91-959d-3cfe584de396">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
