### PR TITLE
feat: improve codecov around dashboard tab changes and adds prefetching

### DIFF
--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -31,7 +31,9 @@ const DashboardPage = () => {
   } = useEnterpriseCuration(enterpriseConfig.uuid);
   const intl = useIntl();
 
-  const { tabs, onSelectHandler, activeTab } = useDashboardTabs({ canOnlyViewHighlightSets });
+  const {
+    tabs, onSelectHandler, activeTab, prefetchTab,
+  } = useDashboardTabs({ canOnlyViewHighlightSets });
 
   useEffect(() => {
     if (state?.activationSuccess) {
@@ -83,6 +85,7 @@ const DashboardPage = () => {
         <Tabs
           activeKey={activeTab}
           onSelect={onSelectHandler}
+          onMouseOverCapture={prefetchTab}
         >
           {tabs}
         </Tabs>

--- a/src/components/dashboard/data/constants.js
+++ b/src/components/dashboard/data/constants.js
@@ -19,10 +19,3 @@ export const DASHBOARD_TABS_SEGMENT_KEY = {
   [DASHBOARD_PATHWAYS_TAB]: 'pathways_tab',
   [DASHBOARD_MY_CAREER_TAB]: 'career_tab',
 };
-
-export const PREFETCH_TAB_ENABLED = {
-  [DASHBOARD_COURSES_TAB]: false,
-  [DASHBOARD_PROGRAMS_TAB]: false,
-  [DASHBOARD_PATHWAYS_TAB]: false,
-  [DASHBOARD_MY_CAREER_TAB]: true,
-};

--- a/src/components/dashboard/data/constants.js
+++ b/src/components/dashboard/data/constants.js
@@ -19,3 +19,10 @@ export const DASHBOARD_TABS_SEGMENT_KEY = {
   [DASHBOARD_PATHWAYS_TAB]: 'pathways_tab',
   [DASHBOARD_MY_CAREER_TAB]: 'career_tab',
 };
+
+export const PREFETCH_TAB_ENABLED = {
+  [DASHBOARD_COURSES_TAB]: false,
+  [DASHBOARD_PROGRAMS_TAB]: false,
+  [DASHBOARD_PATHWAYS_TAB]: false,
+  [DASHBOARD_MY_CAREER_TAB]: true,
+};

--- a/src/components/dashboard/data/useDashboardTabs.jsx
+++ b/src/components/dashboard/data/useDashboardTabs.jsx
@@ -101,7 +101,7 @@ const useDashboardTabs = ({
         {activeTab === DASHBOARD_MY_CAREER_TAB && <MyCareerTab />}
       </Tab>
     ),
-  ].filter(tab => tab); // Filtering done for truthy values
+  ].filter(tab => tab); // Filtering for truthy values
 
   return {
     tabs: allTabs,

--- a/src/components/dashboard/data/useDashboardTabs.jsx
+++ b/src/components/dashboard/data/useDashboardTabs.jsx
@@ -1,4 +1,4 @@
-import { Skeleton, Tab } from '@edx/paragon';
+import { Tab } from '@edx/paragon';
 import React, { useContext, useState } from 'react';
 import loadable from '@loadable/component';
 
@@ -11,36 +11,15 @@ import PathwayProgressListingPage from '../../pathway-progress/PathwayProgressLi
 import { features } from '../../../config';
 
 import {
-  DASHBOARD_COURSES_TAB, DASHBOARD_MY_CAREER_TAB,
+  DASHBOARD_COURSES_TAB,
+  DASHBOARD_MY_CAREER_TAB,
   DASHBOARD_PATHWAYS_TAB,
   DASHBOARD_PROGRAMS_TAB,
-  DASHBOARD_TABS_SEGMENT_KEY, PREFETCH_TAB_ENABLED,
+  DASHBOARD_TABS_SEGMENT_KEY,
 } from './constants';
 import { useInProgressPathwaysData } from '../../pathway-progress/data/hooks';
 import { useLearnerProgramsListData } from '../../program-progress/data/hooks';
-
-const MyCareerTabSkeleton = () => (
-  <div className="py-3">
-    <header>
-      <h2>
-        <Skeleton width={200} />
-      </h2>
-    </header>
-    <section className="row">
-      <div className="col-lg-8">
-        <Skeleton count={5} />
-      </div>
-      <aside className="card col-lg-4 p-3">
-        <h3>
-          <Skeleton count={1} />
-        </h3>
-        <p>
-          <Skeleton count={3} />
-        </p>
-      </aside>
-    </section>
-  </div>
-);
+import MyCareerTabSkeleton from '../../my-career/MyCareerTabSkeleton';
 
 const MyCareerTab = loadable(() => import(
   '../../my-career/MyCareerTab'
@@ -69,8 +48,10 @@ const useDashboardTabs = ({
   // Creates prefetch logic based on loadable-components, "component splitting" capability expose to Tabs component
   const prefetchTab = (e) => {
     const eventTarget = e.target;
+
+    // `rbEventKey` is added by Paragon's usage of `react-bootstrap` in the `Tabs` component.
     const eventKey = eventTarget.dataset.rbEventKey;
-    if (PREFETCH_TAB_ENABLED[eventKey] && eventKey === DASHBOARD_MY_CAREER_TAB) {
+    if (eventKey === DASHBOARD_MY_CAREER_TAB) {
       MyCareerTab.preload();
     }
   };

--- a/src/components/dashboard/data/useDashboardTabs.jsx
+++ b/src/components/dashboard/data/useDashboardTabs.jsx
@@ -1,5 +1,7 @@
-import { Tab } from '@edx/paragon';
+import { Skeleton, Tab } from '@edx/paragon';
 import React, { useContext, useState } from 'react';
+import loadable from '@loadable/component';
+
 import { AppContext } from '@edx/frontend-platform/react';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -7,15 +9,21 @@ import CoursesTabComponent from '../main-content/CoursesTabComponent';
 import { ProgramListingPage } from '../../program-progress';
 import PathwayProgressListingPage from '../../pathway-progress/PathwayProgressListingPage';
 import { features } from '../../../config';
-import { MyCareerTab } from '../../my-career';
+
 import {
   DASHBOARD_COURSES_TAB, DASHBOARD_MY_CAREER_TAB,
   DASHBOARD_PATHWAYS_TAB,
   DASHBOARD_PROGRAMS_TAB,
-  DASHBOARD_TABS_SEGMENT_KEY,
+  DASHBOARD_TABS_SEGMENT_KEY, PREFETCH_TAB_ENABLED,
 } from './constants';
 import { useInProgressPathwaysData } from '../../pathway-progress/data/hooks';
 import { useLearnerProgramsListData } from '../../program-progress/data/hooks';
+
+const MyCareerTab = loadable(() => import(
+  '../../my-career/MyCareerTab'
+), {
+  fallback: <Skeleton height={30} />,
+});
 
 const useDashboardTabs = ({
   canOnlyViewHighlightSets,
@@ -33,6 +41,15 @@ const useDashboardTabs = ({
       enterpriseConfig.uuid,
           `edx.ui.enterprise.learner_portal.${DASHBOARD_TABS_SEGMENT_KEY[tabName]}.page_visit`,
     );
+  };
+
+  // Creates prefetch logic based on loadable-components, "component splitting" capability expose to Tabs component
+  const prefetchTab = (e) => {
+    const eventTarget = e.target;
+    const eventKey = eventTarget.dataset.rbEventKey;
+    if (PREFETCH_TAB_ENABLED[eventKey] && eventKey === DASHBOARD_MY_CAREER_TAB) {
+      MyCareerTab.preload();
+    }
   };
 
   // Defines the tab components and rendered child, and filters based on active features
@@ -107,6 +124,7 @@ const useDashboardTabs = ({
     tabs: allTabs,
     onSelectHandler,
     activeTab,
+    prefetchTab,
   };
 };
 

--- a/src/components/dashboard/data/useDashboardTabs.jsx
+++ b/src/components/dashboard/data/useDashboardTabs.jsx
@@ -19,10 +19,33 @@ import {
 import { useInProgressPathwaysData } from '../../pathway-progress/data/hooks';
 import { useLearnerProgramsListData } from '../../program-progress/data/hooks';
 
+const MyCareerTabSkeleton = () => (
+  <div className="py-3">
+    <header>
+      <h2>
+        <Skeleton width={200} />
+      </h2>
+    </header>
+    <section className="row">
+      <div className="col-lg-8">
+        <Skeleton count={5} />
+      </div>
+      <aside className="card col-lg-4 p-3">
+        <h3>
+          <Skeleton count={1} />
+        </h3>
+        <p>
+          <Skeleton count={3} />
+        </p>
+      </aside>
+    </section>
+  </div>
+);
+
 const MyCareerTab = loadable(() => import(
   '../../my-career/MyCareerTab'
 ), {
-  fallback: <Skeleton height={30} />,
+  fallback: <MyCareerTabSkeleton />,
 });
 
 const useDashboardTabs = ({

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -8,6 +8,7 @@ import Cookies from 'universal-cookie';
 import userEvent from '@testing-library/user-event';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
+import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { CourseContextProvider } from '../../course/CourseContextProvider';
 import { SUBSCRIPTION_EXPIRED_MODAL_TITLE, SUBSCRIPTION_EXPIRING_MODAL_TITLE } from '../SubscriptionExpirationModal';
@@ -16,6 +17,7 @@ import { features } from '../../../config';
 import * as courseEnrollmentsHooks from '../main-content/course-enrollments/data/hooks';
 import * as myCareerHooks from '../../my-career/data/hooks';
 import * as pathwayProgressHooks from '../../pathway-progress/data/hooks';
+import * as programsHooks from '../../program-progress/data/hooks';
 import { renderWithRouter } from '../../../utils/tests';
 import DashboardPage from '../DashboardPage';
 import { LICENSE_ACTIVATION_MESSAGE } from '../data/constants';
@@ -25,6 +27,46 @@ import { LICENSE_STATUS, emptyRedeemableLearnerCreditPolicies } from '../../ente
 import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import { SUBSIDY_TYPE } from '../../enterprise-subsidy-requests/constants';
 import { sortAssignmentsByAssignmentStatus } from '../main-content/course-enrollments/data/utils';
+import learnerPathwayData from '../../pathway-progress/data/__mocks__/PathwayProgressListData.json';
+
+const dummyProgramData = {
+  uuid: 'test-uuid',
+  title: 'Test Program Title',
+  type: 'MicroMasters',
+  bannerImage: {
+    large: {
+      url: 'www.example.com/large',
+      height: 123,
+      width: 455,
+    },
+    medium: {
+      url: 'www.example.com/medium',
+      height: 123,
+      width: 455,
+    },
+    small: {
+      url: 'www.example.com/small',
+      height: 123,
+      width: 455,
+    },
+    xSmall: {
+      url: 'www.example.com/xSmall',
+      height: 123,
+      width: 455,
+    },
+  },
+  authoringOrganizations: [
+    {
+      key: 'test-key',
+      logoImageUrl: '/media/organization/logos/shield.png',
+    },
+  ],
+  progress: {
+    inProgress: 1,
+    completed: 2,
+    notStarted: 3,
+  },
+};
 
 const defaultCouponCodesState = {
   couponCodes: [],
@@ -184,6 +226,7 @@ jest.mock('universal-cookie');
 jest.mock('../main-content/course-enrollments/data/hooks');
 jest.mock('../../my-career/data/hooks');
 jest.mock('../../pathway-progress/data/hooks');
+jest.mock('../../program-progress/data/hooks');
 courseEnrollmentsHooks.useCourseEnrollments.mockReturnValue({
   courseEnrollmentsByStatus: {
     inProgress: [],
@@ -210,7 +253,7 @@ courseEnrollmentsHooks.useCourseEnrollmentsBySection.mockReturnValue({
 });
 myCareerHooks.useLearnerProfileData.mockReturnValue([{}, null, false]);
 pathwayProgressHooks.useInProgressPathwaysData.mockReturnValue([{}, null, false]);
-
+programsHooks.useLearnerProgramsListData.mockReturnValue([[], null]);
 // eslint-disable-next-line no-console
 console.error = jest.fn();
 
@@ -276,6 +319,43 @@ describe('<Dashboard />', () => {
     userEvent.click(screen.getByText('My Career'));
 
     expect(screen.getByTestId('add-job-role-sidebar')).toBeInTheDocument();
+  });
+
+  it('renders pathway tab', () => {
+    pathwayProgressHooks.useInProgressPathwaysData.mockReturnValue([camelCaseObject(learnerPathwayData), null]);
+    const appState = {
+      ...defaultAppState,
+      enterpriseConfig: {
+        ...defaultAppState.enterpriseConfig,
+        enablePathways: true,
+      },
+    };
+
+    renderWithRouter(
+      <DashboardWithContext initialAppState={appState} />,
+    );
+
+    userEvent.click(screen.getByText('Pathways'));
+
+    expect(screen.getByTestId('pathway-listing-page')).toBeInTheDocument();
+  });
+
+  it('renders programs tab', async () => {
+    programsHooks.useLearnerProgramsListData.mockImplementation(() => [[dummyProgramData], null]);
+    const appState = {
+      ...defaultAppState,
+      enterpriseConfig: {
+        ...defaultAppState.enterpriseConfig,
+        enablePrograms: true,
+      },
+    };
+    renderWithRouter(
+      <DashboardWithContext initialAppState={appState} />,
+    );
+
+    userEvent.click(screen.getByText('Programs'));
+
+    expect(screen.getByTestId('program-listing-page')).toBeInTheDocument();
   });
 
   it('renders subsidies summary on a small screen', () => {

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { breakpoints } from '@edx/paragon';
@@ -318,7 +318,7 @@ describe('<Dashboard />', () => {
 
     userEvent.click(screen.getByText('My Career'));
 
-    expect(screen.getByTestId('add-job-role-sidebar')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('add-job-role-sidebar')).toBeInTheDocument());
   });
 
   it('renders pathway tab', () => {

--- a/src/components/my-career/MyCareerTab.jsx
+++ b/src/components/my-career/MyCareerTab.jsx
@@ -1,4 +1,6 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, {
+  useContext, useEffect, useState,
+} from 'react';
 
 import { AppContext, ErrorPage } from '@edx/frontend-platform/react';
 import { SearchData } from '@edx/frontend-enterprise-catalog-search';

--- a/src/components/my-career/MyCareerTabSkeleton.jsx
+++ b/src/components/my-career/MyCareerTabSkeleton.jsx
@@ -1,0 +1,29 @@
+import {
+  Card,
+  Col,
+  Row,
+  Skeleton,
+} from '@edx/paragon';
+import React from 'react';
+
+const MyCareerTabSkeleton = () => (
+  <div className="py-4.5">
+    <Row>
+      <Col lg={8}>
+        <h2>
+          <Skeleton width={200} />
+        </h2>
+        <Skeleton count={5} />
+      </Col>
+      <Col as="aside">
+        <Card>
+          <Card.Section>
+            <Skeleton count={3} />
+          </Card.Section>
+        </Card>
+      </Col>
+    </Row>
+  </div>
+);
+
+export default MyCareerTabSkeleton;

--- a/src/components/my-career/data/hooks.jsx
+++ b/src/components/my-career/data/hooks.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
+import Plotly from 'plotly.js-dist';
 import { getLearnerProfileInfo, getLearnerSkillLevels } from './service';
 import { getSpiderChartData, prepareSpiderChartData } from './utils';
 
@@ -85,10 +86,6 @@ export function usePlotlySpiderChart(categories) {
     if (!spiderChartResults) {
       return;
     }
-    import(
-      /* webpackChunkName: "plotly" */'plotly.js-dist'
-    ).then(
-      Plotly => Plotly.newPlot('skill-levels-spider', spiderChartResults.data, spiderChartResults.layout, spiderChartResults.config),
-    );
+    Plotly.newPlot('skill-levels-spider', spiderChartResults.data, spiderChartResults.layout, spiderChartResults.config);
   }, [spiderChartResults]);
 }

--- a/src/components/my-career/data/hooks.jsx
+++ b/src/components/my-career/data/hooks.jsx
@@ -56,8 +56,6 @@ export function useLearnerSkillLevels(jobId) {
 }
 
 export function usePlotlySpiderChart(categories) {
-  const [spiderChartResults, setSpiderChartResults] = useState();
-
   useEffect(() => { // eslint-disable-line consistent-return
     if (!categories) {
       return;
@@ -75,17 +73,7 @@ export function usePlotlySpiderChart(categories) {
       averageScores,
       learnerScores,
     );
-    setSpiderChartResults({
-      data,
-      layout,
-      config,
-    });
-  }, [categories]);
 
-  useEffect(() => {
-    if (!spiderChartResults) {
-      return;
-    }
-    Plotly.newPlot('skill-levels-spider', spiderChartResults.data, spiderChartResults.layout, spiderChartResults.config);
-  }, [spiderChartResults]);
+    Plotly.newPlot('skill-levels-spider', data, layout, config);
+  }, [categories]);
 }

--- a/src/components/pathway-progress/PathwayProgressListingPage.jsx
+++ b/src/components/pathway-progress/PathwayProgressListingPage.jsx
@@ -36,7 +36,7 @@ const PathwayProgressListingPage = ({ canOnlyViewHighlightSets, pathwayProgressD
   }
 
   return (
-    <div className="py-5">
+    <div className="py-5" data-testid="pathway-listing-page">
       {pathwayProgressData.length > 0 ? (
         <CardGrid columnSizes={{ xs: 12, lg: 6 }}>
           {pathwayProgressData.map((pathway) => (

--- a/src/components/program-progress/ProgramListingPage.jsx
+++ b/src/components/program-progress/ProgramListingPage.jsx
@@ -32,7 +32,7 @@ const ProgramListingPage = ({ canOnlyViewHighlightSets, programsListData, progra
   }
 
   return (
-    <div className="py-5">
+    <div className="py-5" data-testid="program-listing-page">
       {programsListData.length > 0 ? (
         <CardGrid columnSizes={{ xs: 12, lg: 6 }}>
           {programsListData.map((program) => <ProgramListingCard program={program} key={program.title} />)}

--- a/src/components/program-progress/tests/ProgramListingPage.test.jsx
+++ b/src/components/program-progress/tests/ProgramListingPage.test.jsx
@@ -51,7 +51,6 @@ const dummyProgramData = {
     completed: 2,
     notStarted: 3,
   },
-
 };
 
 jest.mock('@edx/frontend-platform/react', () => ({


### PR DESCRIPTION
Add tests relating to a related PRs code changes to uphold repository testing coverage.
Adds prefetching on hover of the My Career tab.

Adds Skeleton state for the My Career tab while prefetching
![Screenshot 2024-02-08 at 5 49 21 PM](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/82611798/0cd1e7b6-30b9-4801-8549-3333304cf46b)



