### PR TITLE
fix: ensure fetchEnterpriseCuration is only called if an enterpriseUUID is present

### DIFF
--- a/src/components/search/content-highlights/data/hooks.js
+++ b/src/components/search/content-highlights/data/hooks.js
@@ -52,6 +52,10 @@ export const useEnterpriseCuration = (enterpriseUUID) => {
   const [fetchError, setFetchError] = useState();
 
   useEffect(() => {
+    if (!enterpriseUUID) {
+      return;
+    }
+
     const fetchEnterpriseCuration = async () => {
       try {
         setIsLoading(true);


### PR DESCRIPTION


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
