### PR TITLE
fix: changing definition of archived

### DIFF
--- a/src/components/course/course-header/tests/CourseHeader.test.jsx
+++ b/src/components/course/course-header/tests/CourseHeader.test.jsx
@@ -137,7 +137,7 @@ const archivedCourseState = {
     catalogList: [],
   },
   courseRunKeys: ['test-course-run-key'],
-  courseRunStatuses: ['archived'],
+  courseRunStatuses: ['archived', 'unpublished'],
 };
 
 const defaultUserSubsidyState = {

--- a/src/components/search/content-highlights/ContentHighlightSet.jsx
+++ b/src/components/search/content-highlights/ContentHighlightSet.jsx
@@ -30,7 +30,12 @@ const ContentHighlightSet = ({ highlightSet }) => {
       courseRunStatuses,
     } = highlightedContent[i];
     if (courseRunStatuses) {
-      if (courseRunStatuses?.every(status => status === COURSE_RUN_AVAILABILITY.ARCHIVED)) {
+      if (courseRunStatuses.length === 1
+        && courseRunStatuses.includes(COURSE_RUN_AVAILABILITY.ARCHIVED)) {
+        archivedContent.push(highlightedContent[i]);
+      } if (courseRunStatuses.length === 2
+        && courseRunStatuses.includes(COURSE_RUN_AVAILABILITY.ARCHIVED
+        && courseRunStatuses.includes(COURSE_RUN_AVAILABILITY.UNPUBLISHED))) {
         archivedContent.push(highlightedContent[i]);
       } else {
         activeContent.push(highlightedContent[i]);

--- a/src/components/search/content-highlights/HighlightedContentCard.jsx
+++ b/src/components/search/content-highlights/HighlightedContentCard.jsx
@@ -38,7 +38,9 @@ const HighlightedContentCard = ({
     highlightedContent,
   });
 
-  const archivedCourse = courseRunStatuses?.every(status => status === COURSE_RUN_AVAILABILITY.ARCHIVED);
+  const archivedCourse = courseRunStatuses?.every(status => (
+    status === COURSE_RUN_AVAILABILITY.ARCHIVED || status === COURSE_RUN_AVAILABILITY.UNPUBLISHED
+  ));
 
   const handleContentCardClick = () => {
     if (!href) {


### PR DESCRIPTION
Changing the definition of an archived course to also include courses where their only course run statuses are archived or archived and unpublished. 
