### PR TITLE
fix: switch to logError in order to alert on button smashing during asynchronous acknowledgement

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -4,7 +4,7 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AppContext } from '@edx/frontend-platform/react';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
-import { logError, logInfo } from '@edx/frontend-platform/logging';
+import { logError } from '@edx/frontend-platform/logging';
 import _camelCase from 'lodash.camelcase';
 import _cloneDeep from 'lodash.clonedeep';
 

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -276,7 +276,7 @@ export function useContentAssignments(redeemableLearnerCreditPolicies) {
 
     // Fail early if mutation is already in progress.
     if (isLoadingMutation) {
-      logInfo('Attempted to acknowledge assignments while mutation is in progress.');
+      logError('Attempted to acknowledge assignments while mutation is already in progress.');
       return;
     }
 


### PR DESCRIPTION
Instead of using `logInfo` (requires NRQL), opts to utilize `logError` in order to have a bit more proactive observability through New Relic errors into when / how often learners "button-smash" the assignment expired/canceled alert "Dismiss" buttons while an `acknowledge-assignments` POST request is already underway (note: it does prevent duplicate requests), given there is no asynchronous loading feedback on this action.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
