### PR TITLE
fix: assigned courses count badge

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
@@ -36,7 +36,7 @@ class CourseSection extends React.Component {
   getCoursesCount = (isOpen, title, coursesCount) => {
     if (!isOpen) {
       if (title === 'Assigned Courses') {
-        return <sup><Badge pill variant="danger">{coursesCount}</Badge></sup>;
+        return <sup><Badge variant="danger" className="rounded-circle">{coursesCount}</Badge></sup>;
       }
       return `(${coursesCount})`;
     }


### PR DESCRIPTION
**Description**
Fix the badge design of the assigned courses count. Previously it was not showing rounded.

Previously:
![image](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/86868918/7b3bbd2a-6f45-4a36-ba0a-23901fdea182)
Now:
<img width="865" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/86868918/c1655a4d-3c02-4bcf-802b-83305cab7f40">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
