### PR TITLE
feat: modifies logic for setting cookies on dashboard page load

### DIFF
--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -15,10 +15,7 @@ import { MyCareerTab } from '../my-career';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import { IntegrationWarningModal } from '../integration-warning-modal';
 import SubscriptionExpirationModal from './SubscriptionExpirationModal';
-import { ASSIGNMENT_TYPES } from './main-content/course-enrollments/CourseEnrollments';
-import EnterpriseLearnerFirstVisitRedirect, {
-  isFirstDashboardPageVisit,
-} from '../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect';
+import EnterpriseLearnerFirstVisitRedirect from '../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect';
 
 const DashboardPage = () => {
   const { state } = useLocation();
@@ -28,7 +25,6 @@ const DashboardPage = () => {
   const {
     subscriptionPlan,
     showExpirationNotifications,
-    redeemableLearnerCreditPolicies,
   } = useContext(UserSubsidyContext);
   // TODO: Create a context provider containing these 2 data fetch hooks to future proof when we need to use this data
   const [learnerProgramsListData, programsFetchError] = useLearnerProgramsListData(enterpriseConfig.uuid);
@@ -38,17 +34,6 @@ const DashboardPage = () => {
       canOnlyViewHighlightSets,
     },
   } = useEnterpriseCuration(enterpriseConfig.uuid);
-
-  const hasActiveCourseAssignments = (learnerCreditPolicies) => {
-    const learnerContentAssignmentsArray = learnerCreditPolicies?.flatMap(
-      item => item?.learnerContentAssignments || [],
-    );
-    // filters out course assignments that are not considered active
-    const hasActiveAssignments = learnerContentAssignmentsArray.filter(
-      assignment => assignment.state !== ASSIGNMENT_TYPES.cancelled,
-    );
-    return hasActiveAssignments.length > 0;
-  };
 
   const onSelectHandler = (key) => {
     if (key === 'my-career') {
@@ -99,10 +84,6 @@ const DashboardPage = () => {
     ),
   ];
 
-  if (!hasActiveCourseAssignments(redeemableLearnerCreditPolicies) && isFirstDashboardPageVisit()) {
-    return <EnterpriseLearnerFirstVisitRedirect />;
-  }
-
   return (
     <>
       <Helmet title={PAGE_TITLE} />
@@ -110,6 +91,7 @@ const DashboardPage = () => {
         <h2 className="h1 mb-4 mt-4">
           {userFirstName ? `Welcome, ${userFirstName}!` : 'Welcome!'}
         </h2>
+        <EnterpriseLearnerFirstVisitRedirect />
         <Tabs defaultActiveKey="courses" onSelect={(k) => onSelectHandler(k)}>{allTabs.filter(tab => tab)}</Tabs>
         {enterpriseConfig.showIntegrationWarning && <IntegrationWarningModal isOpen />}
         {subscriptionPlan && showExpirationNotifications && <SubscriptionExpirationModal />}

--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -1,13 +1,7 @@
-import React, {
-  useContext, useEffect, useMemo,
-} from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import { Helmet } from 'react-helmet';
 import { useHistory, useLocation } from 'react-router-dom';
-import {
-  Container,
-  Tabs,
-  Tab,
-} from '@edx/paragon';
+import { Container, Tab, Tabs } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { ProgramListingPage } from '../program-progress';
@@ -18,7 +12,6 @@ import { useLearnerProgramsListData } from '../program-progress/data/hooks';
 import { useInProgressPathwaysData } from '../pathway-progress/data/hooks';
 import CoursesTabComponent from './main-content/CoursesTabComponent';
 import { MyCareerTab } from '../my-career';
-import EnterpriseLearnerFirstVisitRedirect from '../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import { IntegrationWarningModal } from '../integration-warning-modal';
 import SubscriptionExpirationModal from './SubscriptionExpirationModal';
@@ -37,7 +30,6 @@ const DashboardPage = () => {
       canOnlyViewHighlightSets,
     },
   } = useEnterpriseCuration(enterpriseConfig.uuid);
-
   const onSelectHandler = (key) => {
     if (key === 'my-career') {
       sendEnterpriseTrackEvent(
@@ -94,7 +86,6 @@ const DashboardPage = () => {
         <h2 className="h1 mb-4 mt-4">
           {userFirstName ? `Welcome, ${userFirstName}!` : 'Welcome!'}
         </h2>
-        <EnterpriseLearnerFirstVisitRedirect />
         <Tabs defaultActiveKey="courses" onSelect={(k) => onSelectHandler(k)}>{allTabs.filter(tab => tab)}</Tabs>
         {enterpriseConfig.showIntegrationWarning && <IntegrationWarningModal isOpen />}
         {subscriptionPlan && showExpirationNotifications && <SubscriptionExpirationModal />}

--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -43,7 +43,7 @@ const DashboardPage = () => {
     const learnerContentAssignmentsArray = learnerCreditPolicies?.flatMap(
       item => item?.learnerContentAssignments || [],
     );
-    // looks for some course assignments that are either 'allocated' or 'accepted'
+    // filters out course assignments that are not considered active
     const hasActiveAssignments = learnerContentAssignmentsArray.filter(
       assignment => assignment.state !== ASSIGNMENT_TYPES.cancelled,
     );

--- a/src/components/dashboard/data/utils.js
+++ b/src/components/dashboard/data/utils.js
@@ -6,8 +6,8 @@ import { ASSIGNMENT_TYPES } from '../../enterprise-user-subsidy/enterprise-offer
  * @param assignments - flatMap'ed object from redeemableLearnerCreditPolicies for learnerContentAssignments
  * @returns {{hasActiveAssignments: boolean, activeAssignments: Array}}
  */
-export default function getActiveAssignments(assignments) {
-  const activeAssignments = assignments?.filter((assignment) => [
+export default function getActiveAssignments(assignments = []) {
+  const activeAssignments = assignments.filter((assignment) => [
     ASSIGNMENT_TYPES.CANCELLED, ASSIGNMENT_TYPES.ALLOCATED,
   ].includes(assignment.state));
   const hasActiveAssignments = activeAssignments.length > 0;

--- a/src/components/dashboard/data/utils.js
+++ b/src/components/dashboard/data/utils.js
@@ -1,11 +1,17 @@
 import { ASSIGNMENT_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
 
+/**
+ * Takes the flattened array from redeemableLearnerCreditPolicies and returns the options of
+ * the array of filteredActiveAssignments, along with a method to return the boolean value
+ * @param assignments - flatMap'ed object from redeemableLearnerCreditPolicies for learnerContentAssignments
+ * @returns {{isActiveAssignments: (function(): boolean), filteredActiveAssignments: *}}
+ */
 export default function getActiveAssignments(assignments) {
-  const filteredAssignments = assignments?.filter((assignment) => assignment?.state === ASSIGNMENT_TYPES.ALLOCATED
+  const filteredActiveAssignments = assignments?.filter((assignment) => assignment?.state === ASSIGNMENT_TYPES.ALLOCATED
       || assignment?.state === ASSIGNMENT_TYPES.CANCELLED);
-  const isActiveAssignments = () => filteredAssignments.length > 0;
+  const isActiveAssignments = () => filteredActiveAssignments.length > 0;
   return {
-    filteredAssignments,
+    filteredActiveAssignments,
     isActiveAssignments,
   };
 }

--- a/src/components/dashboard/data/utils.js
+++ b/src/components/dashboard/data/utils.js
@@ -1,0 +1,11 @@
+import { ASSIGNMENT_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
+
+export default function getActiveAssignments(assignments) {
+  const filteredAssignments = assignments?.filter((assignment) => assignment?.state === ASSIGNMENT_TYPES.ALLOCATED
+      || assignment?.state === ASSIGNMENT_TYPES.CANCELLED);
+  const isActiveAssignments = () => filteredAssignments.length > 0;
+  return {
+    filteredAssignments,
+    isActiveAssignments,
+  };
+}

--- a/src/components/dashboard/data/utils.js
+++ b/src/components/dashboard/data/utils.js
@@ -2,16 +2,17 @@ import { ASSIGNMENT_TYPES } from '../../enterprise-user-subsidy/enterprise-offer
 
 /**
  * Takes the flattened array from redeemableLearnerCreditPolicies and returns the options of
- * the array of filteredActiveAssignments, along with a method to return the boolean value
+ * the array of activeAssignments, or hasActiveAssignments which returns a boolean value
  * @param assignments - flatMap'ed object from redeemableLearnerCreditPolicies for learnerContentAssignments
- * @returns {{isActiveAssignments: (function(): boolean), filteredActiveAssignments: *}}
+ * @returns {{hasActiveAssignments: boolean, activeAssignments: Array}}
  */
 export default function getActiveAssignments(assignments) {
-  const filteredActiveAssignments = assignments?.filter((assignment) => assignment?.state === ASSIGNMENT_TYPES.ALLOCATED
-      || assignment?.state === ASSIGNMENT_TYPES.CANCELLED);
-  const isActiveAssignments = () => filteredActiveAssignments.length > 0;
+  const activeAssignments = assignments?.filter((assignment) => [
+    ASSIGNMENT_TYPES.CANCELLED, ASSIGNMENT_TYPES.ALLOCATED,
+  ].includes(assignment.state));
+  const hasActiveAssignments = activeAssignments.length > 0;
   return {
-    filteredActiveAssignments,
-    isActiveAssignments,
+    activeAssignments,
+    hasActiveAssignments,
   };
 }

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -63,7 +63,7 @@ const CourseEnrollments = ({ children }) => {
     setShowCancelledAssignmentsAlert(hasCancelledAssignments);
     setShowExpiredAssignmentsAlert(hasExpiredAssignments);
   }, [redeemableLearnerCreditPolicies]);
-  const { activeAssigments } = getActiveAssignments(assignments);
+  const { activeAssigments, hasActiveAssignments } = getActiveAssignments(assignments);
   const assignedCourses = getTransformedAllocatedAssignments(activeAssigments, slug);
 
   const currentCourseEnrollments = useMemo(
@@ -111,8 +111,6 @@ const CourseEnrollments = ({ children }) => {
   }
 
   const hasCourseEnrollments = Object.values(courseEnrollmentsByStatus).flat().length > 0;
-  const hasCourseAssignments = activeAssigments?.length > 0;
-
   return (
     <>
       {showCancelledAssignmentsAlert && (
@@ -136,7 +134,7 @@ const CourseEnrollments = ({ children }) => {
           This allows the parent component to customize what
           gets displayed if the user does not have any course enrollments.
       */}
-      {(!hasCourseEnrollments && !hasCourseAssignments) && children}
+      {(!hasCourseEnrollments && !hasActiveAssignments) && children}
       <>
         {features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && (
           <CourseSection

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -63,8 +63,8 @@ const CourseEnrollments = ({ children }) => {
     setShowCancelledAssignmentsAlert(hasCancelledAssignments);
     setShowExpiredAssignmentsAlert(hasExpiredAssignments);
   }, [redeemableLearnerCreditPolicies]);
-  const { filteredActiveAssignments } = getActiveAssignments(assignments);
-  const assignedCourses = getTransformedAllocatedAssignments(filteredActiveAssignments, slug);
+  const { activeAssigments } = getActiveAssignments(assignments);
+  const assignedCourses = getTransformedAllocatedAssignments(activeAssigments, slug);
 
   const currentCourseEnrollments = useMemo(
     () => {
@@ -111,7 +111,7 @@ const CourseEnrollments = ({ children }) => {
   }
 
   const hasCourseEnrollments = Object.values(courseEnrollmentsByStatus).flat().length > 0;
-  const hasCourseAssignments = filteredActiveAssignments?.length > 0;
+  const hasCourseAssignments = activeAssigments?.length > 0;
 
   return (
     <>

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -63,8 +63,8 @@ const CourseEnrollments = ({ children }) => {
     setShowCancelledAssignmentsAlert(hasCancelledAssignments);
     setShowExpiredAssignmentsAlert(hasExpiredAssignments);
   }, [redeemableLearnerCreditPolicies]);
-  const { filteredAssignments } = getActiveAssignments(assignments);
-  const assignedCourses = getTransformedAllocatedAssignments(filteredAssignments, slug);
+  const { filteredActiveAssignments } = getActiveAssignments(assignments);
+  const assignedCourses = getTransformedAllocatedAssignments(filteredActiveAssignments, slug);
 
   const currentCourseEnrollments = useMemo(
     () => {
@@ -111,7 +111,7 @@ const CourseEnrollments = ({ children }) => {
   }
 
   const hasCourseEnrollments = Object.values(courseEnrollmentsByStatus).flat().length > 0;
-  const hasCourseAssignments = filteredAssignments?.length > 0;
+  const hasCourseAssignments = filteredActiveAssignments?.length > 0;
 
   return (
     <>

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -17,17 +17,14 @@ import {
 } from './data/utils';
 import { UserSubsidyContext } from '../../../enterprise-user-subsidy';
 import { features } from '../../../../config';
+import getActiveAssignments from '../../data/utils';
+import { ASSIGNMENT_TYPES } from '../../../enterprise-user-subsidy/enterprise-offers/data/constants';
 
 export const COURSE_SECTION_TITLES = {
   current: 'My courses',
   completed: 'Completed courses',
   savedForLater: 'Saved for later',
   assigned: 'Assigned Courses',
-};
-export const ASSIGNMENT_TYPES = {
-  accepted: 'accepted',
-  allocated: 'allocated',
-  cancelled: 'cancelled',
 };
 
 const CourseEnrollments = ({ children }) => {
@@ -59,22 +56,21 @@ const CourseEnrollments = ({ children }) => {
     setAssignments(assignmentsData);
 
     const hasCancelledAssignments = assignmentsData?.some(
-      assignment => assignment.state === ASSIGNMENT_TYPES.cancelled,
+      assignment => assignment.state === ASSIGNMENT_TYPES.CANCELLED,
     );
     const hasExpiredAssignments = assignmentsData?.some(assignment => isAssignmentExpired(assignment));
 
     setShowCancelledAssignmentsAlert(hasCancelledAssignments);
     setShowExpiredAssignmentsAlert(hasExpiredAssignments);
   }, [redeemableLearnerCreditPolicies]);
-  const filteredAssignments = assignments?.filter((assignment) => assignment?.state === ASSIGNMENT_TYPES.allocated
-    || assignment?.state === ASSIGNMENT_TYPES.cancelled);
+  const { filteredAssignments } = getActiveAssignments(assignments);
   const assignedCourses = getTransformedAllocatedAssignments(filteredAssignments, slug);
 
   const currentCourseEnrollments = useMemo(
     () => {
       Object.keys(courseEnrollmentsByStatus).forEach((status) => {
         courseEnrollmentsByStatus[status] = courseEnrollmentsByStatus[status].map((course) => {
-          const isAssigned = assignments?.some(assignment => (assignment?.state === ASSIGNMENT_TYPES.accepted
+          const isAssigned = assignments?.some(assignment => (assignment?.state === ASSIGNMENT_TYPES.ACCEPTED
             && course.courseRunId.includes(assignment?.contentKey)));
           if (isAssigned) {
             return { ...course, isCourseAssigned: true };

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -17,9 +17,6 @@ import {
 } from './data/utils';
 import { UserSubsidyContext } from '../../../enterprise-user-subsidy';
 import { features } from '../../../../config';
-import EnterpriseLearnerFirstVisitRedirect, {
-  isFirstDashboardPageVisit,
-} from '../../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect';
 
 export const COURSE_SECTION_TITLES = {
   current: 'My courses',
@@ -68,7 +65,6 @@ const CourseEnrollments = ({ children }) => {
     setShowCancelledAssignmentsAlert(hasCancelledAssignments);
     setShowExpiredAssignmentsAlert(hasExpiredAssignments);
   }, [redeemableLearnerCreditPolicies]);
-
   const filteredAssignments = assignments?.filter((assignment) => assignment?.state === ASSIGNMENT_TYPES.allocated
     || assignment?.state === ASSIGNMENT_TYPES.cancelled);
   const assignedCourses = getTransformedAllocatedAssignments(filteredAssignments, slug);
@@ -119,10 +115,6 @@ const CourseEnrollments = ({ children }) => {
 
   const hasCourseEnrollments = Object.values(courseEnrollmentsByStatus).flat().length > 0;
   const hasCourseAssignments = filteredAssignments?.length > 0;
-
-  if (hasCourseAssignments && isFirstDashboardPageVisit()) {
-    return <EnterpriseLearnerFirstVisitRedirect />;
-  }
 
   return (
     <>

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -10,11 +10,16 @@ import CourseEnrollmentsAlert from './CourseEnrollmentsAlert';
 import CourseAssignmentAlert from './CourseAssignmentAlert';
 import { CourseEnrollmentsContext } from './CourseEnrollmentsContextProvider';
 import {
-  getTransformedAllocatedAssignments, sortedEnrollmentsByEnrollmentDate, sortAssignmentsByAssignmentStatus,
+  getTransformedAllocatedAssignments,
   isAssignmentExpired,
+  sortAssignmentsByAssignmentStatus,
+  sortedEnrollmentsByEnrollmentDate,
 } from './data/utils';
 import { UserSubsidyContext } from '../../../enterprise-user-subsidy';
 import { features } from '../../../../config';
+import EnterpriseLearnerFirstVisitRedirect, {
+  isFirstDashboardPageVisit,
+} from '../../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect';
 
 export const COURSE_SECTION_TITLES = {
   current: 'My courses',
@@ -114,6 +119,10 @@ const CourseEnrollments = ({ children }) => {
 
   const hasCourseEnrollments = Object.values(courseEnrollmentsByStatus).flat().length > 0;
   const hasCourseAssignments = filteredAssignments?.length > 0;
+
+  if (hasCourseAssignments && isFirstDashboardPageVisit()) {
+    return <EnterpriseLearnerFirstVisitRedirect />;
+  }
 
   return (
     <>

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -53,6 +53,7 @@ const CourseEnrollments = ({ children }) => {
   const [showExpiredAssignmentsAlert, setShowExpiredAssignmentsAlert] = useState(false);
 
   useEffect(() => {
+    // TODO: Refactor to DRY up code for redeemableLearnerCreditPolicies
     const data = redeemableLearnerCreditPolicies?.flatMap(item => item?.learnerContentAssignments || []);
     const assignmentsData = sortAssignmentsByAssignmentStatus(data);
     setAssignments(assignmentsData);

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -1,6 +1,4 @@
-import {
-  useState, useEffect, useCallback,
-} from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { logError } from '@edx/frontend-platform/logging';
 import _camelCase from 'lodash.camelcase';
@@ -11,8 +9,8 @@ import { groupCourseEnrollmentsByStatus, transformCourseEnrollment } from './uti
 import { COURSE_STATUSES } from './constants';
 import CourseService from '../../../../course/data/service';
 import {
-  createEnrollWithLicenseUrl,
   createEnrollWithCouponCodeUrl,
+  createEnrollWithLicenseUrl,
   findCouponCodeForCourse,
   findHighestLevelSeatSku,
   getSubsidyToApplyForCourse,

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -56,12 +56,6 @@ jest.mock('../main-content/course-enrollments/data/utils', () => ({
 
 jest.mock('../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect');
 
-// jest.mock('../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect', () => (
-//   {
-//     ...jest.requireActual('../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect'),
-//     isFirstDashboardPageVisit: jest.fn(),
-//   }));
-
 const defaultAppState = {
   enterpriseConfig: {
     name: 'BearsRUs',

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -25,9 +25,7 @@ import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import { SUBSIDY_TYPE } from '../../enterprise-subsidy-requests/constants';
 import { sortAssignmentsByAssignmentStatus } from '../main-content/course-enrollments/data/utils';
-import EnterpriseLearnerFirstVisitRedirect, {
-  isFirstDashboardPageVisit,
-} from '../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect';
+import * as EnterpriseLearnerFirstVisitRedirect from '../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect';
 
 const defaultCouponCodesState = {
   couponCodes: [],
@@ -54,7 +52,7 @@ jest.mock('../main-content/course-enrollments/data/utils', () => ({
   sortAssignmentsByAssignmentStatus: jest.fn(),
 }));
 
-jest.mock('../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect');
+// jest.mock('../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect');
 
 const defaultAppState = {
   enterpriseConfig: {
@@ -72,7 +70,16 @@ const defaultAppState = {
 const defaultUserSubsidyState = {
   couponCodes: defaultCouponCodesState,
   enterpriseOffers: [],
-  redeemableLearnerCreditPolicies: [],
+  redeemableLearnerCreditPolicies: [{
+    learnerContentAssignments: {
+      state: 'allocated',
+    },
+  },
+  {
+    learnerContentAssignments: {
+      state: 'accepted',
+    },
+  }],
 };
 
 const defaultCourseState = {
@@ -347,13 +354,6 @@ describe('<Dashboard />', () => {
   });
 
   it('should render redirect component if no cookie and no courseAssignments exist', () => {
-    isFirstDashboardPageVisit.mockReturnValueOnce(true);
-    EnterpriseLearnerFirstVisitRedirect.mockImplementation(() => (
-      <IntlProvider locale="en">
-        <div>search-page</div>
-      </IntlProvider>
-    ));
-
     const noActiveCourseAssignmentUserSubsidyState = {
       ...defaultUserSubsidyState,
       redeemableLearnerCreditPolicies: [{
@@ -363,35 +363,9 @@ describe('<Dashboard />', () => {
         ],
       }],
     };
+    jest.spyOn(EnterpriseLearnerFirstVisitRedirect, 'default').mockReturnValueOnce(<IntlProvider locale="en">search-page</IntlProvider>);
     renderWithRouter(<DashboardWithContext initialUserSubsidyState={noActiveCourseAssignmentUserSubsidyState} />);
-
-    expect(isFirstDashboardPageVisit).toHaveBeenCalled();
-    expect(screen.getByText('search-page')).toBeInTheDocument();
-  });
-
-  it('should not render redirect component if active learnerContentAssignment exist', () => {
-    isFirstDashboardPageVisit.mockReturnValueOnce(true);
-    EnterpriseLearnerFirstVisitRedirect.mockImplementation(() => (
-      <IntlProvider locale="en">
-        <div>search-page</div>
-      </IntlProvider>
-    ));
-
-    const noActiveCourseAssignmentUserSubsidyState = {
-      ...defaultUserSubsidyState,
-      redeemableLearnerCreditPolicies: [{
-        learnerContentAssignments: [{
-          state: 'allocated',
-        },
-        {
-          state: 'accepted',
-        },
-        ],
-      }],
-    };
-    renderWithRouter(<DashboardWithContext initialUserSubsidyState={noActiveCourseAssignmentUserSubsidyState} />);
-
-    expect(screen.queryByText('search-page')).not.toBeInTheDocument();
+    expect(screen.queryByText('search-page')).toBeTruthy();
   });
 
   describe('SubscriptionExpirationModal', () => {

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -337,7 +337,7 @@ describe('<Dashboard />', () => {
     expect(programsTab).toHaveAttribute('aria-selected', 'false');
   });
 
-  it('should send track event when "my-craeer" tab selected', () => {
+  it('should send track event when "my-career" tab selected', () => {
     renderWithRouter(<DashboardWithContext />);
 
     const myCareerTab = screen.getByText('My Career');

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -25,7 +25,6 @@ import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import { SUBSIDY_TYPE } from '../../enterprise-subsidy-requests/constants';
 import { sortAssignmentsByAssignmentStatus } from '../main-content/course-enrollments/data/utils';
-import * as EnterpriseLearnerFirstVisitRedirect from '../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect';
 
 const defaultCouponCodesState = {
   couponCodes: [],
@@ -52,6 +51,10 @@ jest.mock('../main-content/course-enrollments/data/utils', () => ({
   sortAssignmentsByAssignmentStatus: jest.fn(),
 }));
 
+jest.mock('../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect', () => jest.fn(
+  () => (<div>enterprise-learner-first-visit-redirect</div>),
+));
+
 const defaultAppState = {
   enterpriseConfig: {
     name: 'BearsRUs',
@@ -75,7 +78,7 @@ const defaultUserSubsidyState = {
   },
   {
     learnerContentAssignments: {
-      state: 'accepted',
+      state: 'cancelled',
     },
   }],
 };
@@ -354,16 +357,10 @@ describe('<Dashboard />', () => {
   it('should render redirect component if no cookie and no courseAssignments exist', () => {
     const noActiveCourseAssignmentUserSubsidyState = {
       ...defaultUserSubsidyState,
-      redeemableLearnerCreditPolicies: [{
-        learnerContentAssignments: [{
-          state: 'cancelled',
-        },
-        ],
-      }],
+      redeemableLearnerCreditPolicies: [],
     };
-    jest.spyOn(EnterpriseLearnerFirstVisitRedirect, 'default').mockReturnValueOnce(<IntlProvider locale="en">search-page</IntlProvider>);
     renderWithRouter(<DashboardWithContext initialUserSubsidyState={noActiveCourseAssignmentUserSubsidyState} />);
-    expect(screen.queryByText('search-page')).toBeTruthy();
+    expect(screen.queryByText('enterprise-learner-first-visit-redirect')).toBeTruthy();
   });
 
   describe('SubscriptionExpirationModal', () => {

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -52,8 +52,6 @@ jest.mock('../main-content/course-enrollments/data/utils', () => ({
   sortAssignmentsByAssignmentStatus: jest.fn(),
 }));
 
-// jest.mock('../../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect');
-
 const defaultAppState = {
   enterpriseConfig: {
     name: 'BearsRUs',

--- a/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
+++ b/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
@@ -23,7 +23,7 @@ const EnterpriseLearnerFirstVisitRedirect = () => {
       item => item?.learnerContentAssignments || [],
     );
     // filters out course assignments that are not considered active and returns a boolean value
-    return getActiveAssignments(learnerContentAssignmentsArray).isActiveAssignments();
+    return getActiveAssignments(learnerContentAssignmentsArray).hasActiveAssignments;
   };
   useEffect(() => {
     const cookies = new Cookies();

--- a/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
+++ b/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
@@ -22,7 +22,7 @@ const EnterpriseLearnerFirstVisitRedirect = () => {
     const learnerContentAssignmentsArray = learnerCreditPolicies?.flatMap(
       item => item?.learnerContentAssignments || [],
     );
-    // filters out course assignments that are not considered active
+    // filters out course assignments that are not considered active and returns a boolean value
     return getActiveAssignments(learnerContentAssignmentsArray).isActiveAssignments();
   };
   useEffect(() => {

--- a/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
+++ b/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
@@ -1,6 +1,8 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Redirect, useParams } from 'react-router-dom';
 import Cookies from 'universal-cookie';
+import { ASSIGNMENT_TYPES } from '../dashboard/main-content/course-enrollments/CourseEnrollments';
+import { UserSubsidyContext } from '../enterprise-user-subsidy';
 
 export const isFirstDashboardPageVisit = () => {
   const cookies = new Cookies();
@@ -11,15 +13,29 @@ export const isFirstDashboardPageVisit = () => {
 
 const EnterpriseLearnerFirstVisitRedirect = () => {
   const { enterpriseSlug } = useParams();
-  const cookies = new Cookies();
+  const {
+    redeemableLearnerCreditPolicies,
+  } = useContext(UserSubsidyContext);
 
+  // TODO: Refactor to DRY up code for redeemableLearnerCreditPolicies
+  const hasActiveCourseAssignments = (learnerCreditPolicies) => {
+    const learnerContentAssignmentsArray = learnerCreditPolicies?.flatMap(
+      item => item?.learnerContentAssignments || [],
+    );
+    // filters out course assignments that are not considered active
+    const hasActiveAssignments = learnerContentAssignmentsArray.filter(
+      assignment => assignment.state !== ASSIGNMENT_TYPES.cancelled,
+    );
+    return hasActiveAssignments.length > 0;
+  };
   useEffect(() => {
+    const cookies = new Cookies();
+
     if (isFirstDashboardPageVisit()) {
       cookies.set('has-user-visited-learner-dashboard', true, { path: '/' });
     }
-  });
-
-  if (isFirstDashboardPageVisit()) {
+  }, []);
+  if (!hasActiveCourseAssignments(redeemableLearnerCreditPolicies) && isFirstDashboardPageVisit()) {
     return <Redirect to={`/${enterpriseSlug}/search`} />;
   }
 

--- a/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
+++ b/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
@@ -1,8 +1,8 @@
 import React, { useContext, useEffect } from 'react';
 import { Redirect, useParams } from 'react-router-dom';
 import Cookies from 'universal-cookie';
-import { ASSIGNMENT_TYPES } from '../dashboard/main-content/course-enrollments/CourseEnrollments';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
+import getActiveAssignments from '../dashboard/data/utils';
 
 export const isFirstDashboardPageVisit = () => {
   const cookies = new Cookies();
@@ -18,15 +18,12 @@ const EnterpriseLearnerFirstVisitRedirect = () => {
   } = useContext(UserSubsidyContext);
 
   // TODO: Refactor to DRY up code for redeemableLearnerCreditPolicies
-  const hasActiveCourseAssignments = (learnerCreditPolicies) => {
+  const hasActiveContentAssignments = (learnerCreditPolicies) => {
     const learnerContentAssignmentsArray = learnerCreditPolicies?.flatMap(
       item => item?.learnerContentAssignments || [],
     );
     // filters out course assignments that are not considered active
-    const hasActiveAssignments = learnerContentAssignmentsArray.filter(
-      assignment => assignment.state !== ASSIGNMENT_TYPES.cancelled,
-    );
-    return hasActiveAssignments.length > 0;
+    return getActiveAssignments(learnerContentAssignmentsArray).isActiveAssignments();
   };
   useEffect(() => {
     const cookies = new Cookies();
@@ -35,7 +32,8 @@ const EnterpriseLearnerFirstVisitRedirect = () => {
       cookies.set('has-user-visited-learner-dashboard', true, { path: '/' });
     }
   }, []);
-  if (!hasActiveCourseAssignments(redeemableLearnerCreditPolicies) && isFirstDashboardPageVisit()) {
+
+  if (!hasActiveContentAssignments(redeemableLearnerCreditPolicies) && isFirstDashboardPageVisit()) {
     return <Redirect to={`/${enterpriseSlug}/search`} />;
   }
 

--- a/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
+++ b/src/components/enterprise-redirects/EnterpriseLearnerFirstVisitRedirect.jsx
@@ -2,23 +2,24 @@ import React, { useEffect } from 'react';
 import { Redirect, useParams } from 'react-router-dom';
 import Cookies from 'universal-cookie';
 
-const EnterpriseLearnerFirstVisitRedirect = () => {
-  const { enterpriseSlug } = useParams();
-
+export const isFirstDashboardPageVisit = () => {
   const cookies = new Cookies();
 
-  const isFirstVisit = () => {
-    const hasUserVisitedDashboard = cookies.get('has-user-visited-learner-dashboard');
-    return !hasUserVisitedDashboard;
-  };
+  const hasUserVisitedDashboard = cookies.get('has-user-visited-learner-dashboard');
+  return !hasUserVisitedDashboard;
+};
+
+const EnterpriseLearnerFirstVisitRedirect = () => {
+  const { enterpriseSlug } = useParams();
+  const cookies = new Cookies();
 
   useEffect(() => {
-    if (isFirstVisit()) {
+    if (isFirstDashboardPageVisit()) {
       cookies.set('has-user-visited-learner-dashboard', true, { path: '/' });
     }
   });
 
-  if (isFirstVisit()) {
+  if (isFirstDashboardPageVisit()) {
     return <Redirect to={`/${enterpriseSlug}/search`} />;
   }
 

--- a/src/components/enterprise-redirects/tests/EnterpriseLearnerFirstVisitRedirect.test.jsx
+++ b/src/components/enterprise-redirects/tests/EnterpriseLearnerFirstVisitRedirect.test.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import Cookies from 'universal-cookie';
-
-import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { renderWithRouter } from '../../../utils/tests';
 import EnterpriseLearnerFirstVisitRedirect from '../EnterpriseLearnerFirstVisitRedirect';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
@@ -29,7 +27,7 @@ const defaultUserSubsidyState = {
   },
   {
     learnerContentAssignments: {
-      state: 'accepted',
+      state: 'cancelled',
     },
   }],
 };
@@ -37,11 +35,9 @@ const defaultUserSubsidyState = {
 const EnterpriseLearnerFirstVisitRedirectWrapper = ({
   initialUserSubsidyState = defaultUserSubsidyState,
 }) => (
-  <IntlProvider locale="en">
-    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-      <EnterpriseLearnerFirstVisitRedirect />
-    </UserSubsidyContext.Provider>
-  </IntlProvider>
+  <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+    <EnterpriseLearnerFirstVisitRedirect />
+  </UserSubsidyContext.Provider>
 );
 
 describe('<EnterpriseLearnerFirstVisitRedirect />', () => {
@@ -53,9 +49,7 @@ describe('<EnterpriseLearnerFirstVisitRedirect />', () => {
   test('redirects to search if user is visiting for the first time.', async () => {
     const noActiveCourseAssignmentUserSubsidyState = {
       ...defaultUserSubsidyState,
-      redeemableLearnerCreditPolicies: [{
-        learnerContentAssignments: [],
-      }],
+      redeemableLearnerCreditPolicies: [],
     };
 
     const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirectWrapper initialUserSubsidyState={noActiveCourseAssignmentUserSubsidyState} />, { route: `/${TEST_ENTERPRISE.slug}` });
@@ -65,12 +59,7 @@ describe('<EnterpriseLearnerFirstVisitRedirect />', () => {
   test('redirects to search if the course assigned is not active.', async () => {
     const noActiveCourseAssignmentUserSubsidyState = {
       ...defaultUserSubsidyState,
-      redeemableLearnerCreditPolicies: [{
-        learnerContentAssignments: [{
-          state: 'cancelled',
-        },
-        ],
-      }],
+      redeemableLearnerCreditPolicies: [],
     };
 
     const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirectWrapper initialUserSubsidyState={noActiveCourseAssignmentUserSubsidyState} />, { route: `/${TEST_ENTERPRISE.slug}` });

--- a/src/components/enterprise-redirects/tests/EnterpriseLearnerFirstVisitRedirect.test.jsx
+++ b/src/components/enterprise-redirects/tests/EnterpriseLearnerFirstVisitRedirect.test.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import Cookies from 'universal-cookie';
 
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { renderWithRouter } from '../../../utils/tests';
 import EnterpriseLearnerFirstVisitRedirect from '../EnterpriseLearnerFirstVisitRedirect';
+import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 
 const COOKIE_NAME = 'has-user-visited-learner-dashboard';
 const TEST_ENTERPRISE = {
@@ -19,6 +21,37 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+const defaultCouponCodesState = {
+  couponCodes: [],
+  loading: false,
+  couponCodesCount: 0,
+};
+
+const defaultUserSubsidyState = {
+  couponCodes: defaultCouponCodesState,
+  enterpriseOffers: [],
+  redeemableLearnerCreditPolicies: [{
+    learnerContentAssignments: {
+      state: 'allocated',
+    },
+  },
+  {
+    learnerContentAssignments: {
+      state: 'accepted',
+    },
+  }],
+};
+
+const EnterpriseLearnerFirstVisitRedirectWrapper = ({
+  initialUserSubsidyState = defaultUserSubsidyState,
+}) => (
+  <IntlProvider locale="en">
+    <UserSubsidyContext.Provider value={initialUserSubsidyState}>
+      <EnterpriseLearnerFirstVisitRedirect />
+    </UserSubsidyContext.Provider>
+  </IntlProvider>
+);
+
 describe('<EnterpriseLearnerFirstVisitRedirect />', () => {
   beforeEach(() => {
     const cookies = new Cookies();
@@ -26,7 +59,29 @@ describe('<EnterpriseLearnerFirstVisitRedirect />', () => {
   });
 
   test('redirects to search if user is visiting for the first time.', async () => {
-    const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirect />, { route: `/${TEST_ENTERPRISE.slug}` });
+    const noActiveCourseAssignmentUserSubsidyState = {
+      ...defaultUserSubsidyState,
+      redeemableLearnerCreditPolicies: [{
+        learnerContentAssignments: [],
+      }],
+    };
+
+    const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirectWrapper initialUserSubsidyState={noActiveCourseAssignmentUserSubsidyState} />, { route: `/${TEST_ENTERPRISE.slug}` });
+    expect(history.location.pathname).toEqual(`/${TEST_ENTERPRISE.slug}/search`);
+  });
+
+  test('redirects to search if the course assigned is not active.', async () => {
+    const noActiveCourseAssignmentUserSubsidyState = {
+      ...defaultUserSubsidyState,
+      redeemableLearnerCreditPolicies: [{
+        learnerContentAssignments: [{
+          state: 'cancelled',
+        },
+        ],
+      }],
+    };
+
+    const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirectWrapper initialUserSubsidyState={noActiveCourseAssignmentUserSubsidyState} />, { route: `/${TEST_ENTERPRISE.slug}` });
     expect(history.location.pathname).toEqual(`/${TEST_ENTERPRISE.slug}/search`);
   });
 
@@ -35,7 +90,7 @@ describe('<EnterpriseLearnerFirstVisitRedirect />', () => {
     const cookies = new Cookies();
     cookies.set(COOKIE_NAME, true);
 
-    const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirect />, { route: `/${TEST_ENTERPRISE.slug}` });
+    const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirectWrapper />, { route: `/${TEST_ENTERPRISE.slug}` });
     expect(history.location.pathname).toEqual(`/${TEST_ENTERPRISE.slug}`);
   });
 
@@ -44,7 +99,7 @@ describe('<EnterpriseLearnerFirstVisitRedirect />', () => {
     const cookies = new Cookies();
     cookies.set(COOKIE_NAME, true);
 
-    const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirect />, { route: `/${TEST_ENTERPRISE.slug}` });
+    const { history } = renderWithRouter(<EnterpriseLearnerFirstVisitRedirectWrapper />, { route: `/${TEST_ENTERPRISE.slug}` });
     expect(history.location.pathname).toEqual(`/${TEST_ENTERPRISE.slug}`);
   });
 });

--- a/src/components/enterprise-redirects/tests/EnterpriseLearnerFirstVisitRedirect.test.jsx
+++ b/src/components/enterprise-redirects/tests/EnterpriseLearnerFirstVisitRedirect.test.jsx
@@ -21,15 +21,7 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-const defaultCouponCodesState = {
-  couponCodes: [],
-  loading: false,
-  couponCodesCount: 0,
-};
-
 const defaultUserSubsidyState = {
-  couponCodes: defaultCouponCodesState,
-  enterpriseOffers: [],
   redeemableLearnerCreditPolicies: [{
     learnerContentAssignments: {
       state: 'allocated',

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
@@ -34,4 +34,5 @@ export const ASSIGNMENT_TYPES = {
   ACCEPTED: 'accepted',
   ALLOCATED: 'allocated',
   CANCELLED: 'cancelled',
+  ERRORED: 'errored',
 };


### PR DESCRIPTION
Modifies the logic for redirecting the page to the search page based on whether the `has-user-visited-learner-dashboard` cookie has been set to take into account whether active course assignments exist.

This involves hoisting some of the logic from `CourseEnrollments.jsx` into `DashboardPage.jsx` to avoid partial render before redirect.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
