### PR TITLE
fix: correct spelling of canceled

### DIFF
--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -858,8 +858,8 @@ export const useIsCourseAssigned = (learnerContentAssignments, courseKey) => {
   const isCourseAssigned = learnerContentAssignments.activeAssignments.some(
     (assignment) => {
       const isCourseKeyMatching = assignment.contentKey === courseKey;
-      const isAssignmentCancelled = assignment.state === ASSIGNMENT_TYPES.CANCELLED;
-      return isCourseKeyMatching && !isAssignmentCancelled;
+      const isAssignmentCanceled = assignment.state === ASSIGNMENT_TYPES.CANCELED;
+      return isCourseKeyMatching && !isAssignmentCanceled;
     },
   );
 

--- a/src/components/dashboard/data/utils.js
+++ b/src/components/dashboard/data/utils.js
@@ -17,7 +17,7 @@ import { ASSIGNMENT_TYPES } from '../../enterprise-user-subsidy/enterprise-offer
  */
 export default function getActiveAssignments(assignments = []) {
   const activeAssignments = assignments.filter((assignment) => [
-    ASSIGNMENT_TYPES.CANCELLED, ASSIGNMENT_TYPES.ALLOCATED,
+    ASSIGNMENT_TYPES.CANCELED, ASSIGNMENT_TYPES.ALLOCATED,
   ].includes(assignment.state));
   const hasAssignments = assignments.length > 0;
   const hasActiveAssignments = activeAssignments.length > 0;

--- a/src/components/dashboard/main-content/course-enrollments/CourseAssignmentAlert.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseAssignmentAlert.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import PropTypes from 'prop-types';
-import { Button, Alert, MailtoLink } from '@edx/paragon';
+import { Alert, Button, MailtoLink } from '@edx/paragon';
 import { Info } from '@edx/paragon/icons';
 import { getContactEmail } from '../../../../utils/common';
 
@@ -9,9 +9,9 @@ const CourseAssignmentAlert = ({
   onClose,
   variant,
 }) => {
-  const heading = variant === 'cancelled' ? 'Course assignment cancelled' : 'Deadline passed';
+  const heading = variant === 'cancelled' ? 'Course assignment canceled' : 'Deadline passed';
   const text = (variant === 'cancelled'
-    ? 'Your learning administrator cancelled one or more course assignments below.'
+    ? 'Your learning administrator canceled one or more course assignments below.'
     : 'Deadline to enroll into one or more courses below has passed.');
 
   const { enterpriseConfig } = useContext(AppContext);

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -44,7 +44,7 @@ const CourseEnrollments = ({ children }) => {
   const { redeemableLearnerCreditPolicies } = useContext(UserSubsidyContext);
 
   const [assignments, setAssignments] = useState([]);
-  const [showCancelledAssignmentsAlert, setShowCancelledAssignmentsAlert] = useState(false);
+  const [showCanceledAssignmentsAlert, setShowCanceledAssignmentsAlert] = useState(false);
   const [showExpiredAssignmentsAlert, setShowExpiredAssignmentsAlert] = useState(false);
 
   useEffect(() => {
@@ -53,12 +53,12 @@ const CourseEnrollments = ({ children }) => {
     );
     setAssignments(assignmentsData);
 
-    const hasCancelledAssignments = assignmentsData?.some(
-      assignment => assignment.state === ASSIGNMENT_TYPES.CANCELLED,
+    const hasCanceledAssignments = assignmentsData?.some(
+      assignment => assignment.state === ASSIGNMENT_TYPES.CANCELED,
     );
     const hasExpiredAssignments = assignmentsData?.some(assignment => isAssignmentExpired(assignment));
 
-    setShowCancelledAssignmentsAlert(hasCancelledAssignments);
+    setShowCanceledAssignmentsAlert(hasCanceledAssignments);
     setShowExpiredAssignmentsAlert(hasExpiredAssignments);
   }, [redeemableLearnerCreditPolicies]);
 
@@ -112,8 +112,8 @@ const CourseEnrollments = ({ children }) => {
   const hasCourseEnrollments = Object.values(courseEnrollmentsByStatus).flat().length > 0;
   return (
     <>
-      {features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && showCancelledAssignmentsAlert && (
-        <CourseAssignmentAlert variant="cancelled" onClose={() => setShowCancelledAssignmentsAlert(false)}> </CourseAssignmentAlert>
+      {features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && showCanceledAssignmentsAlert && (
+        <CourseAssignmentAlert variant="cancelled" onClose={() => setShowCanceledAssignmentsAlert(false)}> </CourseAssignmentAlert>
       )}
       {features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && showExpiredAssignmentsAlert && (
         <CourseAssignmentAlert variant="expired" onClose={() => setShowExpiredAssignmentsAlert(false)}> </CourseAssignmentAlert>

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/AssignedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/AssignedCourseCard.jsx
@@ -11,8 +11,8 @@ import { COURSE_STATUSES } from '../data';
 
 const AssignedCourseCard = (props) => {
   const { enterpriseConfig } = useContext(AppContext);
-  const { courseKey, isCancelledAssignment, isExpiredAssignment } = props;
-  const disabled = (isCancelledAssignment || isExpiredAssignment) && 'disabled';
+  const { courseKey, isCanceledAssignment, isExpiredAssignment } = props;
+  const disabled = (isCanceledAssignment || isExpiredAssignment) && 'disabled';
 
   const renderButtons = () => (
     <Button
@@ -45,7 +45,7 @@ AssignedCourseCard.propTypes = {
   startDate: PropTypes.string,
   linkToCourse: PropTypes.string.isRequired,
   mode: PropTypes.string,
-  isCancelledAssignment: PropTypes.bool,
+  isCanceledAssignment: PropTypes.bool,
   isExpiredAssignment: PropTypes.bool,
 };
 
@@ -54,7 +54,7 @@ AssignedCourseCard.defaultProps = {
   isRevoked: false,
   startDate: null,
   mode: null,
-  isCancelledAssignment: false,
+  isCanceledAssignment: false,
   isExpiredAssignment: false,
 };
 

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Dropdown, Badge, IconButton, Icon, Skeleton, OverlayTrigger, Tooltip, Row, Col,
+  Badge, Col, Dropdown, Icon, IconButton, OverlayTrigger, Row, Skeleton, Tooltip,
 } from '@edx/paragon';
 import classNames from 'classnames';
 import camelCase from 'lodash.camelcase';
@@ -9,14 +9,12 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
-import {
-  MoreVert, InfoOutline, Info,
-} from '@edx/paragon/icons';
+import { Info, InfoOutline, MoreVert } from '@edx/paragon/icons';
 
 import dayjs from '../../../../../utils/dayjs';
 import { EmailSettingsModal } from './email-settings';
 import { UnenrollModal } from './unenroll';
-import { COURSE_STATUSES, COURSE_PACING, EXECUTIVE_EDUCATION_COURSE_MODES } from '../../../../../constants';
+import { COURSE_PACING, COURSE_STATUSES, EXECUTIVE_EDUCATION_COURSE_MODES } from '../../../../../constants';
 import { features } from '../../../../../config';
 
 const BADGE_PROPS_BY_COURSE_STATUS = {
@@ -453,8 +451,8 @@ class BaseCourseCard extends Component {
   };
 
   renderAssignmentAlert = () => {
-    const { isCancelledAssignment, mode } = this.props;
-    const alertText = isCancelledAssignment ? 'Your learning administrator canceled this assignment.' : 'Deadline to enroll in this course has passed';
+    const { isCanceledAssignment, mode } = this.props;
+    const alertText = isCanceledAssignment ? 'Your learning administrator canceled this assignment.' : 'Deadline to enroll in this course has passed';
     const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
 
     return (
@@ -475,13 +473,13 @@ class BaseCourseCard extends Component {
     } = this.props;
     const dropdownMenuItems = this.getDropdownMenuItems();
     const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
-    const { isCancelledAssignment, isExpiredAssignment } = this.props;
+    const { isCanceledAssignment, isExpiredAssignment } = this.props;
 
     return (
       <div className={classNames(
         'dashboard-course-card py-3 border-bottom mb-2',
         { 'exec-ed-course-card rounded-lg p-3 text-light-100': isExecutiveEducation2UCourse },
-        { 'mb-3': (isCancelledAssignment || isExpiredAssignment) },
+        { 'mb-3': (isCanceledAssignment || isExpiredAssignment) },
       )}
       >
         {isLoading ? (
@@ -515,7 +513,7 @@ class BaseCourseCard extends Component {
                   {hasViewCertificateLink && this.renderViewCertificateText()}
                 </Col>
               </Row>
-              { (isCancelledAssignment || isExpiredAssignment) && (
+              { (isCanceledAssignment || isExpiredAssignment) && (
                 <Row className={classNames({ 'mt-4 assignment-alert-row': isExecutiveEducation2UCourse }, { 'mt-2 pl-2': !isExecutiveEducation2UCourse })}>
                   {this.renderAssignmentAlert()}
                 </Row>
@@ -557,7 +555,7 @@ BaseCourseCard.propTypes = {
   enrollBy: PropTypes.string,
   courseRunStatus: PropTypes.string,
   isCourseAssigned: PropTypes.bool,
-  isCancelledAssignment: PropTypes.bool,
+  isCanceledAssignment: PropTypes.bool,
   isExpiredAssignment: PropTypes.bool,
 };
 
@@ -581,7 +579,7 @@ BaseCourseCard.defaultProps = {
   enrollBy: null,
   courseRunStatus: null,
   isCourseAssigned: false,
-  isCancelledAssignment: false,
+  isCanceledAssignment: false,
   isExpiredAssignment: false,
 };
 

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
@@ -33,7 +33,7 @@ export const OFFER_BALANCE_CLICK_EVENT = 'edx.ui.enterprise.learner_portal.offer
 export const ASSIGNMENT_TYPES = {
   ACCEPTED: 'accepted',
   ALLOCATED: 'allocated',
-  CANCELLED: 'cancelled',
+  CANCELED: 'cancelled',
   ERRORED: 'errored',
 };
 


### PR DESCRIPTION
Updates instances of 'cancelled' to 'canceled'

Cool regex used `(["'].*?)?[Cc]ancell?ed`

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
