### PR TITLE
feat: hide backdoors for search course

### DIFF
--- a/src/components/course/routes/CourseAbout.jsx
+++ b/src/components/course/routes/CourseAbout.jsx
@@ -40,9 +40,10 @@ const CourseAbout = () => {
   );
 
   const featuredHideCourseSearch = features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && hideCourseSearch;
-  if (!isCourseAssigned && !featuredHideCourseSearch) {
+  if (!isCourseAssigned && featuredHideCourseSearch) {
     return <Redirect to={`/${enterpriseConfig.slug}`} />;
   }
+
   return (
     <>
       <CourseHeader />

--- a/src/components/course/routes/CourseAbout.jsx
+++ b/src/components/course/routes/CourseAbout.jsx
@@ -4,16 +4,45 @@ import {
 } from '@edx/paragon';
 
 import { AppContext } from '@edx/frontend-platform/react';
+import { Redirect } from 'react-router-dom';
 import { MainContent, Sidebar } from '../../layout';
 import CourseHeader from '../course-header/CourseHeader';
 import CourseMainContent from '../CourseMainContent';
 import CourseSidebar from '../CourseSidebar';
 import CourseRecommendations from '../CourseRecommendations';
 import { CourseContext } from '../CourseContextProvider';
+import { UserSubsidyContext } from '../../enterprise-user-subsidy';
+import { isDisableCourseSearch } from '../../enterprise-user-subsidy/enterprise-offers/data/utils';
+import { useIsCourseAssigned } from '../data/hooks';
+import { features } from '../../../config';
 
 const CourseAbout = () => {
-  const { canOnlyViewHighlightSets } = useContext(CourseContext);
+  const {
+    canOnlyViewHighlightSets,
+    state: {
+      course,
+    },
+  } = useContext(CourseContext);
   const { enterpriseConfig } = useContext(AppContext);
+  const {
+    redeemableLearnerCreditPolicies,
+    enterpriseOffers,
+    subscriptionPlan,
+    subscriptionLicense,
+  } = useContext(UserSubsidyContext);
+
+  const isCourseAssigned = useIsCourseAssigned(redeemableLearnerCreditPolicies, course?.key);
+  const hideCourseSearch = isDisableCourseSearch(
+    redeemableLearnerCreditPolicies,
+    enterpriseOffers,
+    subscriptionPlan,
+    subscriptionLicense,
+  );
+
+  const featuredHideCourseSearch = features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && hideCourseSearch;
+  if (!isCourseAssigned && !featuredHideCourseSearch) {
+    return <Redirect to={`/${enterpriseConfig.slug}`} />;
+  }
   return (
     <>
       <CourseHeader />
@@ -29,7 +58,8 @@ const CourseAbout = () => {
               </Sidebar>
             )}
           </MediaQuery>
-          {(canOnlyViewHighlightSets === false && !enterpriseConfig.disableSearch) && <CourseRecommendations />}
+          {(canOnlyViewHighlightSets === false
+            && !enterpriseConfig.disableSearch && !featuredHideCourseSearch) && <CourseRecommendations />}
         </Row>
       </Container>
     </>

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
@@ -29,3 +29,9 @@ export const NO_BALANCE_ALERT_TEXT = 'Your learner credit balance has run out, a
 export const NO_BALANCE_CONTACT_ADMIN_TEXT = 'Contact administrator';
 
 export const OFFER_BALANCE_CLICK_EVENT = 'edx.ui.enterprise.learner_portal.offer_balance_alert.clicked';
+
+export const ASSIGNMENT_TYPES = {
+  ACCEPTED: 'accepted',
+  ALLOCATED: 'allocated',
+  CANCELLED: 'cancelled',
+};

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/utils.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/utils.js
@@ -130,7 +130,7 @@ export const isDisableCourseSearch = (
     return false;
   }
 
-  const activeOffers = enterpriseOffers?.filter(item => item?.isCurrent === true);
+  const activeOffers = enterpriseOffers?.filter(item => item?.isCurrent);
   const hasActiveSubPlan = subscriptionPlan?.isActive && subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED;
 
   return (activeOffers?.length === 1 && !hasActiveSubPlan) || (activeOffers?.length === 0 && hasActiveSubPlan);

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/utils.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/utils.js
@@ -1,11 +1,14 @@
 import isNil from 'lodash.isnil';
 import {
+  ASSIGNMENT_TYPES,
   ENTERPRISE_OFFER_LOW_BALANCE_THRESHOLD_RATIO,
   ENTERPRISE_OFFER_LOW_BALANCE_USER_THRESHOLD_DOLLARS,
   ENTERPRISE_OFFER_NO_BALANCE_THRESHOLD_DOLLARS,
   ENTERPRISE_OFFER_NO_BALANCE_USER_THRESHOLD_DOLLARS,
   ENTERPRISE_OFFER_TYPE,
 } from './constants';
+
+import { LICENSE_STATUS } from '../../data/constants';
 
 export const offerHasBookingsLimit = offer => (
   !isNil(offer.maxDiscount) || !isNil(offer.maxUserDiscount)
@@ -98,4 +101,37 @@ export const transformEnterpriseOffer = (offer) => {
     isLowOnBalance: isOfferLowOnBalance(transformedOffer),
     isOutOfBalance: isOfferOutOfBalance(transformedOffer),
   };
+};
+
+/**
+ * Determines whether course search should be disabled based on the provided criteria.
+ * Criteria:
+ * -> Is assigned a course,
+ * -> And has no other subsidy,If they had a subscription,
+ *    but the license is no longer relevant, we would not want to count that.
+ * @param {Array} redeemableLearnerCreditPolicies - Array of redeemable learner credit policies.
+ * @param {Array} enterpriseOffers - Array of enterprise offers.
+ * @param {Object} subscriptionPlan - Subscription plan object.
+ * @param {Object} subscriptionLicense - Subscription license object.
+ *
+ * @returns {boolean} Returns true if course search should be disabled, otherwise false.
+ */
+export const isDisableCourseSearch = (
+  redeemableLearnerCreditPolicies,
+  enterpriseOffers,
+  subscriptionPlan,
+  subscriptionLicense,
+) => {
+  const assignments = redeemableLearnerCreditPolicies?.flatMap(item => item?.learnerContentAssignments || []);
+  const allocatedAndAcceptedAssignments = assignments?.filter(item => item?.state === ASSIGNMENT_TYPES.ALLOCATED
+    || item?.state === ASSIGNMENT_TYPES.ACCEPTED);
+
+  if (allocatedAndAcceptedAssignments?.length === 0) {
+    return false;
+  }
+
+  const activeOffers = enterpriseOffers?.filter(item => item?.isCurrent === true);
+  const hasActiveSubPlan = subscriptionPlan?.isActive && subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED;
+
+  return (activeOffers?.length === 1 && !hasActiveSubPlan) || (activeOffers?.length === 0 && hasActiveSubPlan);
 };

--- a/src/components/my-career/CategoryCard.jsx
+++ b/src/components/my-career/CategoryCard.jsx
@@ -13,6 +13,9 @@ import algoliasearch from 'algoliasearch/lite';
 import { AppContext } from '@edx/frontend-platform/react';
 import LevelBars from './LevelBars';
 import SkillsRecommendationCourses from './SkillsRecommendationCourses';
+import { UserSubsidyContext } from '../enterprise-user-subsidy';
+import { isDisableCourseSearch } from '../enterprise-user-subsidy/enterprise-offers/data/utils';
+import { features } from '../../config';
 
 const CategoryCard = ({ topCategory }) => {
   const { skillsSubcategories } = topCategory;
@@ -23,6 +26,20 @@ const CategoryCard = ({ topCategory }) => {
   const [showSkills, setShowSkillsOn, , toggleShowSkills] = useToggle(false);
   const [showAll, setShowAllOn, setShowAllOff, toggleShowAll] = useToggle(false);
   const [showLess, , setShowLessOff, toggleShowLess] = useToggle(false);
+  const {
+    redeemableLearnerCreditPolicies,
+    enterpriseOffers,
+    subscriptionPlan,
+    subscriptionLicense,
+  } = useContext(UserSubsidyContext);
+  const hideCourseSearch = isDisableCourseSearch(
+    redeemableLearnerCreditPolicies,
+    enterpriseOffers,
+    subscriptionPlan,
+    subscriptionLicense,
+  );
+
+  const featuredHideCourseSearch = features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && hideCourseSearch;
 
   const config = getConfig();
   const { enterpriseConfig } = useContext(AppContext);
@@ -152,7 +169,7 @@ const CategoryCard = ({ topCategory }) => {
           }
         </Button>
       )}
-      {!enterpriseConfig.disableSearch && (
+      {(!enterpriseConfig.disableSearch && !featuredHideCourseSearch) && (
         <Card.Section>
           {showSkills && subcategorySkills && (
             <div className="skill-details-recommended-courses">


### PR DESCRIPTION
**Description**
When a learner 
- Is assigned a course,
- And has no other subsidy, If they had a subscription, but the license is no longer relevant, we would not want to count that.

we disabled the course search for them.

There are “backdoors” that I have covered in this PR – 

- Course recommendations on the course page.
- My Career Chart recommendations.
- Someone sending a link to another learner of the course page.

JIRA -> [ENT-7854](https://2u-internal.atlassian.net/browse/ENT-7854)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
