### PR TITLE
feat: resolve all data during route transitions

### DIFF
--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -93,6 +93,11 @@ const queryClient = new QueryClient({
   },
 });
 
+// Determines amount of time that must elapse before the
+// NProgress loader is shown in the UI. No need to show it
+// for quick route transitions.
+const NPROGRESS_DELAY_MS = 300;
+
 const Root = () => {
   const navigation = useNavigation();
   const fetchers = useFetchers();
@@ -105,7 +110,7 @@ const Root = () => {
       } else {
         NProgress.start();
       }
-    }, 300);
+    }, NPROGRESS_DELAY_MS);
     return () => clearTimeout(timeoutId);
   }, [navigation, fetchers]);
 

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -18,8 +18,6 @@ import {
   generatePath,
   useAsyncError,
   Link,
-  useLoaderData,
-  Await,
 } from 'react-router-dom';
 import NProgress from 'nprogress';
 import { Helmet } from 'react-helmet';
@@ -304,8 +302,6 @@ const Course = () => {
 };
 
 const Layout = () => {
-  const loaderData = useLoaderData();
-
   const { authenticatedUser } = useContext(AppContext);
   const { data: enterpriseLearnerData } = useEnterpriseLearner();
 

--- a/src/components/app/routes/loaders/dashboardLoader.js
+++ b/src/components/app/routes/loaders/dashboardLoader.js
@@ -1,0 +1,21 @@
+import { extractActiveEnterpriseId, makeEnterpriseCourseEnrollmentsQuery } from './courseLoader';
+import ensureAuthenticatedUser from './ensureAuthenticatedUser';
+
+/**
+ * TODO
+ * @param {*} queryClient
+ * @returns
+ */
+export default function makeDashboardLoader(queryClient) {
+  return async function dashboardLoader({ params = {} }) {
+    const authenticatedUser = await ensureAuthenticatedUser();
+    const { enterpriseSlug } = params;
+    const enterpriseId = await extractActiveEnterpriseId({
+      queryClient,
+      authenticatedUser,
+      enterpriseSlug,
+    });
+    await queryClient.fetchQuery(makeEnterpriseCourseEnrollmentsQuery(enterpriseId));
+    return null;
+  };
+}

--- a/src/components/app/routes/loaders/updateActiveEnterpriseCustomerUserLoader.js
+++ b/src/components/app/routes/loaders/updateActiveEnterpriseCustomerUserLoader.js
@@ -28,17 +28,6 @@ export default function makeUpdateActiveEnterpriseCustomerUserLoader(queryClient
       return null;
     }
 
-    console.log({
-      currentEnterpriseSlug,
-      nextEnterpriseSlug,
-      activeEnterpriseCustomerSlug: activeEnterpriseCustomer?.slug,
-    });
-
-    // Return early (do nothing) if the enterprise slug matches the active enterprise customer.
-    // if (currentEnterpriseSlug === nextEnterpriseSlug && nextEnterpriseSlug === activeEnterpriseCustomer?.slug) {
-    //   return null;
-    // }
-
     if (nextEnterpriseSlug !== activeEnterpriseCustomer.slug) {
       // Otherwise, try to find the enterprise customer for the given slug and update it as the active
       // enterprise customer for the learner.

--- a/src/components/app/routes/loaders/updateActiveEnterpriseCustomerUserLoader.js
+++ b/src/components/app/routes/loaders/updateActiveEnterpriseCustomerUserLoader.js
@@ -14,7 +14,6 @@ export default function makeUpdateActiveEnterpriseCustomerUserLoader(queryClient
     const authenticatedUser = await ensureAuthenticatedUser(requestUrl);
     const { username, userId, email: userEmail } = authenticatedUser;
     const { enterpriseSlug: nextEnterpriseSlug } = params;
-    const currentEnterpriseSlug = global.location.pathname.split('/').filter(pathPart => !!pathPart)[0];
 
     const linkedEnterpriseCustomersQuery = makeEnterpriseLearnerQuery(username, nextEnterpriseSlug);
     const enterpriseLearnerData = await queryClient.fetchQuery(linkedEnterpriseCustomersQuery);

--- a/src/components/app/routes/loaders/updateActiveEnterpriseCustomerUserLoader.js
+++ b/src/components/app/routes/loaders/updateActiveEnterpriseCustomerUserLoader.js
@@ -1,0 +1,81 @@
+import { redirect, generatePath } from 'react-router-dom';
+
+import ensureAuthenticatedUser from './ensureAuthenticatedUser';
+import { getEnterpriseAppData, makeEnterpriseLearnerQuery, updateUserActiveEnterprise } from './rootLoader';
+
+/**
+ * TODO
+ * @param {*} queryClient
+ * @returns
+ */
+export default function makeUpdateActiveEnterpriseCustomerUserLoader(queryClient) {
+  return async function updateActiveEnterpriseCustomerUserLoader({ params = {}, request }) {
+    const requestUrl = new URL(request.url);
+    const authenticatedUser = await ensureAuthenticatedUser(requestUrl);
+    const { username, userId, email: userEmail } = authenticatedUser;
+    const { enterpriseSlug: nextEnterpriseSlug } = params;
+    const currentEnterpriseSlug = global.location.pathname.split('/').filter(pathPart => !!pathPart)[0];
+
+    const linkedEnterpriseCustomersQuery = makeEnterpriseLearnerQuery(username, nextEnterpriseSlug);
+    const enterpriseLearnerData = await queryClient.fetchQuery(linkedEnterpriseCustomersQuery);
+    const {
+      activeEnterpriseCustomer,
+      allLinkedEnterpriseCustomerUsers,
+    } = enterpriseLearnerData;
+
+    // User has no active, linked enterprise customer; return early.
+    if (!activeEnterpriseCustomer) {
+      return null;
+    }
+
+    console.log({
+      currentEnterpriseSlug,
+      nextEnterpriseSlug,
+      activeEnterpriseCustomerSlug: activeEnterpriseCustomer?.slug,
+    });
+
+    // Return early (do nothing) if the enterprise slug matches the active enterprise customer.
+    // if (currentEnterpriseSlug === nextEnterpriseSlug && nextEnterpriseSlug === activeEnterpriseCustomer?.slug) {
+    //   return null;
+    // }
+
+    if (nextEnterpriseSlug !== activeEnterpriseCustomer.slug) {
+      // Otherwise, try to find the enterprise customer for the given slug and update it as the active
+      // enterprise customer for the learner.
+      const foundEnterpriseCustomerForSlug = allLinkedEnterpriseCustomerUsers.find(
+        enterpriseCustomerUser => enterpriseCustomerUser.enterpriseCustomer.slug === nextEnterpriseSlug,
+      );
+      if (foundEnterpriseCustomerForSlug) {
+        await updateUserActiveEnterprise({
+          enterpriseCustomer: foundEnterpriseCustomerForSlug.enterpriseCustomer,
+        });
+        queryClient.setQueryData(linkedEnterpriseCustomersQuery.queryKey, {
+          ...enterpriseLearnerData,
+          activeEnterpriseCustomer: foundEnterpriseCustomerForSlug.enterpriseCustomer,
+          allLinkedEnterpriseCustomerUsers: allLinkedEnterpriseCustomerUsers.map(
+            ecu => ({
+              ...ecu,
+              active: (
+                ecu.enterpriseCustomer.uuid === foundEnterpriseCustomerForSlug.enterpriseCustomer.uuid
+              ),
+            }),
+          ),
+        });
+        await Promise.all(getEnterpriseAppData({
+          enterpriseCustomer: foundEnterpriseCustomerForSlug.enterpriseCustomer,
+          userId,
+          userEmail,
+          queryClient,
+        }));
+        return null;
+      }
+
+      return redirect(generatePath('/:enterpriseSlug/*', {
+        enterpriseSlug: activeEnterpriseCustomer.slug,
+        '*': requestUrl.pathname.split('/').filter(pathPart => !!pathPart).slice(1).join('/'),
+      }));
+    }
+
+    return null;
+  };
+}


### PR DESCRIPTION
Resolves all primary data thus far in route loaders **before** the page changes in the UI, with feedback in the form of the progress bar at the top of the page (fairly common loading pattern across the web; relies on popular `nprogress` NPM package.

As a result, we can effectively remove all spinners from the experience and ensure all queries are stored in the client-side query cache to return fresh data instantly and only refetch API calls when they are stale or get invalidated.

https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/a42f0bb6-c940-4e39-8940-0f433aa09d35

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
