### PR TITLE
fix: update redirect logic to take into account available coupon codes

### DIFF
--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -434,6 +434,7 @@ export const getCouponCodesDisabledEnrollmentReasonType = ({
   const applicableCouponsToCatalog = couponsOverview?.data?.results.filter(
     coupon => catalogsWithCourse.includes(coupon.enterpriseCatalogUuid),
   ) || [];
+
   const hasCouponsApplicableToCourse = applicableCouponsToCatalog.length > 0;
   if (!hasCouponsApplicableToCourse) {
     return undefined;

--- a/src/components/course/routes/CourseAbout.jsx
+++ b/src/components/course/routes/CourseAbout.jsx
@@ -29,6 +29,7 @@ const CourseAbout = () => {
     enterpriseOffers,
     subscriptionPlan,
     subscriptionLicense,
+    couponCodes,
   } = useContext(UserSubsidyContext);
 
   const isCourseAssigned = useIsCourseAssigned(redeemableLearnerCreditPolicies?.learnerContentAssignments, course?.key);
@@ -37,6 +38,7 @@ const CourseAbout = () => {
     enterpriseOffers,
     subscriptionPlan,
     subscriptionLicense,
+    couponCodes.couponCodes,
   );
 
   const featuredHideCourseSearch = features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && hideCourseSearch;

--- a/src/components/course/routes/tests/CourseAbout.test.jsx
+++ b/src/components/course/routes/tests/CourseAbout.test.jsx
@@ -65,6 +65,9 @@ const initialUserSubsidyState = {
   enterpriseOffers: [],
   subscriptionPlan: {},
   subscriptionLicense: {},
+  couponCodes: {
+    couponCodes: [],
+  },
 };
 
 const CourseAboutWrapper = ({

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/utils.test.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/utils.test.js
@@ -364,6 +364,7 @@ describe('isDisableCourseSearch', () => {
       subscriptionLicenses: {
         status: LICENSE_STATUS.ACTIVATED,
       },
+      couponCodes: [],
     },
     {
       isCourseSearchDisabled: false,
@@ -400,6 +401,7 @@ describe('isDisableCourseSearch', () => {
       subscriptionLicenses: {
         status: LICENSE_STATUS.ACTIVATED,
       },
+      couponCodes: [],
     },
     {
       isCourseSearchDisabled: false,
@@ -430,6 +432,38 @@ describe('isDisableCourseSearch', () => {
       subscriptionLicenses: {
         status: LICENSE_STATUS.ACTIVATED,
       },
+      couponCodes: [],
+    },
+    {
+      isCourseSearchDisabled: false,
+      redeemableLearnerCreditPolicies: {
+        redeemablePolicies: [
+          {
+            policyType: POLICY_TYPES.ASSIGNED_CREDIT,
+            learnerContentAssignments: [
+              { state: ASSIGNMENT_TYPES.ALLOCATED },
+            ],
+          },
+        ],
+        learnerContentAssignments: {
+          assignments: [],
+          hasAssignments: false,
+          activeAssignments: [],
+          hasActiveAssignments: false,
+        },
+      },
+      enterpriseOffers: [{
+        isCurrent: true,
+      }],
+      subscriptionPlan: {
+        isActive: false,
+      },
+      subscriptionLicenses: {
+        status: LICENSE_STATUS.ACTIVATED,
+      },
+      couponCodes: [
+        { available: true },
+      ],
     },
     {
       isCourseSearchDisabled: true,
@@ -458,6 +492,7 @@ describe('isDisableCourseSearch', () => {
       subscriptionLicenses: {
         status: LICENSE_STATUS.ACTIVATED,
       },
+      couponCodes: [],
     },
     {
       isCourseSearchDisabled: true,
@@ -492,6 +527,7 @@ describe('isDisableCourseSearch', () => {
       subscriptionLicenses: {
         status: LICENSE_STATUS.ACTIVATED,
       },
+      couponCodes: [],
     },
   ])('isCourseSearchDisabled - (%p), (%s)', ({
     isCourseSearchDisabled,

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/utils.test.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/tests/utils.test.js
@@ -499,12 +499,14 @@ describe('isDisableCourseSearch', () => {
     enterpriseOffers,
     subscriptionPlan,
     subscriptionLicenses,
+    couponCodes,
   }) => {
     const isDisableSearch = isDisableCourseSearch(
       redeemableLearnerCreditPolicies,
       enterpriseOffers,
       subscriptionPlan,
       subscriptionLicenses,
+      couponCodes,
     );
     expect(isDisableSearch).toEqual(isCourseSearchDisabled);
   });

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/utils.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/utils.js
@@ -115,8 +115,8 @@ export const transformEnterpriseOffer = (offer) => {
  * @param {Array} enterpriseOffers - Array of enterprise offers.
  * @param {Object} subscriptionPlan - Subscription plan object.
  * @param {Object} subscriptionLicense - Subscription license object.
+ * @param {Array} couponCodes - Array of couponCodes from the UserSubsidyContext, couponCodes.couponCodes
  *
- * @param couponCodes
  * @returns {boolean} Returns true if course search should be disabled, otherwise false.
  */
 export const isDisableCourseSearch = (

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/utils.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/utils.js
@@ -116,6 +116,7 @@ export const transformEnterpriseOffer = (offer) => {
  * @param {Object} subscriptionPlan - Subscription plan object.
  * @param {Object} subscriptionLicense - Subscription license object.
  *
+ * @param couponCodes
  * @returns {boolean} Returns true if course search should be disabled, otherwise false.
  */
 export const isDisableCourseSearch = (
@@ -123,12 +124,12 @@ export const isDisableCourseSearch = (
   enterpriseOffers,
   subscriptionPlan,
   subscriptionLicense,
+  couponCodes,
 ) => {
   const {
     redeemablePolicies,
     learnerContentAssignments,
   } = redeemableLearnerCreditPolicies || {};
-
   const nonAssignablePolicyTypes = redeemablePolicies.filter(
     item => item.policyType !== POLICY_TYPES.ASSIGNED_CREDIT,
   );
@@ -137,16 +138,18 @@ export const isDisableCourseSearch = (
   }
 
   const hasActiveSubPlan = subscriptionPlan?.isActive && subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED;
-  const activeOffers = enterpriseOffers?.filter(item => item?.isCurrent);
-
+  const hasCouponCodes = couponCodes.filter(code => !!code?.available).length > 0;
   const allocatedOrAcceptedAssignments = learnerContentAssignments.assignments
     .filter(item => [ASSIGNMENT_TYPES.ALLOCATED, ASSIGNMENT_TYPES.ACCEPTED].includes(item.state));
-
-  if (allocatedOrAcceptedAssignments?.length === 0) {
-    return false;
-  }
+  const activeOffers = enterpriseOffers?.filter(item => item?.isCurrent);
 
   if (hasActiveSubPlan) {
+    return false;
+  }
+  if (hasCouponCodes) {
+    return false;
+  }
+  if (allocatedOrAcceptedAssignments?.length === 0) {
     return false;
   }
 

--- a/src/components/my-career/CategoryCard.jsx
+++ b/src/components/my-career/CategoryCard.jsx
@@ -27,13 +27,14 @@ const CategoryCard = ({ topCategory }) => {
     enterpriseOffers,
     subscriptionPlan,
     subscriptionLicense,
+    couponCodes,
   } = useContext(UserSubsidyContext);
   const hideCourseSearch = isDisableCourseSearch(
     redeemableLearnerCreditPolicies,
     enterpriseOffers,
     subscriptionPlan,
     subscriptionLicense,
-    couponCodes,
+    couponCodes.couponCodes,
   );
 
   const featuredHideCourseSearch = features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && hideCourseSearch;

--- a/src/components/my-career/CategoryCard.jsx
+++ b/src/components/my-career/CategoryCard.jsx
@@ -1,13 +1,9 @@
 import React, {
-  useMemo, useState, useEffect, useContext,
+  useContext, useEffect, useMemo, useState,
 } from 'react';
 
 import PropTypes from 'prop-types';
-import {
-  Card,
-  Button,
-  useToggle,
-} from '@edx/paragon';
+import { Button, Card, useToggle } from '@edx/paragon';
 import { getConfig } from '@edx/frontend-platform/config';
 import algoliasearch from 'algoliasearch/lite';
 import { AppContext } from '@edx/frontend-platform/react';
@@ -37,6 +33,7 @@ const CategoryCard = ({ topCategory }) => {
     enterpriseOffers,
     subscriptionPlan,
     subscriptionLicense,
+    couponCodes,
   );
 
   const featuredHideCourseSearch = features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && hideCourseSearch;


### PR DESCRIPTION
Updates my favorite function, `isDisableCourseSearch`, to take into account existing coupon codes before redirecting. If there exists an available coupon code, then we will not redirect away from the course about page.

We also refactor the `isDisableCourseSearch` to return out of the function as false (can view the course page) in the following order.

- If a `nonAssignablePolicyType` exist where a `nonAssignablePolicyType` is not 'AssignedLearnerCreditAccessPolicy'
- If a user `hasActiveSubPlan` where a subscription plan is active AND the subscription license status is 'activated'
- If a user `hasCouponCodes` where a coupon code is available (active defined as the current date/time falls between a coupon start/end date)
- If a user does NOT have a `allocatedOrAcceptedAssignment` where an assignment state is either 'accepted' OR 'allocated'

A user is redirected away from the course about page if either of the following conditions are true
- There exist an `activeOffer` where an active offer is defined as a current offer 
-  There exist an `allocatedOrAcceptedAssignment` where an assignment assignment state is either 'accepted' OR 'allocated'

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
