### PR TITLE
fix: update point of contact email for admin support

### DIFF
--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -45,6 +45,7 @@ const CoursePage = () => {
   const {
     uuid: enterpriseUUID,
     adminUsers: enterpriseAdminUsers,
+    contactEmail,
   } = enterpriseConfig;
   const {
     subscriptionPlan,
@@ -203,6 +204,7 @@ const CoursePage = () => {
     onSubscriptionLicenseForCourseValidationError,
     missingSubsidyAccessPolicyReason,
     enterpriseAdminUsers,
+    contactEmail,
     courseListPrice,
     customerAgreementConfig,
   });

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -654,6 +654,7 @@ export const useUserSubsidyApplicableToCourse = ({
   enterpriseOffers,
   onSubscriptionLicenseForCourseValidationError,
   enterpriseAdminUsers: fallbackAdminUsers,
+  contactEmail,
   courseListPrice,
   customerAgreementConfig,
 }) => {
@@ -716,6 +717,7 @@ export const useUserSubsidyApplicableToCourse = ({
         );
         missingApplicableSubsidyReason = getMissingApplicableSubsidyReason({
           enterpriseAdminUsers,
+          contactEmail,
           catalogsWithCourse,
           couponCodes,
           couponsOverview,
@@ -757,6 +759,7 @@ export const useUserSubsidyApplicableToCourse = ({
     isPolicyRedemptionEnabled,
     missingSubsidyAccessPolicyReason,
     fallbackAdminUsers,
+    contactEmail,
     couponsOverview,
   ]);
 

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -1039,6 +1039,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     },
     enterpriseAdminUsers: [],
     customerAgreementConfig: undefined,
+    contactEmail: undefined,
   };
   const argsWithMissingCourse = {
     ...baseArgs,

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -605,6 +605,7 @@ describe('getMissingSubsidyReasonActions', () => {
     const ActionsComponent = getMissingSubsidyReasonActions({
       reasonType,
       enterpriseAdminUsers: [],
+      contactEmail: 'randomEmail@edx.org',
     });
     render(ActionsComponent);
     const ctaBtn = screen.getByText('Learn about limits');
@@ -616,6 +617,7 @@ describe('getMissingSubsidyReasonActions', () => {
     const ActionsComponent = getMissingSubsidyReasonActions({
       reasonType: DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_DEACTIVATED,
       enterpriseAdminUsers: [],
+      contactEmail: 'randomEmail@edx.org',
     });
     render(ActionsComponent);
     const ctaBtn = screen.getByText('Learn about deactivation');
@@ -632,10 +634,11 @@ describe('getMissingSubsidyReasonActions', () => {
     DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_EXPIRED,
     DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_SEATS_EXHAUSTED,
     DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_LICENSE_NOT_ASSIGNED,
-  ])('returns "Contact administrator" CTA when `reasonType` is: %s', (reasonType) => {
+  ])('returns enterpriseAdminUsers email "Contact administrator" CTA when `reasonType` is: %s', (reasonType) => {
     const ActionsComponent = getMissingSubsidyReasonActions({
       reasonType,
       enterpriseAdminUsers: [{ email: 'admin@example.com' }],
+      contactEmail: undefined,
     });
     render(ActionsComponent);
     const ctaBtn = screen.getByText('Contact administrator');
@@ -652,10 +655,32 @@ describe('getMissingSubsidyReasonActions', () => {
     DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_EXPIRED,
     DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_SEATS_EXHAUSTED,
     DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_LICENSE_NOT_ASSIGNED,
+  ])('returns contactEmail value in "Contact administrator" CTA when `reasonType` is: %s', (reasonType) => {
+    const ActionsComponent = getMissingSubsidyReasonActions({
+      reasonType,
+      enterpriseAdminUsers: [{ email: 'admin@example.com' }],
+      contactEmail: 'testEmail@edx.org',
+    });
+    render(ActionsComponent);
+    const ctaBtn = screen.getByText('Contact administrator');
+    expect(ctaBtn).toBeInTheDocument();
+    expect(ctaBtn.getAttribute('href')).toEqual('mailto:testEmail@edx.org');
+  });
+
+  it.each([
+    DISABLED_ENROLL_REASON_TYPES.NO_SUBSIDY,
+    DISABLED_ENROLL_REASON_TYPES.POLICY_NOT_ACTIVE,
+    DISABLED_ENROLL_REASON_TYPES.LEARNER_NOT_IN_ENTERPRISE,
+    DISABLED_ENROLL_REASON_TYPES.CONTENT_NOT_IN_CATALOG,
+    DISABLED_ENROLL_REASON_TYPES.NOT_ENOUGH_VALUE_IN_SUBSIDY,
+    DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_EXPIRED,
+    DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_SEATS_EXHAUSTED,
+    DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_LICENSE_NOT_ASSIGNED,
   ])('returns no "Contact administrator" CTA when `reasonType` is %s and there are no enterprise admins', (reasonType) => {
     const ActionsComponent = getMissingSubsidyReasonActions({
       reasonType,
       enterpriseAdminUsers: [],
+      contactEmail: 'randomEmail@edx.org',
     });
     const { container } = render(ActionsComponent);
     expect(container).toBeEmptyDOMElement();
@@ -665,6 +690,7 @@ describe('getMissingSubsidyReasonActions', () => {
     const ActionsComponent = getMissingSubsidyReasonActions({
       reasonType: 'invalid',
       enterpriseAdminUsers: [],
+      contactEmail: 'randomEmail@edx.org',
     });
     const { container } = render(ActionsComponent);
     expect(container).toBeEmptyDOMElement();

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -578,10 +578,12 @@ export const getEnterpriseOffersDisabledEnrollmentReasonType = ({
  * @param {object} args
  * @param {string} args.reasonType Reason type for the missing subsidy.
  * @param {array} args.enterpriseAdminUsers List of enterprise admin users.
+ * @param {string} args.contactEmail String of customer admin contact email as POC
  */
 export const getMissingSubsidyReasonActions = ({
   reasonType,
   enterpriseAdminUsers,
+  contactEmail,
 }) => {
   const hasLimitsLearnMoreCTA = [
     DISABLED_ENROLL_REASON_TYPES.LEARNER_MAX_SPEND_REACHED,
@@ -639,7 +641,14 @@ export const getMissingSubsidyReasonActions = ({
     if (enterpriseAdminUsers?.length === 0) {
       return null;
     }
-    const adminEmails = enterpriseAdminUsers.map(({ email }) => email).join(',');
+
+    let adminEmails = null;
+    if (contactEmail) {
+      adminEmails = contactEmail;
+    } else if (enterpriseAdminUsers.length >= 1) {
+      adminEmails = enterpriseAdminUsers.map(({ email }) => email).join(',');
+    }
+
     return (
       <Button
         as={MailtoLink}
@@ -660,6 +669,7 @@ export const getMissingSubsidyReasonActions = ({
 
 export const getMissingApplicableSubsidyReason = ({
   enterpriseAdminUsers,
+  contactEmail,
   catalogsWithCourse,
   couponCodes,
   couponsOverview,
@@ -728,6 +738,7 @@ export const getMissingApplicableSubsidyReason = ({
     actions: getMissingSubsidyReasonActions({
       reasonType,
       enterpriseAdminUsers,
+      contactEmail,
     }),
   };
 };


### PR DESCRIPTION
## Description
When a learner clicks on the Contact Administrator button in `CoursePage`, they would address all the admins associated with the enterprise's account instead of the email linked as the public point of contact. The solution is to add the `contactEmail` property from the `enterpriseConfig` and pass that value down to the `getMissingSubsidyReasonActions` util function where the logic is updated to check for the `contactEmail` or fall back to the admin users emails.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
