### PR TITLE
feat: fetching of a secured Algolia key [BB-8083]

### DIFF
--- a/src/components/academies/AcademyDetailPage.jsx
+++ b/src/components/academies/AcademyDetailPage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useContext } from 'react';
 import {
   Container, Chip, Breadcrumb,
   Skeleton, Spinner,
@@ -7,12 +7,12 @@ import {
   useParams, Link,
 } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
-import algoliasearch from 'algoliasearch/lite';
 import { getConfig } from '@edx/frontend-platform/config';
 import { useAcademyMetadata } from './data/hooks';
 import CourseCard from './CourseCard';
 import NotFoundPage from '../NotFoundPage';
 import { ACADEMY_NOT_FOUND_TITLE } from './data/constants';
+import { useAlgoliaSearch } from '../../utils/hooks';
 
 const AcademyDetailPage = () => {
   const config = getConfig();
@@ -21,17 +21,7 @@ const AcademyDetailPage = () => {
   const [academy, isAcademyAPILoading, academyAPIError] = useAcademyMetadata(academyUUID);
   const academyURL = `/${enterpriseConfig.slug}/academy/${academyUUID}`;
 
-  // init algolia index
-  const courseIndex = useMemo(
-    () => {
-      const client = algoliasearch(
-        config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
-      );
-      return client.initIndex(config.ALGOLIA_INDEX_NAME);
-    },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY],
-  );
+  const [, courseIndex] = useAlgoliaSearch(config, config.ALGOLIA_INDEX_NAME);
 
   if (academyAPIError) {
     return (

--- a/src/components/academies/tests/AcademyDetailPage.test.jsx
+++ b/src/components/academies/tests/AcademyDetailPage.test.jsx
@@ -74,7 +74,7 @@ getAuthenticatedHttpClient.mockReturnValue(axios);
 axiosMock.onGet(ACADEMY_API_ENDPOINT).reply(200, ACADEMY_MOCK_DATA);
 
 // Mock the 'algoliasearch' module
-jest.mock('algoliasearch/lite', () => {
+jest.mock('algoliasearch', () => {
   // Mock the 'initIndex' function
   const mockInitIndex = jest.fn(() => {
     // Mock the 'search' function of the index

--- a/src/components/my-career/CategoryCard.jsx
+++ b/src/components/my-career/CategoryCard.jsx
@@ -1,17 +1,17 @@
 import React, {
-  useContext, useEffect, useMemo, useState,
+  useContext, useEffect, useState,
 } from 'react';
 
 import PropTypes from 'prop-types';
 import { Button, Card, useToggle } from '@edx/paragon';
 import { getConfig } from '@edx/frontend-platform/config';
-import algoliasearch from 'algoliasearch/lite';
 import { AppContext } from '@edx/frontend-platform/react';
 import LevelBars from './LevelBars';
 import SkillsRecommendationCourses from './SkillsRecommendationCourses';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import { isDisableCourseSearch } from '../enterprise-user-subsidy/enterprise-offers/data/utils';
 import { features } from '../../config';
+import { useAlgoliaSearch } from '../../utils/hooks';
 
 const CategoryCard = ({ topCategory }) => {
   const { skillsSubcategories } = topCategory;
@@ -41,16 +41,7 @@ const CategoryCard = ({ topCategory }) => {
 
   const config = getConfig();
   const { enterpriseConfig } = useContext(AppContext);
-  const courseIndex = useMemo(
-    () => {
-      const client = algoliasearch(
-        config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
-      );
-      return client.initIndex(config.ALGOLIA_INDEX_NAME);
-    },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY],
-  );
+  const [, courseIndex] = useAlgoliaSearch(config, config.ALGOLIA_INDEX_NAME);
 
   const filterRenderableSkills = (skills) => {
     const renderableSkills = [];

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useContext, useMemo, useEffect,
+  useContext, useEffect,
 } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
@@ -9,7 +9,6 @@ import { getConfig } from '@edx/frontend-platform/config';
 import { SearchHeader, SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { useToggle, Stack } from '@edx/paragon';
 
-import algoliasearch from 'algoliasearch/lite';
 import { useDefaultSearchFilters, useSearchCatalogs } from './data/hooks';
 import {
   NUM_RESULTS_PER_PAGE,
@@ -41,6 +40,7 @@ import AssignmentsOnlyEmptyState from './AssignmentsOnlyEmptyState';
 import { LICENSE_STATUS } from '../enterprise-user-subsidy/data/constants';
 import { POLICY_TYPES } from '../enterprise-user-subsidy/enterprise-offers/data/constants';
 import AuthenticatedPageContext from '../app/AuthenticatedPageContext';
+import { useAlgoliaSearch } from '../../utils/hooks';
 
 const Search = () => {
   const config = getConfig();
@@ -85,17 +85,7 @@ const Search = () => {
   const enterpriseUUID = enterpriseConfig.uuid;
   const { enterpriseCuration: { canOnlyViewHighlightSets } } = useEnterpriseCuration(enterpriseUUID);
 
-  const courseIndex = useMemo(
-    () => {
-      const client = algoliasearch(
-        config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
-      );
-      const cIndex = client.initIndex(config.ALGOLIA_INDEX_NAME);
-      return cIndex;
-    },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY],
-  );
+  const [, courseIndex] = useAlgoliaSearch(config, config.ALGOLIA_INDEX_NAME);
 
   // If a pathwayUUID exists, open the pathway modal.
   useEffect(() => {

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -1,9 +1,8 @@
 /* eslint-disable object-curly-newline */
-import React, { useEffect, useState, useContext, useMemo } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import {
   Button, Stepper, ModalDialog, Container, Form, Stack,
 } from '@edx/paragon';
-import algoliasearch from 'algoliasearch/lite';
 import { Configure, InstantSearch } from 'react-instantsearch-dom';
 import { getConfig } from '@edx/frontend-platform/config';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
@@ -38,6 +37,7 @@ import {
 import { SkillsContext } from './SkillsContextProvider';
 import { SET_KEY_VALUE } from './data/constants';
 import { checkValidGoalAndJobSelected } from '../utils/skills-quiz';
+import { useAlgoliaSearch } from '../../utils/hooks';
 import TopSkillsOverview from './TopSkillsOverview';
 import SkillsQuizHeader from './SkillsQuizHeader';
 
@@ -48,18 +48,9 @@ import { fetchCourseEnrollments } from './data/service';
 const SkillsQuizStepper = () => {
   const config = getConfig();
   const { userId } = getAuthenticatedUser();
-  const [searchClient, courseIndex, jobIndex] = useMemo(
-    () => {
-      const client = algoliasearch(
-        config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
-      );
-      const cIndex = client.initIndex(config.ALGOLIA_INDEX_NAME);
-      const jIndex = client.initIndex(config.ALGOLIA_INDEX_NAME_JOBS);
-      return [client, cIndex, jIndex];
-    },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_INDEX_NAME_JOBS, config.ALGOLIA_SEARCH_API_KEY],
-  );
+  const [, courseIndex] = useAlgoliaSearch(config, config.ALGOLIA_INDEX_NAME);
+  const [jobSearchClient, jobIndex] = useAlgoliaSearch(config, config.ALGOLIA_INDEX_NAME_JOBS);
+
   const [currentStep, setCurrentStep] = useState(STEP1);
   const [isStudentChecked, setIsStudentChecked] = useState(false);
   const handleIsStudentCheckedChange = e => setIsStudentChecked(e.target.checked);
@@ -198,7 +189,7 @@ const SkillsQuizStepper = () => {
                   <div>
                     <InstantSearch
                       indexName={config.ALGOLIA_INDEX_NAME_JOBS}
-                      searchClient={searchClient}
+                      searchClient={jobSearchClient}
                     >
                       <Configure
                         facetingAfterDistinct

--- a/src/components/skills-quiz/tests/SearchFilters.test.jsx
+++ b/src/components/skills-quiz/tests/SearchFilters.test.jsx
@@ -21,6 +21,7 @@ import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 jest.mock('@edx/frontend-platform/auth', () => ({
   ...jest.requireActual('@edx/frontend-platform/auth'),
   getAuthenticatedUser: () => ({ username: 'myspace-tom' }),
+  getAuthenticatedHttpClient: jest.fn(),
 }));
 
 jest.mock('@edx/frontend-enterprise-utils', () => ({

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,6 +34,8 @@ initialize({
         LICENSE_MANAGER_URL: process.env.LICENSE_MANAGER_URL || null,
         ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID || null,
         ALGOLIA_SEARCH_API_KEY: process.env.ALGOLIA_SEARCH_API_KEY || null,
+        ALGOLIA_SECURED_KEY_ENDPOINT: process.env.ALGOLIA_SECURED_KEY_ENDPOINT
+          || `${process.env.LMS_BASE_URL}/enterprise/api/v1/enterprise-customer/algolia_key/`,
         ALGOLIA_INDEX_NAME: process.env.ALGOLIA_INDEX_NAME || null,
         ALGOLIA_INDEX_NAME_JOBS: process.env.ALGOLIA_INDEX_NAME_JOBS || null,
         INTEGRATION_WARNING_DISMISSED_COOKIE_NAME: process.env.INTEGRATION_WARNING_DISMISSED_COOKIE_NAME || null,

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1,6 +1,7 @@
 import Cookies from 'universal-cookie';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
+import { logError } from '@edx/frontend-platform/logging';
 import dayjs from './dayjs';
 
 export const isCourseEnded = endDate => dayjs(endDate) < dayjs();
@@ -63,6 +64,22 @@ export const loginRefresh = async () => {
       cookies.remove(config.ACCESS_TOKEN_COOKIE_NAME);
     }
     return Promise.resolve();
+  }
+};
+
+export const fetchAlgoliaSecuredApiKey = async () => {
+  const config = getConfig();
+  const httpClient = getAuthenticatedHttpClient();
+
+  try {
+    const response = await httpClient.get(config.ALGOLIA_SECURED_KEY_ENDPOINT);
+    if (response && response.data) {
+      return response.data.key;
+    }
+    throw new Error('Response does not contain data');
+  } catch (error) {
+    logError(error);
+    return null;
   }
 };
 

--- a/src/utils/hooks.jsx
+++ b/src/utils/hooks.jsx
@@ -1,5 +1,12 @@
-import React, { useCallback, useMemo } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import algoliasearch from 'algoliasearch';
+
+import { fetchAlgoliaSecuredApiKey } from './common';
 
 export const useRenderContactHelpText = (enterpriseConfig) => {
   const renderContactHelpText = useCallback(
@@ -22,17 +29,41 @@ export const useRenderContactHelpText = (enterpriseConfig) => {
   return renderContactHelpText;
 };
 
+let cachedApiKey = null;
+
+export const useAlgoliaSearchApiKey = (config) => {
+  // If the search API key is not provided in the config,
+  // fetch it from `ALGOLIA_SECURED_KEY_ENDPOINT`.
+
+  const [searchApiKey, setSearchApiKey] = useState(cachedApiKey || config.ALGOLIA_SEARCH_API_KEY);
+
+  useEffect(() => {
+    const fetchApiKey = async () => {
+      const key = await fetchAlgoliaSecuredApiKey();
+      cachedApiKey = key;
+      setSearchApiKey(key);
+    };
+
+    if (!searchApiKey) {
+      fetchApiKey();
+    }
+  }, [searchApiKey]);
+
+  return searchApiKey;
+};
+
 export const useAlgoliaSearch = (config, indexName) => {
+  const algoliaSearchApiKey = useAlgoliaSearchApiKey(config);
   const [searchClient, searchIndex] = useMemo(
     () => {
       const client = algoliasearch(
         config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
+        algoliaSearchApiKey,
       );
       const index = client.initIndex(indexName || config.ALGOLIA_INDEX_NAME);
       return [client, index];
     },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY, indexName],
+    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, algoliaSearchApiKey, indexName],
   );
   return [searchClient, searchIndex];
 };


### PR DESCRIPTION
## Description

Adds a fallback mechanism, so when the `ALGOLIA_SEARCH_API_KEY` environment variable is not set, the key is fetched from the endpoint defined by the `ALGOLIA_SECURED_KEY_ENDPOINT` environment variable. It expects this endpoint to return a JSON like:
```json
{
  "key": "<ALGOLIA_SEARCH_API_KEY>"
}
```
This is intended, but not limited to, to be used with https://github.com/openedx/edx-enterprise/pull/1962.

## Testing steps

We're going to test this and https://github.com/openedx/edx-enterprise/pull/1962 PRs at once by creating three courses and three enterprise customers, uploading them to Algolia through `enterprise-catalog` and checking that learners are able to browse catalogs of their enterprises with the help of this MFE, but unable to access courses of enterprises they don't belong to.

#### Prerequisites

You'll need an Algolia account. Create an application and `enterprise-catalog` index. Write down the application id, admin API key, and search API key somewhere.

#### Installing master devstack
```bash
mkdir master && cd master
export DEVSTACK_WORKSPACE=$(pwd)
git clone git@github.com:openedx/devstack.git && cd devstack
virtualenv -p python3 .fenv
source .fenv/bin/activate
make requirements
make dev.clone
make dev.provision
make dev.up.large-and-slow
```
After that:
1. `cd ../edx-platform`
2. Add `ENTERPRISE_ALGOLIA_SEARCH_API_KEY = '<YOUR_ALGOLIA_SEARCH_(NOT ADMIN)_API_KEY>'` to the end of `lms/envs/devstack.py`.

#### Installing edx-enterprise fork
```bash
sudo chown $USER:$USER ../src
cd ../src
git clone -b 0x29a/bb8083/per-user-algolia-key git@github.com:open-craft/edx-enterprise.git
cd ../devstack
make lms-shell
cd /edx/src/edx-enterprise/
pip uninstall edx-enterprise
pip install -e .
exit
make lms-shell
python manage.py lms migrate
exit
make cms-shell
cd /edx/src/edx-enterprise/
pip uninstall edx-enterprise
pip install -e .
exit
make lms-restart
make cms-restart
```
#### Installing enterprise-catalog
```bash
cd ..
git clone git@github.com:openedx/enterprise-catalog.git && cd enterprise-catalog
```
After that:
1. Open `enterprise_catalog/apps/catalog/constants.py` and add `'source'` to the `CONTENT_PRODUCT_SOURCE_ALLOW_LIST` set.
2. Add the following to the end of `enterprise_catalog/settings/devstack.py`:
    ```python
    ALGOLIA = {
        'INDEX_NAME': 'enterprise-catalog',
        'APPLICATION_ID': '<YOUR_ALGOLIA_APPLICATION_ID>',
        'API_KEY': '<YOUR_ADMIN_ALGOLIA_API_KEY>',
    }
    ```
4. Run `make dev.provision`.
#### Installing frontend-app-learner-portal-enterprise
```bash
cd ..
git clone -b 0x29a/bb8083/per-user-algolia-key git@github.com:open-craft/frontend-app-learner-portal-enterprise.git && cd frontend-app-learner-portal-enterprise
export ALGOLIA_APP_ID=<YOUR_ALGOLIA_APPLICATION_ID>
export ALGOLIA_INDEX_NAME=enterprise-catalog
nvm use
npm install
npm start
```
Leave this terminal open, do all the remaining steps in a separate one.
#### Creating test entities
1. Create three courses here: http://localhost:18010/home/. Use `ABC`, `XYZ`, and `PSY` for all fields, like here:
   ![image](https://github.com/open-craft/frontend-app-learner-portal-enterprise/assets/18251194/89b10b44-be98-43b7-8558-fd3d08e8a445)
2. Add a section with a dropdown unit to each course, publish each.
3. Set `Course Start Date` and `Enrollment Start Date` for each course [here](http://localhost:18010/settings/details/course-v1:PSY+PSY+PSY) to `01/01/2019`.
5. Add all three courses [here](http://localhost:18130/courses/new/), like this:
   ![image](https://github.com/open-craft/frontend-app-learner-portal-enterprise/assets/18251194/80aba072-26e9-4e36-99c0-7cc65d622db4)
6. Create a source with a `Source` name here: http://localhost:18381/admin/course_metadata/source/add/
7. Go [here](http://localhost:18000/admin/enterprise/enterprisecatalogquery/) and create three queries with the following content filters for each course:
    ```json
    {
        "content_type":[
            "course",
            "courserun"
        ],
        "aggregation_key":[
            "course:ABC+ABC",
            "courserun:ABC+ABC"
        ],
        "partner":"edx",
        "availability":[
            "Current",
            "Starting Soon",
            "Upcoming"
        ],
        "status":"published"
    }
    ```
    Change `ABC` to `XYZ` and `PSY` for each query.
8. Go [here](http://localhost:18000/admin/enterprise/enterprisecustomer/) and create three enterprise customers: `XXX`, `YYY`, `ZZZ`. Change their slugs respectively.
9. Go [here](http://localhost:18000/admin/enterprise/enterprisecustomercatalog/add/) and create three catalogs for each customer selecting different course queries we created earlier.  `XXX` should be assigned to the query selecting `ABC` course, `YYY` -> `XYZ` and `ZZZ` -> `PSY.`

#### Indexing
Go to the `<DEVSTACK_WORKSPACE>` and replace in `course_discovery/settings/base.py` this:
```python
DEFAULT_PRODUCT_SOURCE_NAME = 'edX'
DEFAULT_PRODUCT_SOURCE_SLUG = 'edx'
```
with this:
```python
DEFAULT_PRODUCT_SOURCE_NAME = 'Source'
DEFAULT_PRODUCT_SOURCE_SLUG = 'source'
```

Then, go to the `<DEVSTACK_WORKSPACE>/devstack` directory run the following to pull the data from LMS to Course Discovery:
```bash
make discovery-shell
./manage.py refresh_course_metadata
```

Then:
1. Go [here](http://localhost:18381/admin/course_metadata/organization/) and set a name for each organization.
2. Go [here](http://localhost:18381/admin/course_metadata/courserun/) and change every course run to be "Published"
3. Run the following in the discovery shell to fill in the product source for each course and update the ES index:
```bash
./manage.py populate_default_product_source
./manage.py update_index --disable-change-limit
exit
```

Now we need to copy course queries and other enterprise-related data from LMS to `enterprise-catalog`. Run the following:
```bash
make lms-shell
./manage.py lms migrate_enterprise_catalogs --api_user enterprise_catalog_worker
```
After that you should see three of your course queries [here](http://localhost:18160/admin/catalog/catalogquery/).

Now, go to the `<DEVSTACK_WORKSPACE>/enterprise-catalog` and run the following to fetch content metadata (courses and course runs) from Course Discovery:

```bash
make app-shell
./manage.py update_content_metadata --force
```

After that you should see `Course` and `Course Run` objects for each of your courses [here](http://localhost:18160/admin/catalog/contentmetadata/). If you don't, then something went wrong. Also, `Json metadata` for each course should contain a non-empty `advertised_course_run_uuid`.

Now you can upload all courses to Algolia:
```bash
./manage.py reindex_algolia
```

If everything go fine, you should see three courses in your `enterprise-catalog` Algolia index.

#### Enrolling users

1. Register a new user: `abc@example.com`.
2. Go the `XXX` enterprise customer and click `Manager Learners` ([example of the admin panel URL](http://localhost:18000/admin/enterprise/enterprisecustomer/a00728ba-b5ee-45a1-8a6d-73ea3870ccec/manage_learners)).
3. Now, enroll `abc@example.com` user to the `course-v1:ABC+ABC+ABC` course. Specify `Audit` track and `test` reason for manual enrollment.
5. Repeat points 2 and 3, but for `YYY` enterprise customer and `course-v1:XYZ+XYZ+XYZ` course, so we have a single learner present in two different enterprises.

#### Testing frontend-app-learner-portal-enterprise

1. Sign out as `abc@example.com`.
2. Go to `http://localhost:8734`.
3. You should be redirected to the LMS.
4. Upon signing in again as `abc@example.com`, you should be offered to choose an organization. Choose `XXX`.
5. You should be redirected to the MFE. You shoud see the `ABC` course [here](http://localhost:8734/xxx/search?showAll=1).
6. Now, if you visit [this URL](http://localhost:18000/enterprise/select/active/?success_url=http%3A%2F%2Flocalhost%3A8734%2F) again and select `YYY`, you should see the `XYZ` course.

Now, open the browser dev tools and locate a query like this:
```
https://ql3i9veweo-dsn.algolia.net/1/indexes/*/queries?x-algolia-agent=Algolia for JavaScript (4.6.0); Browser; JS Helper (3.12.0); react (17.0.2); react-instantsearch (6.38.1)
```
1. Click the right mouse button on it and `Edit and Resend` (that's for Firefox).
2. Paste the following JSON to the `Body` field and click `Send`:
    ```json
    {
      "requests": [
        {
          "indexName": "enterprise-catalog",
          "params": "facetingAfterDistinct=true&facets=%5B%5D&highlightPostTag=%3C%2Fais-highlight-0000000000%3E&highlightPreTag=%3Cais-highlight-0000000000%3E&tagFilters="
        }
      ]
    }
    ```
    Normally, this request would fetch all courses from the index. But the MFE is using our secured Algolia key now.
3. Observe what this query returned. There should be only 2 hits, for the `ABC` and `XYZ` courses, omitting the `PSY` course.

To test the default MFE behavior, try setting the `ALGOLIA_SEARCH_API_KEY` environment variable, re-starting the npm server and testing that the MFE is pulling all courses from the index.