### PR TITLE
ENT-8331: Only show academies if the learner's enterprise has enabled them.

### DIFF
--- a/src/components/enterprise-page/data/hooks.js
+++ b/src/components/enterprise-page/data/hooks.js
@@ -64,6 +64,7 @@ export const useEnterpriseCustomerConfig = (enterpriseSlug, useCache = true) => 
             careerEngagementNetworkMessage,
             enablePathways,
             enablePrograms,
+            enableAcademies,
           } = config;
           setEnterpriseConfig({
             name,
@@ -92,6 +93,7 @@ export const useEnterpriseCustomerConfig = (enterpriseSlug, useCache = true) => 
             careerEngagementNetworkMessage,
             enablePathways,
             enablePrograms,
+            enableAcademies,
           });
         } else {
           if (!config) {

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -178,7 +178,7 @@ const Search = () => {
         {(contentType === undefined || contentType.length === 0) && (
           <Stack className="my-5" gap={5}>
             {!hasRefinements && <ContentHighlights />}
-            {canOnlyViewHighlightSets === false && <SearchAcademy />}
+            {canOnlyViewHighlightSets === false && enterpriseConfig.enableAcademies && <SearchAcademy />}
             {features.ENABLE_PATHWAYS && (canOnlyViewHighlightSets === false) && <SearchPathway filter={filters} />}
             {features.ENABLE_PROGRAMS && (canOnlyViewHighlightSets === false) && <SearchProgram filter={filters} />}
             {canOnlyViewHighlightSets === false && <SearchCourse filter={filters} /> }


### PR DESCRIPTION
__Jira Ticket:__ [ENT-8331](https://2u-internal.atlassian.net/browse/ENT-8331)

__Description:__
Show academies only to those learners whose enterprise has enabled academies. This is to speed up page load and also avoid showing network errors for learners who do not have any academies.

__Blockers:__
This ticket depends on `enable_academies` flag that is added in https://github.com/openedx/edx-enterprise/pull/2007. We would only be able to merge once those changes are deployed.


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
