### PR TITLE
fix: checks for non-assignable policy types to allow course search

### DIFF
--- a/src/components/course/routes/CourseAbout.jsx
+++ b/src/components/course/routes/CourseAbout.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import {
-  Container, MediaQuery, Row, breakpoints,
+  breakpoints, Container, MediaQuery, Row,
 } from '@edx/paragon';
 
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
@@ -36,3 +36,9 @@ export const ASSIGNMENT_TYPES = {
   CANCELLED: 'cancelled',
   ERRORED: 'errored',
 };
+
+export const POLICY_TYPES = {
+  ASSIGNED_CREDIT: 'AssignedLearnerCreditAccessPolicy',
+  PER_LEARNER_CREDIT: 'PerLearnerSpendCreditAccessPolicy',
+  PER_ENROLLMENT_CREDIT: 'PerLearnerEnrollmentCreditAccessPolicy',
+};

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/utils.test.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/utils.test.js
@@ -1,4 +1,4 @@
-import { ASSIGNMENT_TYPES, ENTERPRISE_OFFER_TYPE } from '../constants';
+import { ASSIGNMENT_TYPES, ENTERPRISE_OFFER_TYPE, POLICY_TYPES } from '../constants';
 import {
   getOfferType,
   isDisableCourseSearch,
@@ -336,9 +336,11 @@ describe('transformEnterpriseOffer', () => {
 });
 
 describe('isDisableCourseSearch', () => {
-  it('returns false if hasActiveSubPlan', () => {
-    const inputs = {
+  it.each([
+    {
+      isCourseSearchDisabled: false,
       redeemableLearnerCreditPolicies: [{
+        policyType: POLICY_TYPES.ASSIGNED_CREDIT,
         learnerContentAssignments: {
           state: ASSIGNMENT_TYPES.ALLOCATED,
         },
@@ -352,18 +354,54 @@ describe('isDisableCourseSearch', () => {
       subscriptionLicenses: {
         status: LICENSE_STATUS.ACTIVATED,
       },
-    };
-    const isDisableSearch = isDisableCourseSearch(
-      inputs.redeemableLearnerCreditPolicies,
-      inputs.enterpriseOffers,
-      inputs.subscriptionPlan,
-      inputs.subscriptionLicenses,
-    );
-    expect(isDisableSearch).toEqual(false);
-  });
-  it('returns true if does not have active sub plans and assignments', () => {
-    const inputs = {
+    },
+    {
+      isCourseSearchDisabled: false,
       redeemableLearnerCreditPolicies: [{
+        policyType: POLICY_TYPES.ASSIGNED_CREDIT,
+        learnerContentAssignments: {
+          state: ASSIGNMENT_TYPES.ALLOCATED,
+        },
+      },
+      {
+        policyType: POLICY_TYPES.PER_LEARNER_CREDIT,
+      },
+      {
+        policyType: POLICY_TYPES.PER_ENROLLMENT_CREDIT,
+      }],
+      enterpriseOffers: [{
+        isCurrent: true,
+      }],
+      subscriptionPlan: {
+        isActive: false,
+      },
+      subscriptionLicenses: {
+        status: LICENSE_STATUS.ACTIVATED,
+      },
+    },
+    {
+      isCourseSearchDisabled: false,
+      redeemableLearnerCreditPolicies: [
+        {
+          policyType: POLICY_TYPES.PER_LEARNER_CREDIT,
+        },
+        {
+          policyType: POLICY_TYPES.PER_ENROLLMENT_CREDIT,
+        }],
+      enterpriseOffers: [{
+        isCurrent: true,
+      }],
+      subscriptionPlan: {
+        isActive: false,
+      },
+      subscriptionLicenses: {
+        status: LICENSE_STATUS.ACTIVATED,
+      },
+    },
+    {
+      isCourseSearchDisabled: true,
+      redeemableLearnerCreditPolicies: [{
+        policyType: POLICY_TYPES.ASSIGNED_CREDIT,
         learnerContentAssignments: {
           state: ASSIGNMENT_TYPES.ALLOCATED,
         },
@@ -377,13 +415,44 @@ describe('isDisableCourseSearch', () => {
       subscriptionLicenses: {
         status: LICENSE_STATUS.ACTIVATED,
       },
-    };
+    },
+    {
+      isCourseSearchDisabled: true,
+      redeemableLearnerCreditPolicies: [{
+        policyType: POLICY_TYPES.ASSIGNED_CREDIT,
+        learnerContentAssignments: {
+          state: ASSIGNMENT_TYPES.ACCEPTED,
+        },
+      },
+      {
+        policyType: POLICY_TYPES.ASSIGNED_CREDIT,
+        learnerContentAssignments: {
+          state: ASSIGNMENT_TYPES.ALLOCATED,
+        },
+      }],
+      enterpriseOffers: [{
+        isCurrent: false,
+      }],
+      subscriptionPlan: {
+        isActive: false,
+      },
+      subscriptionLicenses: {
+        status: LICENSE_STATUS.ACTIVATED,
+      },
+    },
+  ])('isCourseSearchDisabled - (%p), (%s)', ({
+    isCourseSearchDisabled,
+    redeemableLearnerCreditPolicies,
+    enterpriseOffers,
+    subscriptionPlan,
+    subscriptionLicenses,
+  }) => {
     const isDisableSearch = isDisableCourseSearch(
-      inputs.redeemableLearnerCreditPolicies,
-      inputs.enterpriseOffers,
-      inputs.subscriptionPlan,
-      inputs.subscriptionLicenses,
+      redeemableLearnerCreditPolicies,
+      enterpriseOffers,
+      subscriptionPlan,
+      subscriptionLicenses,
     );
-    expect(isDisableSearch).toEqual(true);
+    expect(isDisableSearch).toEqual(isCourseSearchDisabled);
   });
 });

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/utils.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/utils.js
@@ -6,6 +6,7 @@ import {
   ENTERPRISE_OFFER_NO_BALANCE_THRESHOLD_DOLLARS,
   ENTERPRISE_OFFER_NO_BALANCE_USER_THRESHOLD_DOLLARS,
   ENTERPRISE_OFFER_TYPE,
+  POLICY_TYPES,
 } from './constants';
 
 import { LICENSE_STATUS } from '../../data/constants';
@@ -122,14 +123,21 @@ export const isDisableCourseSearch = (
   subscriptionPlan,
   subscriptionLicense,
 ) => {
+  const nonAssignablePolicyTypes = redeemableLearnerCreditPolicies.filter(
+    item => item.policyType !== POLICY_TYPES.ASSIGNED_CREDIT,
+  );
+  if (nonAssignablePolicyTypes.length > 0) {
+    return false;
+  }
+
   const hasActiveSubPlan = subscriptionPlan?.isActive && subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED;
   const activeOffers = enterpriseOffers?.filter(item => item?.isCurrent);
 
   const assignments = redeemableLearnerCreditPolicies?.flatMap(item => item?.learnerContentAssignments || []);
-  const allocatedAndAcceptedAssignments = assignments?.filter(item => item?.state === ASSIGNMENT_TYPES.ALLOCATED
+  const allocatedOrAcceptedAssignments = assignments?.filter(item => item?.state === ASSIGNMENT_TYPES.ALLOCATED
     || item?.state === ASSIGNMENT_TYPES.ACCEPTED);
 
-  if (allocatedAndAcceptedAssignments?.length === 0) {
+  if (allocatedOrAcceptedAssignments?.length === 0) {
     return false;
   }
 
@@ -137,5 +145,5 @@ export const isDisableCourseSearch = (
     return false;
   }
 
-  return activeOffers?.length > 0 || allocatedAndAcceptedAssignments?.length > 0;
+  return activeOffers?.length > 0 || allocatedOrAcceptedAssignments?.length > 0;
 };

--- a/src/components/my-career/tests/CategoryCard.test.jsx
+++ b/src/components/my-career/tests/CategoryCard.test.jsx
@@ -9,6 +9,7 @@ import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import { SUBSIDY_TYPE } from '../../enterprise-subsidy-requests/constants';
 import { renderWithRouter } from '../../../utils/tests';
 import CategoryCard from '../CategoryCard';
+import { POLICY_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
 
 jest.mock('@edx/frontend-platform/i18n', () => ({
   ...jest.requireActual('@edx/frontend-platform/i18n'),
@@ -90,6 +91,9 @@ const expiringSubscriptionUserSubsidyState = {
   },
   couponCodes: [],
   showExpirationNotifications: false,
+  redeemableLearnerCreditPolicies: [{
+    policyType: POLICY_TYPES.PER_LEARNER_CREDIT,
+  }],
 };
 
 const CategoryCardWithContext = () => (

--- a/src/components/my-career/tests/MyCareerTab.test.jsx
+++ b/src/components/my-career/tests/MyCareerTab.test.jsx
@@ -12,6 +12,7 @@ import * as hooks from '../data/hooks';
 
 import { renderWithRouter } from '../../../utils/tests';
 import MyCareerTab from '../MyCareerTab';
+import { POLICY_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
 
 jest.mock('@edx/frontend-platform/i18n', () => ({
   ...jest.requireActual('@edx/frontend-platform/i18n'),
@@ -206,6 +207,9 @@ const expiringSubscriptionUserSubsidyState = {
   },
   showExpirationNotifications: false,
   couponCodes: defaultCouponCodesState,
+  redeemableLearnerCreditPolicies: [{
+    policyType: POLICY_TYPES.PER_LEARNER_CREDIT,
+  }],
 };
 
 const MyCareerTabWithContext = ({

--- a/src/components/my-career/tests/VisualizeCareer.test.jsx
+++ b/src/components/my-career/tests/VisualizeCareer.test.jsx
@@ -10,6 +10,7 @@ import { renderWithRouter } from '../../../utils/tests';
 import VisualizeCareer from '../VisualizeCareer';
 import { SUBSIDY_TYPE, SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
+import { POLICY_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
 
 jest.mock('@edx/frontend-platform/i18n', () => ({
   ...jest.requireActual('@edx/frontend-platform/i18n'),
@@ -176,6 +177,9 @@ const expiringSubscriptionUserSubsidyState = {
   },
   showExpirationNotifications: false,
   couponCodes: defaultCouponCodesState,
+  redeemableLearnerCreditPolicies: [{
+    policyType: POLICY_TYPES.PER_LEARNER_CREDIT,
+  }],
 };
 
 const defaultSearchContext = {


### PR DESCRIPTION
Checks policy types within `redeemableLearnerCreditPolicies` for whether a non-assignable redeemable policy exist, if so, return `false` for `isDisableCourseSearch`.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
