### PR TITLE
build: introduce serve command into NPM scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ Our goal is to setup a enterprise customer, obtains its slug, then visit it such
 Now quickly check the .env.development file for which services are used by the application. e.g. `LMS_BASE_URL='http://localhost:18000'` . We will get back to this.
 
 
+## Serving production builds
+
+During production builds, the NPM script ``npm run build`` is executived, which runs the production Webpack configuration (``webpack.prod.config.js``) to generate output files in the ``dist`` directory. However, these output files cannot be loaded directly into the browser. Instead, to preview a production build locally, these output files must be served via a server that can associate any URL route to the ``index.html`` entry-point of the application. The ``@edx/frontend-build`` package supports a ``serve`` command, which runs the generated production output from Webpack with a Node.js Express server.
+
+To serve a production build, the build must include the appropriate environment variables. The custom ``webpack.prod.config.js`` file in this project attempts to load all environment variables configured via the Git-ignored ``.env.private`` file, such that the production build can point to localhost URLs, etc.
+
+Relevant commands:
+* ``npm run serve``: Serves the output files from the ``dist`` directory on the ``PORT`` environment variable defined in the ``.env.development`` file.
+* ``npm run build:serve``: Executes ``npm run build``, followed by serving those generated assets in one command.
+* ``npm run build:with-theme:serve``: Executes ``npm run build:with-theme`` (i.e., utilizes custom brand package), followed by serving those generated assets in a single command.
+
 ## Setup test users and data
 
 An enterprise portal will need a couple of roles: The Enterprise customer, and at least one learner account.

--- a/package.json
+++ b/package.json
@@ -92,7 +92,10 @@
     "start:with-theme": "THEME=npm:@edx/brand-edx.org@latest npm run install-theme && npm run start",
     "start:stage:with-theme": "THEME=npm:@edx/brand-edx.org@latest npm run install-theme && npm run start:stage",
     "test": "fedx-scripts jest --coverage --passWithNoTests --maxWorkers=50%",
-    "test:watch": "npm run test -- --watch"
+    "test:watch": "npm run test -- --watch",
+    "serve": "fedx-scripts serve",
+    "build:serve": "npm run build && npm run serve",
+    "build:with-theme:serve": "npm run build:with-theme && npm run serve"
   },
   "repository": {
     "type": "git",

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const dotenv = require('dotenv');
+const { createConfig } = require('@edx/frontend-build');
+
+// Note: copied from `@openedx/frontend-build`
+function resolvePrivateEnvConfig(filePath) {
+  if (fs.existsSync(filePath)) {
+    const privateEnvConfig = dotenv.parse(fs.readFileSync(filePath));
+    Object.entries(privateEnvConfig).forEach(([key, value]) => {
+      process.env[key] = value;
+    });
+  }
+};
+resolvePrivateEnvConfig('.env.private');
+
+const config = createConfig('webpack-prod');
+
+module.exports = config;


### PR DESCRIPTION
# Description

Ticket: https://2u-internal.atlassian.net/browse/ENT-8372

Introduces the ability to serve production Webpack builds via a Node.js server (Express) shipped from `@edx/frontend-build`. Running `npm run start` does not adequately do code splitting as it would in a production environment, hence the desire/need for `npm run build:serve`.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
