### PR TITLE
feat: update career chart to pull interested role not current role

### DIFF
--- a/src/components/my-career/VisualizeCareer.jsx
+++ b/src/components/my-career/VisualizeCareer.jsx
@@ -62,7 +62,7 @@ const VisualizeCareer = ({ jobId, submitClickHandler }) => {
           {!isEditable ? (
             <div key="edit-job-button">
               <ActionRow>
-                <p>Current Role</p>
+                <p>Desired Role</p>
                 <ActionRow.Spacer />
                 <Button variant="link" iconBefore={editIcon} onClick={editOnClickHandler}>Edit</Button>
               </ActionRow>

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -42,7 +42,7 @@ import TopSkillsOverview from './TopSkillsOverview';
 import SkillsQuizHeader from './SkillsQuizHeader';
 
 import headerImage from './images/headerImage.png';
-import { saveSkillsGoalsAndJobsUserSelected } from './data/utils';
+import { saveDesiredRoleForCareerChart, saveSkillsGoalsAndJobsUserSelected } from './data/utils';
 import { fetchCourseEnrollments } from './data/service';
 
 const SkillsQuizStepper = () => {
@@ -90,6 +90,7 @@ const SkillsQuizStepper = () => {
 
   const flipToRecommendedCourses = () => {
     saveSkillsGoalsAndJobsUserSelected(goal, currentJobRole, interestedJobs);
+    saveDesiredRoleForCareerChart(goal, currentJobRole, interestedJobs);
     // show  courses if learner has selected skills or jobs.
     if (goalExceptImproveAndJobSelected) {
       // verify if selectedJob is still checked and within first 3 jobs else


### PR DESCRIPTION
**Description**

- When the user fills out the Skills Builder, we take the first job from their list of up to three jobs they are interested in and write it to their career chart.
- If the user selects they want to improve in their current role, we write from the current job field.
- On the UI of the career chart, change the Current Role field name to Desired Role.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
