### PR TITLE
fix: blank courses tab issue

### DIFF
--- a/src/components/dashboard/main-content/DashboardMainContent.test.jsx
+++ b/src/components/dashboard/main-content/DashboardMainContent.test.jsx
@@ -8,6 +8,7 @@ import { CourseEnrollmentsContextProvider } from './course-enrollments';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { SubsidyRequestsContext, SUBSIDY_TYPE } from '../../enterprise-subsidy-requests';
 import { renderWithRouter } from '../../../utils/tests';
+import { features } from '../../../config';
 
 jest.mock('../../search/content-highlights/data', () => ({
   useEnterpriseCuration: jest.fn(() => ({
@@ -16,7 +17,11 @@ jest.mock('../../search/content-highlights/data', () => ({
     },
   })),
 }));
-
+jest.mock('../../../config', () => ({
+  features: {
+    FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT: jest.fn(),
+  },
+}));
 const DashboardMainContentWrapper = ({
   initialAppState = { fakeContext: 'foo' },
   initialUserSubsidyState = {},
@@ -80,6 +85,7 @@ describe('DashboardMainContent', () => {
     expect(screen.queryByText('Recommend courses for me')).not.toBeInTheDocument();
   });
   it('renders recommended courses when canOnlyViewHighlightSets false', () => {
+    features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT.mockImplementation(() => true);
     useEnterpriseCuration.mockImplementation(() => ({
       enterpriseCuration: {
         canOnlyViewHighlightSets: false,

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -63,8 +63,8 @@ const CourseEnrollments = ({ children }) => {
     setShowCancelledAssignmentsAlert(hasCancelledAssignments);
     setShowExpiredAssignmentsAlert(hasExpiredAssignments);
   }, [redeemableLearnerCreditPolicies]);
-  const { activeAssigments, hasActiveAssignments } = getActiveAssignments(assignments);
-  const assignedCourses = getTransformedAllocatedAssignments(activeAssigments, slug);
+  const { activeAssignments, hasActiveAssignments } = getActiveAssignments(assignments);
+  const assignedCourses = getTransformedAllocatedAssignments(activeAssignments, slug);
 
   const currentCourseEnrollments = useMemo(
     () => {
@@ -113,10 +113,10 @@ const CourseEnrollments = ({ children }) => {
   const hasCourseEnrollments = Object.values(courseEnrollmentsByStatus).flat().length > 0;
   return (
     <>
-      {showCancelledAssignmentsAlert && (
+      {features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && showCancelledAssignmentsAlert && (
         <CourseAssignmentAlert variant="cancelled" onClose={() => setShowCancelledAssignmentsAlert(false)}> </CourseAssignmentAlert>
       )}
-      {showExpiredAssignmentsAlert && (
+      {features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && showExpiredAssignmentsAlert && (
         <CourseAssignmentAlert variant="expired" onClose={() => setShowExpiredAssignmentsAlert(false)}> </CourseAssignmentAlert>
       )}
       {showMarkCourseCompleteSuccess && (
@@ -134,7 +134,7 @@ const CourseEnrollments = ({ children }) => {
           This allows the parent component to customize what
           gets displayed if the user does not have any course enrollments.
       */}
-      {(!hasCourseEnrollments && !hasActiveAssignments) && children}
+      {(!hasCourseEnrollments && (features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && !hasActiveAssignments)) && children}
       <>
         {features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && (
           <CourseSection

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -43,6 +43,7 @@ jest.mock('../../../config', () => ({
   features: {
     FEATURE_ENABLE_PATHWAY_PROGRESS: jest.fn(),
     FEATURE_ENABLE_MY_CAREER: jest.fn(),
+    FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT: jest.fn(),
   },
 }));
 
@@ -251,6 +252,7 @@ describe('<Dashboard />', () => {
   });
 
   it('renders "Find a course" when search is enabled for the customer', () => {
+    features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT.mockImplementation(() => true);
     renderWithRouter(
       <DashboardWithContext />,
     );


### PR DESCRIPTION
**Description**
***Problem***
After enabling `FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT` on stage it came out that the learner was not able to see his assignments and the course section was blank.

This issue was because of this PR https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/881
Some variable name was used incorrectly which caused the problem.

Solution:
Fix those variables' names and add some additional checks based on the feature flag.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
