### PR TITLE
fix: Tabs conditionally render child components and refactor

### DIFF
--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -1,22 +1,17 @@
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, {
+  useContext, useEffect, useMemo,
+} from 'react';
 import { Helmet } from 'react-helmet';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Container, Tab, Tabs } from '@edx/paragon';
+import { Container, Tabs } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
-import { ProgramListingPage } from '../program-progress';
-import PathwayProgressListingPage from '../pathway-progress/PathwayProgressListingPage';
-import { features } from '../../config';
 import { useEnterpriseCuration } from '../search/content-highlights/data';
-import { useLearnerProgramsListData } from '../program-progress/data/hooks';
-import { useInProgressPathwaysData } from '../pathway-progress/data/hooks';
-import CoursesTabComponent from './main-content/CoursesTabComponent';
-import { MyCareerTab } from '../my-career';
 import { UserSubsidyContext } from '../enterprise-user-subsidy';
 import { IntegrationWarningModal } from '../integration-warning-modal';
 import SubscriptionExpirationModal from './SubscriptionExpirationModal';
 import EnterpriseLearnerFirstVisitRedirect from '../enterprise-redirects/EnterpriseLearnerFirstVisitRedirect';
+import useDashboardTabs from './data/useDashboardTabs';
 
 const DashboardPage = () => {
   const {
@@ -28,9 +23,7 @@ const DashboardPage = () => {
     subscriptionPlan,
     showExpirationNotifications,
   } = useContext(UserSubsidyContext);
-  // TODO: Create a context provider containing these 2 data fetch hooks to future proof when we need to use this data
-  const [learnerProgramsListData, programsFetchError] = useLearnerProgramsListData(enterpriseConfig.uuid);
-  const [pathwayProgressData, pathwayFetchError] = useInProgressPathwaysData(enterpriseConfig.uuid);
+
   const {
     enterpriseCuration: {
       canOnlyViewHighlightSets,
@@ -38,14 +31,9 @@ const DashboardPage = () => {
   } = useEnterpriseCuration(enterpriseConfig.uuid);
   const intl = useIntl();
 
-  const onSelectHandler = (key) => {
-    if (key === 'my-career') {
-      sendEnterpriseTrackEvent(
-        enterpriseConfig.uuid,
-        'edx.ui.enterprise.learner_portal.career_tab.page_visit',
-      );
-    }
-  };
+  const { tabs, onSelectHandler, activeTab } = useDashboardTabs(
+    { canOnlyViewHighlightSets },
+  );
 
   useEffect(() => {
     if (state?.activationSuccess) {
@@ -68,64 +56,6 @@ const DashboardPage = () => {
       enterpriseName: enterpriseConfig.name,
     },
   );
-  const allTabs = [
-    <Tab
-      eventKey="courses"
-      title={intl.formatMessage({
-        id: 'enterprise.dashboard.tab.courses',
-        defaultMessage: 'Courses',
-        description: 'Title for courses tab on enterprise dashboard.',
-      })}
-    >
-      <CoursesTabComponent canOnlyViewHighlightSets={canOnlyViewHighlightSets} />
-    </Tab>,
-    enterpriseConfig.enablePrograms && (
-      <Tab
-        eventKey="programs"
-        title={intl.formatMessage({
-          id: 'enterprise.dashboard.tab.programs',
-          defaultMessage: 'Programs',
-          description: 'Title for programs tab on enterprise dashboard.',
-        })}
-        disabled={learnerProgramsListData.length === 0}
-      >
-        <ProgramListingPage
-          canOnlyViewHighlightSets={canOnlyViewHighlightSets}
-          programsListData={learnerProgramsListData}
-          programsFetchError={programsFetchError}
-        />
-      </Tab>
-    ),
-    enterpriseConfig.enablePathways && (
-      <Tab
-        eventKey="pathways"
-        title={intl.formatMessage({
-          id: 'enterprise.dashboard.tab.pathways',
-          defaultMessage: 'Pathways',
-          description: 'Title for pathways tab on enterprise dashboard.',
-        })}
-        disabled={pathwayProgressData.length === 0}
-      >
-        <PathwayProgressListingPage
-          canOnlyViewHighlightSets={canOnlyViewHighlightSets}
-          pathwayProgressData={pathwayProgressData}
-          pathwayFetchError={pathwayFetchError}
-        />
-      </Tab>
-    ),
-    features.FEATURE_ENABLE_MY_CAREER && (
-      <Tab
-        eventKey="my-career"
-        title={intl.formatMessage({
-          id: 'enterprise.dashboard.tab.my.career',
-          defaultMessage: 'My Career',
-          description: 'Title for my career tab on enterprise dashboard.',
-        })}
-      >
-        <MyCareerTab />
-      </Tab>
-    ),
-  ];
 
   return (
     <>
@@ -152,7 +82,12 @@ const DashboardPage = () => {
           }
         </h2>
         <EnterpriseLearnerFirstVisitRedirect />
-        <Tabs defaultActiveKey="courses" onSelect={(k) => onSelectHandler(k)}>{allTabs.filter(tab => tab)}</Tabs>
+        <Tabs
+          activeKey={activeTab}
+          onSelect={onSelectHandler}
+        >
+          {tabs}
+        </Tabs>
         {enterpriseConfig.showIntegrationWarning && <IntegrationWarningModal isOpen />}
         {subscriptionPlan && showExpirationNotifications && <SubscriptionExpirationModal />}
       </Container>

--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -31,9 +31,7 @@ const DashboardPage = () => {
   } = useEnterpriseCuration(enterpriseConfig.uuid);
   const intl = useIntl();
 
-  const { tabs, onSelectHandler, activeTab } = useDashboardTabs(
-    { canOnlyViewHighlightSets },
-  );
+  const { tabs, onSelectHandler, activeTab } = useDashboardTabs({ canOnlyViewHighlightSets });
 
   useEffect(() => {
     if (state?.activationSuccess) {

--- a/src/components/dashboard/data/constants.js
+++ b/src/components/dashboard/data/constants.js
@@ -7,3 +7,15 @@ export const COURSE_SECTION_TITLES = {
   assigned: 'Assigned Courses',
   firstTimeUserAndAssigned: 'Your learning journey starts now!',
 };
+
+export const DASHBOARD_COURSES_TAB = 'courses';
+export const DASHBOARD_PROGRAMS_TAB = 'programs';
+export const DASHBOARD_PATHWAYS_TAB = 'pathways';
+export const DASHBOARD_MY_CAREER_TAB = 'my-career';
+
+export const DASHBOARD_TABS_SEGMENT_KEY = {
+  [DASHBOARD_COURSES_TAB]: 'courses_tab',
+  [DASHBOARD_PROGRAMS_TAB]: 'programs_tab',
+  [DASHBOARD_PATHWAYS_TAB]: 'pathways_tab',
+  [DASHBOARD_MY_CAREER_TAB]: 'career_tab',
+};

--- a/src/components/dashboard/data/useDashboardTabs.jsx
+++ b/src/components/dashboard/data/useDashboardTabs.jsx
@@ -1,0 +1,113 @@
+import { Tab } from '@edx/paragon';
+import React, { useContext, useState } from 'react';
+import { AppContext } from '@edx/frontend-platform/react';
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import CoursesTabComponent from '../main-content/CoursesTabComponent';
+import { ProgramListingPage } from '../../program-progress';
+import PathwayProgressListingPage from '../../pathway-progress/PathwayProgressListingPage';
+import { features } from '../../../config';
+import { MyCareerTab } from '../../my-career';
+import {
+  DASHBOARD_COURSES_TAB, DASHBOARD_MY_CAREER_TAB,
+  DASHBOARD_PATHWAYS_TAB,
+  DASHBOARD_PROGRAMS_TAB,
+  DASHBOARD_TABS_SEGMENT_KEY,
+} from './constants';
+import { useInProgressPathwaysData } from '../../pathway-progress/data/hooks';
+import { useLearnerProgramsListData } from '../../program-progress/data/hooks';
+
+const useDashboardTab = ({
+  canOnlyViewHighlightSets,
+}) => {
+  const { enterpriseConfig } = useContext(AppContext);
+  const [activeTab, setActiveTab] = useState(DASHBOARD_COURSES_TAB);
+  const intl = useIntl();
+
+  const [learnerProgramsListData, programsFetchError] = useLearnerProgramsListData(enterpriseConfig.uuid);
+  const [pathwayProgressData, pathwayFetchError] = useInProgressPathwaysData(enterpriseConfig.uuid);
+
+  const onSelectHandler = (tabName) => {
+    setActiveTab(tabName);
+    sendEnterpriseTrackEvent(
+      enterpriseConfig.uuid,
+          `edx.ui.enterprise.learner_portal.${DASHBOARD_TABS_SEGMENT_KEY[tabName]}.page_visit`,
+    );
+  };
+
+  // Defines the tab components and rendered child, and filters based on active features
+  const allTabs = [
+    <Tab
+      eventKey={DASHBOARD_COURSES_TAB}
+      title={intl.formatMessage({
+        id: 'enterprise.dashboard.tab.courses',
+        defaultMessage: 'Courses',
+        description: 'Title for courses tab on enterprise dashboard.',
+      })}
+    >
+      {activeTab === DASHBOARD_COURSES_TAB && (
+        <CoursesTabComponent
+          canOnlyViewHighlightSets={canOnlyViewHighlightSets}
+        />
+      )}
+    </Tab>,
+    enterpriseConfig.enablePrograms && (
+      <Tab
+        eventKey={DASHBOARD_PROGRAMS_TAB}
+        title={intl.formatMessage({
+          id: 'enterprise.dashboard.tab.programs',
+          defaultMessage: 'Programs',
+          description: 'Title for programs tab on enterprise dashboard.',
+        })}
+        disabled={learnerProgramsListData.length === 0}
+      >
+        {activeTab === DASHBOARD_PROGRAMS_TAB && (
+          <ProgramListingPage
+            canOnlyViewHighlightSets={canOnlyViewHighlightSets}
+            programsListData={learnerProgramsListData}
+            programsFetchError={programsFetchError}
+          />
+        )}
+      </Tab>
+    ),
+    enterpriseConfig.enablePathways && (
+      <Tab
+        eventKey={DASHBOARD_PATHWAYS_TAB}
+        title={intl.formatMessage({
+          id: 'enterprise.dashboard.tab.pathways',
+          defaultMessage: 'Pathways',
+          description: 'Title for pathways tab on enterprise dashboard.',
+        })}
+        disabled={pathwayProgressData.length === 0}
+      >
+        {activeTab === DASHBOARD_PATHWAYS_TAB && (
+          <PathwayProgressListingPage
+            canOnlyViewHighlightSets={canOnlyViewHighlightSets}
+            pathwayProgressData={pathwayProgressData}
+            pathwayFetchError={pathwayFetchError}
+          />
+        )}
+      </Tab>
+    ),
+    features.FEATURE_ENABLE_MY_CAREER && (
+      <Tab
+        eventKey={DASHBOARD_MY_CAREER_TAB}
+        title={intl.formatMessage({
+          id: 'enterprise.dashboard.tab.my.career',
+          defaultMessage: 'My Career',
+          description: 'Title for my career tab on enterprise dashboard.',
+        })}
+      >
+        {activeTab === DASHBOARD_MY_CAREER_TAB && <MyCareerTab />}
+      </Tab>
+    ),
+  ].filter(tab => tab); // Filtering done for truthy values
+
+  return {
+    tabs: allTabs,
+    onSelectHandler,
+    activeTab,
+  };
+};
+
+export default useDashboardTab;

--- a/src/components/dashboard/data/useDashboardTabs.jsx
+++ b/src/components/dashboard/data/useDashboardTabs.jsx
@@ -17,7 +17,7 @@ import {
 import { useInProgressPathwaysData } from '../../pathway-progress/data/hooks';
 import { useLearnerProgramsListData } from '../../program-progress/data/hooks';
 
-const useDashboardTab = ({
+const useDashboardTabs = ({
   canOnlyViewHighlightSets,
 }) => {
   const { enterpriseConfig } = useContext(AppContext);
@@ -110,4 +110,4 @@ const useDashboardTab = ({
   };
 };
 
-export default useDashboardTab;
+export default useDashboardTabs;

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -258,12 +258,23 @@ describe('<Dashboard />', () => {
     expect(screen.queryByText(LICENSE_ACTIVATION_MESSAGE)).toBeFalsy();
   });
 
-  it('renders a sidebar on a large screen', () => {
+  it('renders a courses sidebar on a large screen', async () => {
     window.matchMedia.setConfig(mockWindowConfig);
     renderWithRouter(
       <DashboardWithContext />,
     );
     expect(screen.getByTestId('courses-tab-sidebar')).toBeInTheDocument();
+  });
+
+  it('renders a add job sidebar on a large screen', async () => {
+    features.FEATURE_ENABLE_MY_CAREER.mockImplementation(() => true);
+    window.matchMedia.setConfig(mockWindowConfig);
+    renderWithRouter(
+      <DashboardWithContext />,
+    );
+
+    userEvent.click(screen.getByText('My Career'));
+
     expect(screen.getByTestId('add-job-role-sidebar')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Updates the logic for the dashboard tab components to conditionally render the children of each tab and abstract the logic into an independent hook.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
