### PR TITLE
feat: defer importing videojs only on video play

### DIFF
--- a/src/components/course/course-header/CoursePreview.jsx
+++ b/src/components/course/course-header/CoursePreview.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { PlayCircleFilled } from '@edx/paragon/icons';
 import { useToggle, Image } from '@edx/paragon';
-import { VideoPlayer } from '../../video';
+
+import VideoPlayer from '../../video/VideoPlayer';
 
 const CoursePreview = ({ previewImage, previewVideoURL }) => {
   const [isVideoPlaying, playVideo] = useToggle(false);
-
   return (
     <div className="course-preview-wrapper">
       {previewVideoURL ? (

--- a/src/components/course/course-header/CoursePreview.jsx
+++ b/src/components/course/course-header/CoursePreview.jsx
@@ -1,13 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import loadable from '@loadable/component';
 
 import { PlayCircleFilled } from '@edx/paragon/icons';
-import { useToggle, Image } from '@edx/paragon';
+import { useToggle, Image, Skeleton } from '@edx/paragon';
+import DelayedFallbackContainer from '../../DelayedFallback/DelayedFallbackContainer';
 
-import VideoPlayer from '../../video/VideoPlayer';
+const VideoPlayer = loadable(() => import(/* webpackChunkName: "videojs" */ '../../video/VideoPlayer'), {
+  fallback: (
+    <DelayedFallbackContainer>
+      <Skeleton height={200} />
+    </DelayedFallbackContainer>
+  ),
+});
 
 const CoursePreview = ({ previewImage, previewVideoURL }) => {
   const [isVideoPlaying, playVideo] = useToggle(false);
+
+  useEffect(() => {
+    if (previewVideoURL) {
+      VideoPlayer.preload();
+    }
+  }, [previewVideoURL]);
+
   return (
     <div className="course-preview-wrapper">
       {previewVideoURL ? (

--- a/src/components/video/VideoPlayer.jsx
+++ b/src/components/video/VideoPlayer.jsx
@@ -1,11 +1,7 @@
-import React, { lazy, Suspense, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import DelayedFallbackContainer from '../DelayedFallback/DelayedFallbackContainer';
+import VideoJS from './VideoJS';
 
-const VideoJS = lazy(() => import(
-  /* webpackChunkName: "videojs" */
-  './VideoJS'
-));
 const hlsExtension = '.m3u8';
 const defaultOptions = {
   autoplay: true,
@@ -36,13 +32,7 @@ const VideoPlayer = ({ videoURL, onReady }) => {
 
   return (
     <div className="video-player-container">
-      <Suspense
-        fallback={
-          <DelayedFallbackContainer className="py-5 d-flex justify-content-center align-items-center" />
-        }
-      >
-        <VideoJS options={videoDetails} onReady={onReady} />
-      </Suspense>
+      <VideoJS options={videoDetails} onReady={onReady} />
     </div>
   );
 };

--- a/src/components/video/VideoPlayer.jsx
+++ b/src/components/video/VideoPlayer.jsx
@@ -1,8 +1,11 @@
-import React, { useMemo } from 'react';
+import React, { lazy, Suspense, useMemo } from 'react';
 import PropTypes from 'prop-types';
+import DelayedFallbackContainer from '../DelayedFallback/DelayedFallbackContainer';
 
-import VideoJS from './VideoJS';
-
+const VideoJS = lazy(() => import(
+  /* webpackChunkName: "videojs" */
+  './VideoJS'
+));
 const hlsExtension = '.m3u8';
 const defaultOptions = {
   autoplay: true,
@@ -33,7 +36,13 @@ const VideoPlayer = ({ videoURL, onReady }) => {
 
   return (
     <div className="video-player-container">
-      <VideoJS options={videoDetails} onReady={onReady} />
+      <Suspense
+        fallback={
+          <DelayedFallbackContainer className="py-5 d-flex justify-content-center align-items-center" />
+        }
+      >
+        <VideoJS options={videoDetails} onReady={onReady} />
+      </Suspense>
     </div>
   );
 };

--- a/src/components/video/tests/VideoPlayer.test.jsx
+++ b/src/components/video/tests/VideoPlayer.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { waitFor } from '@testing-library/react';
 import { VideoPlayer } from '..';
 import { renderWithRouter } from '../../../utils/tests';
 
@@ -6,10 +7,10 @@ const hlsUrl = 'https://test-domain.com/test-prefix/id.m3u8';
 const ytUrl = 'https://www.youtube.com/watch?v=oHg5SJYRHA0';
 
 describe('Video Player component', () => {
-  it('Renders Video Player components correctly.', () => {
+  it('Renders Video Player components correctly.', async () => {
     const { container } = renderWithRouter(<VideoPlayer videoURL={hlsUrl} />);
     expect(container.querySelector('.video-player-container')).toBeTruthy();
-    expect(container.querySelector('.video-js-wrapper')).toBeTruthy();
+    await waitFor(() => expect(container.querySelector('.video-js-wrapper')).toBeTruthy());
     expect(container.querySelector('.vjs-big-play-centered')).toBeTruthy();
     expect(container.querySelector('video-js')).toBeTruthy();
   });


### PR DESCRIPTION
Defer importing `VideoJS` component only when a video is being played. This results in pages that don't have a video to not have to import `video.js` and other associated imports at all.

Example of deferred loading:
https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/82611798/ce71ef33-18d7-4201-952c-2f4b8310faa2





# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
