### PR TITLE
fix: invalidate redeemable policies query on enrollment

### DIFF
--- a/src/components/course/course-header/data/hooks/useRedemptionStatus.js
+++ b/src/components/course/course-header/data/hooks/useRedemptionStatus.js
@@ -17,6 +17,8 @@ const useRedemptionStatus = () => {
 
   const handleRedeemSuccess = (transaction) => {
     queryClient.invalidateQueries({ queryKey: ['policy'] });
+    queryClient.invalidateQueries({ queryKey: ['redeemablePolicies'] });
+
     setRedemptionStatus('success');
 
     // redirect to courseware

--- a/src/components/course/course-header/data/hooks/useRedemptionStatus.js
+++ b/src/components/course/course-header/data/hooks/useRedemptionStatus.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { enterpriseUserSubsidyQueryKeys } from '../../../../enterprise-user-subsidy/data/constants';
 
 /**
  * Acts as a state machine for the redemption status, with side effects for
@@ -16,8 +17,7 @@ const useRedemptionStatus = () => {
   };
 
   const handleRedeemSuccess = (transaction) => {
-    queryClient.invalidateQueries({ queryKey: ['policy'] });
-    queryClient.invalidateQueries({ queryKey: ['redeemablePolicies'] });
+    queryClient.invalidateQueries({ queryKey: enterpriseUserSubsidyQueryKeys.policy() });
 
     setRedemptionStatus('success');
 

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -28,12 +28,11 @@ import {
   findEnterpriseOfferForCourse,
   getCourseRunPrice,
   getCourseTypeConfig,
+  getMissingApplicableSubsidyReason,
   getSubscriptionDisabledEnrollmentReasonType,
   getSubsidyToApplyForCourse,
-  getMissingApplicableSubsidyReason,
 } from '../utils';
-import { SubsidyRequestsContext } from '../../../enterprise-subsidy-requests/SubsidyRequestsContextProvider';
-import { SUBSIDY_REQUEST_STATE, SUBSIDY_TYPE } from '../../../enterprise-subsidy-requests/constants';
+import { SUBSIDY_REQUEST_STATE, SUBSIDY_TYPE, SubsidyRequestsContext } from '../../../enterprise-subsidy-requests';
 import {
   COUPON_CODE_SUBSIDY_TYPE,
   DISABLED_ENROLL_REASON_TYPES,
@@ -59,6 +58,7 @@ import {
 } from '../../tests/constants';
 import * as optimizelyUtils from '../../../../utils/optimizely';
 import { CourseContext } from '../../CourseContextProvider';
+import { enterpriseUserSubsidyQueryKeys } from '../../../enterprise-user-subsidy/data/constants';
 
 const oldGlobalLocation = global.location;
 
@@ -911,7 +911,7 @@ describe('useCheckSubsidyAccessPolicyRedeemability', () => {
     expect(result.current.isInitialLoading).toBeDefined();
     expect(useQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        queryKey: ['policy', baseArgs.enterpriseUuid, 'can-redeem', {
+        queryKey: [...enterpriseUserSubsidyQueryKeys.policy(), baseArgs.enterpriseUuid, 'can-redeem', {
           activeCourseRunKey: undefined,
           courseRunKeys: [],
           lmsUserId: mockLmsUserId,
@@ -978,7 +978,7 @@ describe('useCheckSubsidyAccessPolicyRedeemability', () => {
       expect(result.current.data.hasSuccessfulRedemption).toBeFalsy();
     }
 
-    const expectQueryKey = ['policy', baseArgs.enterpriseUuid, 'can-redeem', {
+    const expectQueryKey = [...enterpriseUserSubsidyQueryKeys.policy(), baseArgs.enterpriseUuid, 'can-redeem', {
       activeCourseRunKey: argsWithCourseRunKeys.courseRunKeys[0],
       lmsUserId: mockLmsUserId,
       courseRunKeys: argsWithCourseRunKeys.courseRunKeys,

--- a/src/components/course/routes/ExternalCourseEnrollment.jsx
+++ b/src/components/course/routes/ExternalCourseEnrollment.jsx
@@ -7,7 +7,6 @@ import { CheckCircle } from '@edx/paragon/icons';
 
 import { getConfig } from '@edx/frontend-platform/config';
 import { AppContext } from '@edx/frontend-platform/react';
-import { useQueryClient } from '@tanstack/react-query';
 import { isDuplicateExternalCourseOrder } from '../../executive-education-2u/data';
 import { CourseContext } from '../CourseContextProvider';
 import CourseSummaryCard from '../../executive-education-2u/components/CourseSummaryCard';
@@ -21,7 +20,6 @@ import { features } from '../../../config';
 const ExternalCourseEnrollment = () => {
   const config = getConfig();
   const history = useHistory();
-  const queryClient = useQueryClient();
   const {
     state: {
       activeCourseRun,
@@ -65,7 +63,6 @@ const ExternalCourseEnrollment = () => {
   }, [externalCourseFormSubmissionError, containerRef]);
 
   const handleCheckoutSuccess = () => {
-    // invalidate redeemable policies to refresh dashboard card
     history.push('enroll/complete');
   };
 

--- a/src/components/course/routes/ExternalCourseEnrollment.jsx
+++ b/src/components/course/routes/ExternalCourseEnrollment.jsx
@@ -1,12 +1,13 @@
 import React, { useContext, useEffect, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
-  Alert, Button, Container, Col, Hyperlink, Row,
+  Alert, Button, Col, Container, Hyperlink, Row,
 } from '@edx/paragon';
 import { CheckCircle } from '@edx/paragon/icons';
 
 import { getConfig } from '@edx/frontend-platform/config';
 import { AppContext } from '@edx/frontend-platform/react';
+import { useQueryClient } from '@tanstack/react-query';
 import { isDuplicateExternalCourseOrder } from '../../executive-education-2u/data';
 import { CourseContext } from '../CourseContextProvider';
 import CourseSummaryCard from '../../executive-education-2u/components/CourseSummaryCard';
@@ -20,6 +21,7 @@ import { features } from '../../../config';
 const ExternalCourseEnrollment = () => {
   const config = getConfig();
   const history = useHistory();
+  const queryClient = useQueryClient();
   const {
     state: {
       activeCourseRun,
@@ -63,6 +65,7 @@ const ExternalCourseEnrollment = () => {
   }, [externalCourseFormSubmissionError, containerRef]);
 
   const handleCheckoutSuccess = () => {
+    // invalidate redeemable policies to refresh dashboard card
     history.push('enroll/complete');
   };
 

--- a/src/components/enterprise-user-subsidy/data/constants.js
+++ b/src/components/enterprise-user-subsidy/data/constants.js
@@ -10,7 +10,6 @@ export const enterpriseUserSubsidyQueryKeys = {
   // Namespace for all user subsidy query keys
   all: ['user-subsidy'],
   policy: () => [
-    // eslint-disable-next-line no-use-before-define
     ...enterpriseUserSubsidyQueryKeys.all,
     'policy',
   ],

--- a/src/components/enterprise-user-subsidy/data/constants.js
+++ b/src/components/enterprise-user-subsidy/data/constants.js
@@ -5,3 +5,7 @@ export const LICENSE_STATUS = {
 };
 
 export const LOADING_SCREEN_READER_TEXT = 'loading your edX benefits from your organization';
+
+export const enterpriseUserSubsidyQueryKeys = {
+  redeemablePolicies: (enterpriseId, userId) => ['redeemablePolicies', enterpriseId, userId],
+};

--- a/src/components/enterprise-user-subsidy/data/constants.js
+++ b/src/components/enterprise-user-subsidy/data/constants.js
@@ -7,5 +7,32 @@ export const LICENSE_STATUS = {
 export const LOADING_SCREEN_READER_TEXT = 'loading your edX benefits from your organization';
 
 export const enterpriseUserSubsidyQueryKeys = {
-  redeemablePolicies: (enterpriseId, userId) => ['redeemablePolicies', enterpriseId, userId],
+  // Namespace for all user subsidy query keys
+  all: ['user-subsidy'],
+  policy: () => [
+    // eslint-disable-next-line no-use-before-define
+    ...enterpriseUserSubsidyQueryKeys.all,
+    'policy',
+  ],
+  // Used with query against `can-redeem` API endpoint
+  coursePolicyRedeemability: ({
+    enterpriseId, lmsUserId, courseRunKeys, activeCourseRunKey,
+  }) => [
+    ...enterpriseUserSubsidyQueryKeys.policy(),
+    enterpriseId,
+    'can-redeem',
+    { lmsUserId, courseRunKeys, activeCourseRunKey },
+  ],
+  // Used with query to fetch user's redeemable subsidy access policies
+  redeemablePolicies: (enterpriseId, userId) => [
+    ...enterpriseUserSubsidyQueryKeys.policy(),
+    'redeemable-policies',
+    enterpriseId,
+    userId],
+  // Used with query for polling pending policy transactions after initial policy redemption
+  pollPendingPolicyTransaction: (transaction) => [
+    ...enterpriseUserSubsidyQueryKeys.policy(),
+    'transactions',
+    transaction,
+  ],
 };

--- a/src/components/enterprise-user-subsidy/data/hooks/hooks.js
+++ b/src/components/enterprise-user-subsidy/data/hooks/hooks.js
@@ -1,5 +1,5 @@
 import {
-  useState, useEffect, useReducer, useCallback, useMemo,
+  useCallback, useEffect, useMemo, useReducer, useState,
 } from 'react';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
@@ -9,13 +9,13 @@ import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { fetchCouponCodeAssignments } from '../../coupons';
 import couponCodesReducer, { initialCouponCodesState } from '../../coupons/data/reducer';
 
-import { LICENSE_STATUS } from '../constants';
+import { enterpriseUserSubsidyQueryKeys, LICENSE_STATUS } from '../constants';
 import {
-  fetchSubscriptionLicensesForUser,
+  activateLicense,
   fetchCustomerAgreementData,
   fetchRedeemableLearnerCreditPolicies,
+  fetchSubscriptionLicensesForUser,
   requestAutoAppliedLicense,
-  activateLicense,
 } from '../service';
 import { features } from '../../../../config';
 import { fetchCouponsOverview } from '../../coupons/data/service';
@@ -249,8 +249,8 @@ export function useCustomerAgreementData(enterpriseId) {
 }
 
 const getRedeemablePoliciesData = async ({ queryKey }) => {
-  const enterpriseId = queryKey[1];
-  const userID = queryKey[2];
+  const enterpriseId = queryKey[3];
+  const userID = queryKey[4];
   const response = await fetchRedeemableLearnerCreditPolicies(enterpriseId, userID);
   const redeemablePolicies = camelCaseObject(transformRedeemablePoliciesData(response.data));
   const learnerContentAssignments = getActiveAssignments(
@@ -265,7 +265,8 @@ const getRedeemablePoliciesData = async ({ queryKey }) => {
 
 export function useRedeemableLearnerCreditPolicies(enterpriseId, userID) {
   return useQuery({
-    queryKey: ['redeemablePolicies', enterpriseId, userID],
+    queryKey: enterpriseUserSubsidyQueryKeys.redeemablePolicies(enterpriseId, userID),
+    // queryKey: ['redeemablePolicies', enterpriseId, userID],
     queryFn: getRedeemablePoliciesData,
     onError: (error) => {
       logError(error);

--- a/src/components/enterprise-user-subsidy/data/hooks/hooks.js
+++ b/src/components/enterprise-user-subsidy/data/hooks/hooks.js
@@ -266,7 +266,6 @@ const getRedeemablePoliciesData = async ({ queryKey }) => {
 export function useRedeemableLearnerCreditPolicies(enterpriseId, userID) {
   return useQuery({
     queryKey: enterpriseUserSubsidyQueryKeys.redeemablePolicies(enterpriseId, userID),
-    // queryKey: ['redeemablePolicies', enterpriseId, userID],
     queryFn: getRedeemablePoliciesData,
     onError: (error) => {
       logError(error);

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
@@ -91,7 +91,7 @@ const ExecutiveEducation2UPage = () => {
     return {};
   }, [contentMetadata]);
 
-  const handleCheckoutSuccess = async () => {
+  const handleCheckoutSuccess = () => {
     history.push({
       pathname: `/${enterpriseConfig.slug}/executive-education-2u/enrollment-completed`,
       state: {

--- a/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UPage.jsx
@@ -1,9 +1,7 @@
-import React, {
-  useContext, useEffect, useMemo,
-} from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import { Helmet } from 'react-helmet';
 import {
-  Container, Row, Col, Skeleton,
+  Col, Container, Row, Skeleton,
 } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 import { logError } from '@edx/frontend-platform/logging';
@@ -11,10 +9,7 @@ import { useHistory } from 'react-router-dom';
 
 import NotFoundPage from '../NotFoundPage';
 import UserEnrollmentForm from './UserEnrollmentForm';
-import {
-  useActiveQueryParams,
-  useExecutiveEducation2UContentMetadata,
-} from './data';
+import { useActiveQueryParams, useExecutiveEducation2UContentMetadata } from './data';
 import ExecutiveEducation2UError from './ExecutiveEducation2UError';
 import CourseSummaryCard from './components/CourseSummaryCard';
 import RegistrationSummaryCard from './components/RegistrationSummaryCard';
@@ -96,7 +91,7 @@ const ExecutiveEducation2UPage = () => {
     return {};
   }, [contentMetadata]);
 
-  const handleCheckoutSuccess = () => {
+  const handleCheckoutSuccess = async () => {
     history.push({
       pathname: `/${enterpriseConfig.slug}/executive-education-2u/enrollment-completed`,
       state: {

--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -14,10 +14,12 @@ import { sendEnterpriseTrackEvent, sendEnterpriseTrackEventWithDelay } from '@ed
 import dayjs from 'dayjs';
 import reactStringReplace from 'react-string-replace';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { checkoutExecutiveEducation2U, isDuplicateExternalCourseOrder, toISOStringWithoutMilliseconds } from './data';
 import { useStatefulEnroll } from '../stateful-enroll/data';
 import { LEARNER_CREDIT_SUBSIDY_TYPE } from '../course/data/constants';
 import { CourseContext } from '../course/CourseContextProvider';
+import { enterpriseUserSubsidyQueryKeys } from '../enterprise-user-subsidy/data/constants';
 
 export const formValidationMessages = {
   firstNameRequired: 'First name is required',
@@ -39,6 +41,7 @@ const UserEnrollmentForm = ({
   userSubsidyApplicableToCourse,
 }) => {
   const config = getConfig();
+  const queryClient = useQueryClient();
   const {
     enterpriseConfig: { uuid: enterpriseId, enableDataSharingConsent },
     authenticatedUser: { id: userId },
@@ -64,6 +67,9 @@ const UserEnrollmentForm = ({
       enterpriseId,
       'edx.ui.enterprise.learner_portal.executive_education.checkout_form.submitted',
     );
+    await queryClient.invalidateQueries({
+      queryKey: enterpriseUserSubsidyQueryKeys.redeemablePolicies(enterpriseId, userId),
+    });
     onCheckoutSuccess(newTransaction);
   };
 

--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -68,7 +68,7 @@ const UserEnrollmentForm = ({
       'edx.ui.enterprise.learner_portal.executive_education.checkout_form.submitted',
     );
     await queryClient.invalidateQueries({
-      queryKey: enterpriseUserSubsidyQueryKeys.redeemablePolicies(enterpriseId, userId),
+      queryKey: enterpriseUserSubsidyQueryKeys.policy(),
     });
     onCheckoutSuccess(newTransaction);
   };

--- a/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  screen, render, waitFor, act,
+  act, render, screen, waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
@@ -9,6 +9,7 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { snakeCaseObject } from '@edx/frontend-platform/utils';
 import dayjs from 'dayjs';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import UserEnrollmentForm, { formValidationMessages } from './UserEnrollmentForm';
 import { checkoutExecutiveEducation2U, toISOStringWithoutMilliseconds } from './data';
 import { ENTERPRISE_OFFER_SUBSIDY_TYPE, LEARNER_CREDIT_SUBSIDY_TYPE } from '../course/data/constants';
@@ -67,6 +68,8 @@ const mockUserSubsidyApplicableToCourse = {
   subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE,
 };
 
+const queryClient = new QueryClient();
+
 const UserEnrollmentFormWrapper = ({
   appContextValue = initialAppContextValue,
   enterpriseId = mockEnterpriseId,
@@ -83,17 +86,19 @@ const UserEnrollmentFormWrapper = ({
   },
 }) => (
   <IntlProvider locale="en">
-    <AppContext.Provider value={appContextValue}>
-      <CourseContext.Provider value={courseContextValue}>
-        <UserEnrollmentForm
-          enterpriseId={enterpriseId}
-          productSKU={productSKU}
-          onCheckoutSuccess={onCheckoutSuccess}
-          activeCourseRun={activeCourseRun}
-          userSubsidyApplicableToCourse={userSubsidyApplicableToCourse}
-        />
-      </CourseContext.Provider>
-    </AppContext.Provider>
+    <QueryClientProvider client={queryClient}>
+      <AppContext.Provider value={appContextValue}>
+        <CourseContext.Provider value={courseContextValue}>
+          <UserEnrollmentForm
+            enterpriseId={enterpriseId}
+            productSKU={productSKU}
+            onCheckoutSuccess={onCheckoutSuccess}
+            activeCourseRun={activeCourseRun}
+            userSubsidyApplicableToCourse={userSubsidyApplicableToCourse}
+          />
+        </CourseContext.Provider>
+      </AppContext.Provider>
+    </QueryClientProvider>
   </IntlProvider>
 );
 

--- a/src/components/stateful-enroll/data/hooks/useStatefulEnroll.js
+++ b/src/components/stateful-enroll/data/hooks/useStatefulEnroll.js
@@ -2,13 +2,11 @@ import { useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { logError } from '@edx/frontend-platform/logging';
-import { useTrackSearchConversionClickHandler, useOptimizelyEnrollmentClickHandler } from '../../../course/data/hooks';
+import { useOptimizelyEnrollmentClickHandler, useTrackSearchConversionClickHandler } from '../../../course/data/hooks';
 import { EVENT_NAMES } from '../../../course/data/constants';
 
-import {
-  submitRedemptionRequest,
-  retrieveTransactionStatus,
-} from '../service';
+import { retrieveTransactionStatus, submitRedemptionRequest } from '../service';
+import { enterpriseUserSubsidyQueryKeys } from '../../../enterprise-user-subsidy/data/constants';
 
 const shouldPollTransactionState = (response) => {
   const transactionState = response?.state;
@@ -23,7 +21,7 @@ const getRefetchInterval = (response) => {
 };
 
 const checkTransactionStatus = async ({ queryKey }) => {
-  const transaction = queryKey[2];
+  const transaction = queryKey[3];
   const { transactionStatusApiUrl } = transaction;
   return retrieveTransactionStatus({ transactionStatusApiUrl });
 };
@@ -72,7 +70,7 @@ const useStatefulEnroll = ({
   };
 
   useQuery({
-    queryKey: ['policy', 'transactions', transaction],
+    queryKey: enterpriseUserSubsidyQueryKeys.pollPendingPolicyTransaction(transaction),
     enabled: shouldPollTransactionState(transaction),
     queryFn: checkTransactionStatus,
     refetchInterval: getRefetchInterval,

--- a/src/components/stateful-enroll/data/hooks/useStatefulEnroll.test.js
+++ b/src/components/stateful-enroll/data/hooks/useStatefulEnroll.test.js
@@ -1,14 +1,12 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
 import useStatefulEnroll from './useStatefulEnroll';
 import * as hooks from '../../../course/data/hooks';
 import { EVENT_NAMES } from '../../../course/data/constants';
 
-import {
-  submitRedemptionRequest,
-  retrieveTransactionStatus,
-} from '../service';
+import { retrieveTransactionStatus, submitRedemptionRequest } from '../service';
+import { enterpriseUserSubsidyQueryKeys } from '../../../enterprise-user-subsidy/data/constants';
 
 const mockMutateAsync = jest.fn();
 jest.mock('@tanstack/react-query', () => ({
@@ -161,7 +159,7 @@ describe('useStatefulEnroll', () => {
 
     expect(useQuery).toHaveBeenCalledTimes(2);
     expect(useQuery).toHaveBeenCalledWith({
-      queryKey: ['policy', 'transactions', mockTransaction],
+      queryKey: [...enterpriseUserSubsidyQueryKeys.policy(), 'transactions', mockTransaction],
       queryFn: expect.any(Function),
       refetchInterval: expect.any(Function),
       onSuccess: expect.any(Function),
@@ -192,7 +190,7 @@ describe('useStatefulEnroll', () => {
     expect(useQuery).toHaveBeenCalledTimes(1);
     expect(useQuery).toHaveBeenCalledWith({
       // undefined here is expected, as we're testing before the redemption mutation has resolved
-      queryKey: ['policy', 'transactions', undefined],
+      queryKey: [...enterpriseUserSubsidyQueryKeys.policy(), 'transactions', undefined],
       queryFn: expect.any(Function),
       refetchInterval: expect.any(Function),
       onSuccess: expect.any(Function),


### PR DESCRIPTION
Invalidates the `redeemablePolicies` query key on success of an external enrollment, and on successful redemption of a course run. 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
