### PR TITLE
fix: ensure isAssignmentExpired is accurate and ignore canceled assignments on course page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "enzyme": "3.11.0",
         "jest-canvas-mock": "^2.4.0",
         "match-media-mock": "0.1.1",
+        "mockdate": "3.0.5",
         "prettier": "2.2.1",
         "react-test-renderer": "17.0.2",
         "resize-observer-polyfill": "^1.5.1"
@@ -14646,6 +14647,12 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
+    "node_modules/mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "dev": true
     },
     "node_modules/moo": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "enzyme": "3.11.0",
     "jest-canvas-mock": "^2.4.0",
     "match-media-mock": "0.1.1",
+    "mockdate": "3.0.5",
     "prettier": "2.2.1",
     "react-test-renderer": "17.0.2",
     "resize-observer-polyfill": "^1.5.1"

--- a/src/components/course/course-header/data/hooks/tests/useCourseRunCardHeading.test.jsx
+++ b/src/components/course/course-header/data/hooks/tests/useCourseRunCardHeading.test.jsx
@@ -1,28 +1,17 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { renderHook } from '@testing-library/react-hooks';
+import MockDate from 'mockdate';
 import '@testing-library/jest-dom/extend-expect';
 
 import { hasTimeToComplete } from '../../../../data/utils';
 
 import { MOCK_COURSE_RUN_START } from './constants';
 import useCourseRunCardHeading from '../useCourseRunCardHeading';
