### PR TITLE
fix: removes duplicate redirect

### DIFF
--- a/src/components/course/routes/CoursePageRoutes.jsx
+++ b/src/components/course/routes/CoursePageRoutes.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { Switch, useRouteMatch } from 'react-router-dom';
 import { PageRoute } from '@edx/frontend-platform/react';
-
-import CourseAbout from './CourseAbout';
 import ExternalCourseEnrollment from './ExternalCourseEnrollment';
 import ExternalCourseEnrollmentConfirmation from './ExternalCourseEnrollmentConfirmation';
+import CourseAbout from './CourseAbout';
 import NotFoundPage from '../../NotFoundPage';
 
 const CoursePageRoutes = () => {

--- a/src/components/course/routes/ExternalCourseEnrollment.jsx
+++ b/src/components/course/routes/ExternalCourseEnrollment.jsx
@@ -69,10 +69,10 @@ const ExternalCourseEnrollment = () => {
 
   useEffect(() => {
     // Once a redemption has successfully completed and the can-redeem query has been invalidated or
-    // a user attempts to navigate directly to :slug/executive-education-2u/course/:courseKey/enroll,
+    // a user attempts to navigate directly to :slug/:courseType/course/:courseKey/enroll,
     //  it will run this conditional and perform the redirect
     if (hasSuccessfulRedemption) {
-      history.push({ pathname: completeEnrollmentUrl });
+      history.push(completeEnrollmentUrl);
     }
   }, [completeEnrollmentUrl, course.key, hasSuccessfulRedemption, history, routeMatch.path, slug]);
 

--- a/src/components/course/routes/ExternalCourseEnrollment.jsx
+++ b/src/components/course/routes/ExternalCourseEnrollment.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useRef } from 'react';
-import { useHistory } from 'react-router-dom';
+import { generatePath, useHistory, useRouteMatch } from 'react-router-dom';
 import {
   Alert, Button, Col, Container, Hyperlink, Row,
 } from '@edx/paragon';
@@ -20,6 +20,7 @@ import { features } from '../../../config';
 const ExternalCourseEnrollment = () => {
   const config = getConfig();
   const history = useHistory();
+  const routeMatch = useRouteMatch();
   const {
     state: {
       activeCourseRun,
@@ -31,9 +32,13 @@ const ExternalCourseEnrollment = () => {
     externalCourseFormSubmissionError,
   } = useContext(CourseContext);
   const {
-    enterpriseConfig: { authOrgId },
+    enterpriseConfig: { authOrgId, slug },
   } = useContext(AppContext);
   const { redeemableLearnerCreditPolicies } = useContext(UserSubsidyContext);
+  const completeEnrollmentUrl = generatePath(
+      `${routeMatch.path}/complete`,
+      { enterpriseSlug: slug, courseType: course.courseType, courseKey: course.key },
+  );
   const isCourseAssigned = useIsCourseAssigned(redeemableLearnerCreditPolicies?.learnerContentAssignments, course?.key);
 
   const courseMetadata = useMinimalCourseMetadata();
@@ -62,15 +67,14 @@ const ExternalCourseEnrollment = () => {
     }
   }, [externalCourseFormSubmissionError, containerRef]);
 
-  const handleCheckoutSuccess = () => {
-    history.push('enroll/complete');
-  };
-
   useEffect(() => {
+    // Once a redemption has successfully completed and the can-redeem query has been invalidated or
+    // a user attempts to navigate directly to :slug/executive-education-2u/course/:courseKey/enroll,
+    //  it will run this conditional and perform the redirect
     if (hasSuccessfulRedemption) {
-      history.push('enroll/complete');
+      history.push({ pathname: completeEnrollmentUrl });
     }
-  }, [hasSuccessfulRedemption, history]);
+  }, [completeEnrollmentUrl, course.key, hasSuccessfulRedemption, history, routeMatch.path, slug]);
 
   return (
     <div className="fill-vertical-space page-light-bg">
@@ -120,7 +124,6 @@ const ExternalCourseEnrollment = () => {
               <RegistrationSummaryCard priceDetails={courseMetadata.priceDetails} />
               <UserEnrollmentForm
                 productSKU={courseEntitlementProductSku}
-                onCheckoutSuccess={handleCheckoutSuccess}
                 activeCourseRun={activeCourseRun}
                 userSubsidyApplicableToCourse={userSubsidyApplicableToCourse}
               />

--- a/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
+++ b/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
@@ -120,13 +120,9 @@ describe('ExternalCourseEnrollment', () => {
     expect(screen.getByTestId('user-enrollment-form')).toBeInTheDocument();
     expect(UserEnrollmentForm.mock.calls[0][0]).toEqual(
       expect.objectContaining({
-        onCheckoutSuccess: expect.any(Function),
         productSKU: 'test-sku',
       }),
     );
-    UserEnrollmentForm.mock.calls[0][0].onCheckoutSuccess();
-    expect(mockHistoryPush).toHaveBeenCalledTimes(1);
-    expect(mockHistoryPush).toHaveBeenCalledWith('enroll/complete');
   });
 
   it.each([

--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -70,7 +70,9 @@ const UserEnrollmentForm = ({
     await queryClient.invalidateQueries({
       queryKey: enterpriseUserSubsidyQueryKeys.policy(),
     });
-    onCheckoutSuccess(newTransaction);
+    if (onCheckoutSuccess) {
+      onCheckoutSuccess(newTransaction);
+    }
   };
 
   const { redeem } = useStatefulEnroll({
@@ -394,7 +396,7 @@ const UserEnrollmentForm = ({
 UserEnrollmentForm.propTypes = {
   className: PropTypes.string,
   productSKU: PropTypes.string.isRequired,
-  onCheckoutSuccess: PropTypes.func.isRequired,
+  onCheckoutSuccess: PropTypes.func,
   activeCourseRun: PropTypes.shape({
     key: PropTypes.string.isRequired,
   }).isRequired,
@@ -406,6 +408,7 @@ UserEnrollmentForm.propTypes = {
 UserEnrollmentForm.defaultProps = {
   className: undefined,
   userSubsidyApplicableToCourse: undefined,
+  onCheckoutSuccess: undefined,
 };
 
 export default UserEnrollmentForm;


### PR DESCRIPTION
Updates redirect logic for routes `/:slug/:courseType/course/:courseKey/enroll` to not pass a onCheckoutSuccess function, and depend on the existing `onSuccessfulRedemption` logic in the useEffect to avoid duplicate redirects.

Also refactors the path name generation using `generatePath` instead of pushing (appending) to the end of a url.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
