### PR TITLE
fix: early return added on hook

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -316,6 +316,10 @@ export function useContentAssignments(redeemableLearnerCreditPolicies) {
    * acknowledged (dismissed) by the learner.
    */
   useEffect(() => {
+    if (!redeemableLearnerCreditPolicies) {
+      // No policies available (yet). Return early.
+      return;
+    }
     const {
       assignmentsForDisplay,
       canceledAssignments,


### PR DESCRIPTION
Based on local error I was facing when default enterprise provisioned with no learner credit.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