-
-jest.mock('dayjs', () => jest.fn(
-  (...args) => jest.requireActual('dayjs')(args.filter((arg) => arg).length > 0 ? args : '2023-03-20'),
-));
-
-jest.mock('../../../../../../utils/dayjs', () => jest.fn(
-  (...args) => jest.requireActual('../../../../../../utils/dayjs')(args.filter((arg) => arg).length > 0 ? args : '2023-03-20'),
-));
+import { COURSE_PACING_MAP } from '../../../../data/constants';
 
 jest.mock('../../../../data/utils', () => ({
   ...jest.requireActual('../../../../data/utils'),
   hasTimeToComplete: jest.fn().mockReturnValue(true),
-}));
-
-jest.mock('../../utils', () => ({
-  ...jest.requireActual('../../utils'),
-  getTodaysDate: jest.fn(() => new Date('2023-10-20')),
 }));
 
 const wrapper = ({ children }) => (
@@ -30,6 +19,10 @@ const wrapper = ({ children }) => (
 );
 
 describe('useCourseRunCardHeading', () => {
+  afterEach(() => {
+    MockDate.reset();
+  });
+
   it('handles non-current course run', () => {
     const { result } = renderHook(
       () => useCourseRunCardHeading({
@@ -49,18 +42,17 @@ describe('useCourseRunCardHeading', () => {
     { hasTimeToCompleteOverride: true },
     { hasTimeToCompleteOverride: false },
   ])('handles current, self-paced, unenrolled course run (%s)', ({ hasTimeToCompleteOverride }) => {
-    // mock hasTimeToComplete
     hasTimeToComplete.mockReturnValue(hasTimeToCompleteOverride);
 
     // mock current date
-    Date.now = jest.fn(() => new Date('2023-03-20T12:00:00Z'));
+    MockDate.set(new Date('2023-05-20T12:00:00Z'));
 
     const { result } = renderHook(
       () => useCourseRunCardHeading({
         isCourseRunCurrent: true,
         isUserEnrolled: false,
         courseRun: {
-          pacingType: 'self_paced',
+          pacingType: COURSE_PACING_MAP.SELF_PACED,
           start: MOCK_COURSE_RUN_START,
         },
       }),
@@ -69,7 +61,7 @@ describe('useCourseRunCardHeading', () => {
 
     if (hasTimeToCompleteOverride) {
       // assert shown start date matches the above mocked current date
-      expect(result.current).toEqual('Starts Mar 20');
+      expect(result.current).toEqual('Starts May 20');
     } else {
       // assert shown start date matches the start date of the course run
       expect(result.current).toEqual('Started Apr 20');

--- a/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
+++ b/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs';
 import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 
-import { getTodaysDate } from '../../../../../utils/dayjs';
 import { getCourseStartDate, hasTimeToComplete, isCourseSelfPaced } from '../../../data/utils';
 import { DATE_FORMAT } from '../constants';
 
@@ -46,7 +45,7 @@ const useCourseRunCardHeading = ({
   // the start date is indeed in the past. As of this implementation, the `availability`
   // for published, enrollable externally hosted courses is always "Current" even if the
   // date is upcoming.
-  if (isCourseRunCurrent && dayjs(courseStartDate).isBefore(dayjs(getTodaysDate()))) {
+  if (isCourseRunCurrent && dayjs(courseStartDate).isBefore(dayjs())) {
     if (isUserEnrolled) {
       return intl.formatMessage(messages.courseStarted);
     }

--- a/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
+++ b/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
@@ -1,9 +1,9 @@
 import dayjs from 'dayjs';
 import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 
+import { getTodaysDate } from '../../../../../utils/dayjs';
 import { getCourseStartDate, hasTimeToComplete, isCourseSelfPaced } from '../../../data/utils';
 import { DATE_FORMAT } from '../constants';
-import { getTodaysDate } from '../utils';
 
 const messages = defineMessages({
   courseStartDate: {

--- a/src/components/course/course-header/data/utils.js
+++ b/src/components/course/course-header/data/utils.js
@@ -1,1 +1,0 @@
-export const getTodaysDate = () => new Date();

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -47,6 +47,7 @@ import { EVENTS, pushEvent } from '../../../utils/optimizely';
 import { getExternalCourseEnrollmentUrl } from '../enrollment/utils';
 import { createExecutiveEducationFailureMessage } from '../../executive-education-2u/ExecutiveEducation2UError';
 import { enterpriseUserSubsidyQueryKeys } from '../../enterprise-user-subsidy/data/constants';
+import { ASSIGNMENT_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
 
 // How long to delay an event, so that we allow enough time for any async analytics event call to resolve
 const CLICK_DELAY_MS = 300; // 300ms replicates Segment's ``trackLink`` function
@@ -854,7 +855,13 @@ export const useIsCourseAssigned = (learnerContentAssignments, courseKey) => {
   if (!learnerContentAssignments.hasActiveAssignments) {
     return false;
   }
-  const isCourseAssigned = learnerContentAssignments.activeAssignments
-    .some(assignment => assignment.contentKey === courseKey);
+  const isCourseAssigned = learnerContentAssignments.activeAssignments.some(
+    (assignment) => {
+      const isCourseKeyMatching = assignment.contentKey === courseKey;
+      const isAssignmentCancelled = assignment.state === ASSIGNMENT_TYPES.CANCELLED;
+      return isCourseKeyMatching && !isAssignmentCancelled;
+    },
+  );
+
   return isCourseAssigned;
 };

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -17,6 +17,7 @@ import {
   useCourseRunWeeksToComplete,
   useCourseTranscriptLanguages,
   useExtractAndRemoveSearchParamsFromURL,
+  useIsCourseAssigned,
   useMinimalCourseMetadata,
   useOptimizelyEnrollmentClickHandler,
   useTrackSearchConversionClickHandler,
@@ -1538,5 +1539,58 @@ describe('useMinimalCourseMetadata', () => {
         },
       }),
     );
+  });
+});
+
+describe('useIsCourseAssigned', () => {
+  const mockContentKey = 'edX+DemoX';
+
+  it('should return false if there are no active assignments', () => {
+    const learnerContentAssignments = {
+      hasActiveAssignments: false,
+    };
+    const { result } = renderHook(() => useIsCourseAssigned(learnerContentAssignments));
+    expect(result.current).toEqual(false);
+  });
+
+  it('should return false if there is NO matching assignment to the course key', () => {
+    const learnerContentAssignments = {
+      hasActiveAssignments: true,
+      activeAssignments: [
+        {
+          contentKey: mockContentKey,
+        },
+      ],
+    };
+    const { result } = renderHook(() => useIsCourseAssigned(learnerContentAssignments, 'non-existent-course-key'));
+    expect(result.current).toEqual(false);
+  });
+
+  it('should return false if matching assignment(s) are canceled', () => {
+    const learnerContentAssignments = {
+      hasActiveAssignments: true,
+      activeAssignments: [
+        {
+          contentKey: mockContentKey,
+          state: 'cancelled',
+        },
+      ],
+    };
+    const { result } = renderHook(() => useIsCourseAssigned(learnerContentAssignments, mockContentKey));
+    expect(result.current).toEqual(false);
+  });
+
+  it('should return true if there is a matching allocated assignment to the course key', () => {
+    const learnerContentAssignments = {
+      hasActiveAssignments: true,
+      activeAssignments: [
+        {
+          contentKey: mockContentKey,
+          state: 'allocated',
+        },
+      ],
+    };
+    const { result } = renderHook(() => useIsCourseAssigned(learnerContentAssignments, mockContentKey));
+    expect(result.current).toEqual(true);
   });
 });

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import { render, screen } from '@testing-library/react';
+import MockDate from 'mockdate';
 import '@testing-library/jest-dom/extend-expect';
 
 import { getConfig } from '@edx/frontend-platform';
@@ -922,9 +923,8 @@ describe('processCourseSubjects', () => {
 });
 
 describe('isCurrentCoupon', () => {
-  const realDateNow = Date.now;
-  afterAll(() => {
-    Date.now = realDateNow;
+  afterEach(() => {
+    MockDate.reset();
   });
 
   it.each([
@@ -953,7 +953,7 @@ describe('isCurrentCoupon', () => {
     expectedIsCurrent,
   }) => {
     // mock current date
-    Date.now = jest.fn(() => new Date(todaysDate).valueOf());
+    MockDate.set(todaysDate);
 
     const coupon = {
       startDate: couponStartDate,
@@ -966,9 +966,9 @@ describe('isCurrentCoupon', () => {
 
 describe('getCouponCodesDisabledEnrollmentReasonType', () => {
   const testCatalogUuid = 'test-catalog-uuid';
-  const realDateNow = Date.now;
-  afterAll(() => {
-    Date.now = realDateNow;
+
+  afterEach(() => {
+    MockDate.reset();
   });
 
   it.each([
@@ -1023,7 +1023,7 @@ describe('getCouponCodesDisabledEnrollmentReasonType', () => {
     expectedResult,
   }) => {
     // mock current date
-    Date.now = jest.fn(() => new Date(todaysDate).valueOf());
+    MockDate.set(todaysDate);
 
     const args = {
       catalogsWithCourse,

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -412,7 +412,7 @@ export function shortenString(str, maxLength, suffix, separator = ' ') {
   return `${str.substring(0, str.lastIndexOf(separator, maxLength))}${suffix}`;
 }
 
-export const isCurrentCoupon = (coupon) => dayjs(Date.now()).isBetween(
+export const isCurrentCoupon = (coupon) => dayjs().isBetween(
   coupon.startDate,
   coupon.endDate,
   'day',

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/utils.test.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/utils.test.js
@@ -9,11 +9,6 @@ import {
   sortAssignmentsByAssignmentStatus,
 } from '../utils';
 import { createRawCourseEnrollment } from '../../tests/enrollment-testutils';
-import { getTodaysDate } from '../../../../../../utils/dayjs';
-
-jest.mock('../../../../../../utils/dayjs', () => ({
-  getTodaysDate: jest.fn(() => new Date('2023-04-20')),
-}));
 
 describe('transformCourseEnrollment', () => {
   it('should transform a course enrollment', () => {
@@ -167,7 +162,6 @@ describe('isAssignmentExpired', () => {
     subsidyExpirationDate,
     isExpired,
   }) => {
-    getTodaysDate.mockReturnValue(currentDate);
     const allocatedAssignment = {
       created,
       contentMetadata: { enrollByDate },

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/utils.test.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/utils.test.js
@@ -1,4 +1,5 @@
 import { camelCaseObject } from '@edx/frontend-platform';
+import MockDate from 'mockdate';
 
 import { COURSE_STATUSES } from '../constants';
 import {
@@ -126,6 +127,14 @@ describe('isAssignmentExpired', () => {
   const futureDate = '2024-04-20';
   const pastDate = '2022-04-20';
 
+  beforeAll(() => {
+    MockDate.set(currentDate);
+  });
+
+  afterAll(() => {
+    MockDate.reset();
+  });
+
   it('handles null/undefined assignment', () => {
     expect(isAssignmentExpired(null)).toBe(false);
     expect(isAssignmentExpired(undefined)).toBe(false);
@@ -172,6 +181,14 @@ describe('isAssignmentExpired', () => {
 });
 
 describe('sortAssignmentsByAssignmentStatus', () => {
+  beforeAll(() => {
+    MockDate.set('2023-04-20');
+  });
+
+  afterAll(() => {
+    MockDate.reset();
+  });
+
   it('sorts assignments by status (cancelled or expired)', () => {
     const baseAssignment = {
       created: '2023-04-20',

--- a/src/components/dashboard/main-content/course-enrollments/data/utils.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/utils.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import { COURSE_STATUSES } from './constants';
+import { getTodaysDate } from '../../../../../utils/dayjs';
 
 /**
  * Determines whether a course enrollment may be unenrolled based on its enrollment
@@ -95,11 +96,11 @@ export const transformSubsidyRequest = ({
  */
 export const isAssignmentExpired = (assignment) => {
   // Assignment is not in an allocated state, so it cannot be expired.
-  if (!assignment?.state !== 'allocated') {
+  if (!assignment) {
     return false;
   }
 
-  const currentDate = dayjs();
+  const currentDate = dayjs(getTodaysDate());
   const allocationDate = dayjs(assignment.created);
   const enrollmentEndDate = dayjs(assignment.contentMetadata.enrollByDate);
   const subsidyExpirationDate = dayjs(assignment.subsidyExpirationDate);

--- a/src/components/dashboard/main-content/course-enrollments/data/utils.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/utils.js
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs';
 import { COURSE_STATUSES } from './constants';
-import { getTodaysDate } from '../../../../../utils/dayjs';
 
 /**
  * Determines whether a course enrollment may be unenrolled based on its enrollment
@@ -100,7 +99,7 @@ export const isAssignmentExpired = (assignment) => {
     return false;
   }
 
-  const currentDate = dayjs(getTodaysDate());
+  const currentDate = dayjs();
   const allocationDate = dayjs(assignment.created);
   const enrollmentEndDate = dayjs(assignment.contentMetadata.enrollByDate);
   const subsidyExpirationDate = dayjs(assignment.subsidyExpirationDate);

--- a/src/components/dashboard/main-content/course-enrollments/data/utils.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/utils.js
@@ -117,14 +117,16 @@ export const isAssignmentExpired = (assignment) => {
  * @returns {array} - Returns the sorted array of assignments.
  */
 export const sortAssignmentsByAssignmentStatus = (assignments) => {
-  if (assignments) {
-    const sortedAssignments = [...assignments].sort((a, b) => (
-      ((a.state === 'cancelled' || isAssignmentExpired(a)) ? 1 : 0)
-    - ((b.state === 'cancelled' || isAssignmentExpired(b)) ? 1 : 0)
-    ));
-    return sortedAssignments;
+  if (!assignments) {
+    return [];
   }
-  return [];
+  const assignmentsCopy = [...assignments];
+  const sortedAssignments = assignmentsCopy.sort((a, b) => {
+    const isAssignmentACanceledOrExpired = a.state === 'cancelled' || isAssignmentExpired(a) ? 1 : 0;
+    const isAssignmentBCanceledOrExpired = b.state === 'cancelled' || isAssignmentExpired(b) ? 1 : 0;
+    return isAssignmentACanceledOrExpired - isAssignmentBCanceledOrExpired;
+  });
+  return sortedAssignments;
 };
 
 export const getTransformedAllocatedAssignments = (assignments, slug) => {

--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -131,7 +131,7 @@ const UserEnrollmentForm = ({
       geagLastName: values.lastName,
       geagEmail: getAuthenticatedUser().email,
       geagDateOfBirth: values.dateOfBirth,
-      geagTermsAcceptedAt: toISOStringWithoutMilliseconds(new Date(Date.now()).toISOString()),
+      geagTermsAcceptedAt: toISOStringWithoutMilliseconds(dayjs().toISOString()),
       geagDataShareConsent: enableDataSharingConsent ? !!values.dataSharingConsent : undefined,
     });
     try {
@@ -151,7 +151,7 @@ const UserEnrollmentForm = ({
           lastName: values.lastName,
           dateOfBirth: values.dateOfBirth,
         },
-        termsAcceptedAt: toISOStringWithoutMilliseconds(new Date(Date.now()).toISOString()),
+        termsAcceptedAt: toISOStringWithoutMilliseconds(dayjs().toISOString()),
         dataShareConsent: enableDataSharingConsent ? !!values.dataSharingConsent : undefined,
       });
       await handleFormSubmissionSuccess();

--- a/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
@@ -8,6 +8,7 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { snakeCaseObject } from '@edx/frontend-platform/utils';
 import dayjs from 'dayjs';
+import MockDate from 'mockdate';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import UserEnrollmentForm, { formValidationMessages } from './UserEnrollmentForm';
@@ -107,6 +108,10 @@ describe('UserEnrollmentForm', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    MockDate.reset();
+  });
+
   it('has course enrollment information section and handles validation', async () => {
     render(<UserEnrollmentFormWrapper />);
     expect(screen.getByText('Course enrollment information')).toBeInTheDocument();
@@ -204,7 +209,7 @@ describe('UserEnrollmentForm', () => {
 
   it('handles successful form submission with subsidy access policy redemption', async () => {
     const mockTermsAcceptedAt = '2022-09-28T13:35:06Z';
-    Date.now = jest.fn(() => new Date(mockTermsAcceptedAt).valueOf());
+    MockDate.set(mockTermsAcceptedAt);
 
     render(<UserEnrollmentFormWrapper />);
     userEvent.type(screen.getByLabelText('First name *'), mockFirstName);
@@ -247,7 +252,7 @@ describe('UserEnrollmentForm', () => {
 
   it('handles successful form submission with data sharing consent disabled', async () => {
     const mockTermsAcceptedAt = '2022-09-28T13:35:06Z';
-    Date.now = jest.fn(() => new Date(mockTermsAcceptedAt).valueOf());
+    MockDate.set(mockTermsAcceptedAt);
     const appContext = {
       enterpriseConfig: {
         ...initialAppContextValue.enterpriseConfig,
@@ -296,7 +301,7 @@ describe('UserEnrollmentForm', () => {
 
   it('handles age related errors during form submission', async () => {
     const mockTermsAcceptedAt = '2022-09-28T13:35:06Z';
-    Date.now = jest.fn(() => new Date(mockTermsAcceptedAt).valueOf());
+    MockDate.set(mockTermsAcceptedAt);
 
     render(<UserEnrollmentFormWrapper />);
     userEvent.type(screen.getByLabelText('First name *'), mockFirstName);
@@ -320,7 +325,7 @@ describe('UserEnrollmentForm', () => {
 
   it('handles network error with form submission', async () => {
     const mockError = new Error('oh noes');
-    Date.now = jest.fn(() => new Date().valueOf());
+    MockDate.set(new Date());
     const mockFormSubmissionValue = { message: 'oh noes' };
 
     render(<UserEnrollmentFormWrapper
@@ -373,7 +378,7 @@ describe('UserEnrollmentForm', () => {
     };
     checkoutExecutiveEducation2U.mockRejectedValueOnce(mockCheckoutAlreadyEnrolledResponse);
     const mockTermsAcceptedAt = '2022-09-28T13:35:06Z';
-    Date.now = jest.fn(() => new Date(mockTermsAcceptedAt).valueOf());
+    MockDate.set(mockTermsAcceptedAt);
 
     const userSubsidyApplicableToCourse = {
       subsidyType: ENTERPRISE_OFFER_SUBSIDY_TYPE,
@@ -419,7 +424,7 @@ describe('UserEnrollmentForm', () => {
 
   it('handles duplicate order with form submission', async () => {
     const mockError = new Error('duplicate order');
-    Date.now = jest.fn(() => new Date().valueOf());
+    MockDate.set(new Date());
     const mockFormSubmissionValue = { message: 'duplicate order' };
     render(<UserEnrollmentFormWrapper
       courseContextValue={{

--- a/src/utils/dayjs.js
+++ b/src/utils/dayjs.js
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs';
 
+export const getTodaysDate = () => new Date();
+
 const advancedFormat = require('dayjs/plugin/advancedFormat');
 const isBetween = require('dayjs/plugin/isBetween');
 const relativeTime = require('dayjs/plugin/relativeTime');

--- a/src/utils/dayjs.js
+++ b/src/utils/dayjs.js
@@ -1,7 +1,5 @@
 import dayjs from 'dayjs';
 
-export const getTodaysDate = () => new Date();
-
 const advancedFormat = require('dayjs/plugin/advancedFormat');
 const isBetween = require('dayjs/plugin/isBetween');
 const relativeTime = require('dayjs/plugin/relativeTime');


### PR DESCRIPTION
**Tickets:**
* https://2u-internal.atlassian.net/browse/ENT-8147
* https://2u-internal.atlassian.net/browse/ENT-8149

When learner has a canceled assignment for the course being viewed in the learner portal, there is "Assigned" messaging as if the assignment is applicable to the course. This PR ensures canceled assignments are ignored on the course page.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
