### PR TITLE
feat: Catch errors around root loader

### DIFF
--- a/src/components/site-header/SiteHeaderNavMenu.jsx
+++ b/src/components/site-header/SiteHeaderNavMenu.jsx
@@ -25,7 +25,7 @@ const SiteHeaderNavMenu = () => {
           description: 'Dashboard link title in site header navigation.',
         })}
       </NavLink>
-      {!contentHighlightsConfiguration.canOnlyViewHighlightSets && (
+      {!contentHighlightsConfiguration?.canOnlyViewHighlightSets && (
         <NavLink to={`/${activeEnterpriseCustomer.slug}/search`} className={mainMenuLinkClassName}>
           {intl.formatMessage({
             id: 'site.header.nav.search.title',

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -102,7 +102,7 @@ export function queryCacheOnErrorHandler(error, query) {
 }
 
 export function defaultQueryClientRetryHandler(failureCount, err) {
-  if (failureCount >= 3 || err.customAttributes?.httpErrorStatus === 404) {
+  if (failureCount >= 3 || err.customAttributes?.httpErrorStatus === 404 || err.response.status === 404) {
     return false;
   }
   return true;


### PR DESCRIPTION
Catches errors around the `rootLoader` loader. The rootLoader will throw an error if the returned services are undefined.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
