### PR TITLE
fix: remove "$0" string from pricing strikeout

### DIFF
--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -51,7 +51,7 @@ const CourseSidebarPrice = () => {
     return (
       <>
         <div>
-          {crossedOutOriginalPrice} <strong>$0</strong>
+          {crossedOutOriginalPrice}
         </div>
         <span className="small">{ASSIGNED_COURSE_MESSAGE}</span>
       </>


### PR DESCRIPTION
Remove extraneous "$0" string from price strikeout. 


|Before|After|
|------|------|
|![Screenshot 2023-12-11 at 12 26 27 PM](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/71999631/f465c575-46da-46b3-8e9c-7e93f72ffb10)| ![Screenshot 2023-12-11 at 12 26 39 PM](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/71999631/45599a43-609a-46c8-9ef6-57644d6148c7)|

[JIRA Ticket](https://2u-internal.atlassian.net/browse/ENT-8094)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
