### PR TITLE
fix: ensure subs takes precedence over policies

### DIFF
--- a/src/components/course/course-header/CourseRunCards.jsx
+++ b/src/components/course/course-header/CourseRunCards.jsx
@@ -4,6 +4,7 @@ import { CardGrid } from '@edx/paragon';
 import { CourseContext } from '../CourseContextProvider';
 import CourseRunCard from './CourseRunCard';
 import DeprecatedCourseRunCard from './deprecated/CourseRunCard';
+import { LEARNER_CREDIT_SUBSIDY_TYPE } from '../data/constants';
 
 /**
  * Displays a grid of `CourseRunCard` components, where each `CourseRunCard` represents
@@ -19,7 +20,7 @@ const CourseRunCards = () => {
       catalog: { catalogList },
     },
     missingUserSubsidyReason,
-    redeemabilityPerContentKey,
+    userSubsidyApplicableToCourse,
   } = useContext(CourseContext);
 
   return (
@@ -28,18 +29,20 @@ const CourseRunCards = () => {
       hasEqualColumnHeights={false}
     >
       {availableCourseRuns.map((courseRun) => {
-        const redeemabilityForContentKey = redeemabilityPerContentKey?.find(r => r.contentKey === courseRun.key);
-        const redeemableSubsidyAccessPolicy = redeemabilityForContentKey?.redeemableSubsidyAccessPolicy;
+        const hasRedeemablePolicy = userSubsidyApplicableToCourse?.subsidyType === LEARNER_CREDIT_SUBSIDY_TYPE;
 
-        if (redeemableSubsidyAccessPolicy || missingUserSubsidyReason?.userMessage) {
+        // Render the newer `CourseRunCard` component when the user's
+        // subsidy (if any) is a policy OR if no disabled enroll reason
+        // was provided by the `can-redeem` API.
+        if (hasRedeemablePolicy || missingUserSubsidyReason?.userMessage) {
           return (
             <CourseRunCard
               key={courseRun.uuid}
               courseRun={courseRun}
-              subsidyAccessPolicy={redeemableSubsidyAccessPolicy}
             />
           );
         }
+
         return (
           <DeprecatedCourseRunCard
             key={courseRun.uuid}

--- a/src/components/course/course-header/tests/CourseRunCards.test.jsx
+++ b/src/components/course/course-header/tests/CourseRunCards.test.jsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom/extend-expect';
 
 import CourseRunCards from '../CourseRunCards';
 import { CourseContext } from '../../CourseContextProvider';
+import { LEARNER_CREDIT_SUBSIDY_TYPE } from '../../data/constants';
 
 jest.mock('../CourseRunCard', () => jest.fn((props) => {
   const MockName = 'course-run-card';
@@ -30,7 +31,7 @@ const defaultCourseContext = {
   },
   subsidyRequestCatalogsApplicableToCourse: [],
   missingUserSubsidyReason: undefined,
-  redeemabilityPerContentKey: [],
+  userSubsidyApplicableToCourse: undefined,
 };
 
 const CourseRunCardsWrapper = ({ courseContexValue = defaultCourseContext }) => (
@@ -43,22 +44,32 @@ describe('<CourseRunCardStatus />', () => {
   test('renders deprecated course run card', () => {
     render(<CourseRunCardsWrapper />);
     expect(screen.getByTestId('deprecated-course-run-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('course-run-card')).not.toBeInTheDocument();
   });
 
-  test('renders non-deprecated course run card', () => {
+  test('renders non-deprecated course run card with an applicable policy', () => {
     render(<CourseRunCardsWrapper
       courseContexValue={{
         ...defaultCourseContext,
-        redeemabilityPerContentKey: [{
-          contentKey: mockCourseRunKey,
-          redeemableSubsidyAccessPolicy: {
-            uuid: 'subsidy-access-policy-uuid',
-            canRedeem: true,
-            policyRedemptionUrl: 'http://redeem.url',
-          },
-        }],
+        userSubsidyApplicableToCourse: {
+          subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE,
+        },
       }}
     />);
     expect(screen.getByTestId('course-run-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('deprecated-course-run-card')).not.toBeInTheDocument();
+  });
+
+  test('renders non-deprecated course run card with a disabled enroll reason', () => {
+    render(<CourseRunCardsWrapper
+      courseContexValue={{
+        ...defaultCourseContext,
+        missingUserSubsidyReason: {
+          userMessage: 'You cannot enroll in this course.',
+        },
+      }}
+    />);
+    expect(screen.getByTestId('course-run-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('deprecated-course-run-card')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Description

Ticket: [ENT-8143](https://2u-internal.atlassian.net/browse/ENT-8143)

Refactors to make use of `userSubsidyApplicableToCourse` in the `CourseRunCards` component to ensure the business logic for the "hierarchy of bad" matrix (i.e, subs/code > auto-applied policies). The non-deprecated `CourseRunCard` component is also rendered if `userSubsidyApplicableToCourse` represents an assignable budget.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
