### PR TITLE
fix: handle when active enterprise is changed external to current page view

### DIFF
--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -319,7 +319,7 @@ const Course = () => {
             },
             redeemableSubsidyAccessPolicy: courseRedemptionEligiblity.find(
               ({ canRedeem }) => canRedeem,
-            )?.redeemableSubsidyAccessPolicy?.uuid,
+            )?.redeemableSubsidyAccessPolicy?.uuid ?? null,
             enterpriseCourseEnrollments: {
               isLoading: isLoadingEnterpriseCourseEnrollments,
               isFetching: isFetchingEnterpriseCourseEnrollments,
@@ -343,7 +343,7 @@ const Layout = () => {
   const { authenticatedUser } = useContext(AppContext);
   const { data: enterpriseLearnerData } = useEnterpriseLearner();
 
-  const brandStyles = useStylesForCustomBrandColors(enterpriseLearnerData?.enterpriseCustomer);
+  const brandStyles = useStylesForCustomBrandColors(enterpriseLearnerData.enterpriseCustomer);
 
   // Authenticated user is NOT linked an enterprise customer, so
   // render the not found page.

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -385,7 +385,7 @@ const Layout = () => {
 
   // Authenticated user is NOT linked an enterprise customer, so
   // render the not found page.
-  if (!enterpriseLearnerData?.activeEnterpriseCustomer) {
+  if (!enterpriseLearnerData.activeEnterpriseCustomer) {
     return <NotFoundPage />;
   }
 

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -3,7 +3,6 @@ import {
   Suspense,
   useContext,
   useEffect,
-  useState,
 } from 'react';
 import {
   createBrowserRouter,
@@ -32,7 +31,6 @@ import {
 import { logError } from '@edx/frontend-platform/logging';
 import SiteFooter from '@edx/frontend-component-footer';
 import {
-  UseQueryResult,
   QueryCache,
   QueryClient,
   QueryClientProvider,
@@ -68,6 +66,10 @@ import { useStylesForCustomBrandColors } from '../layout/data/hooks';
 import { DEFAULT_TITLE, TITLE_TEMPLATE } from '../layout/Layout';
 import makeDashboardLoader from './routes/loaders/dashboardLoader';
 import makeUpdateActiveEnterpriseCustomerUserLoader from './routes/loaders/updateActiveEnterpriseCustomerUserLoader';
+
+/**
+ * @typedef {import('@tanstack/react-query').UseQueryResult} UseQueryResult
+ */
 
 /* eslint-disable no-unused-vars */
 const EnterpriseCustomerRedirect = lazy(() => import(/* webpackChunkName: "enterprise-customer-redirect" */ '../enterprise-redirects/EnterpriseCustomerRedirect'));

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -130,28 +130,6 @@ const Root = () => {
 };
 
 /**
- * Determines whether the enterprise learner data should be refetched in the query options.
- *
- * True when activeEnterpriseCustomer doesn't exist or the activeEnterpriseCustomer's slug matches the
- * current slug from the page route params. Otherwise, false.
- *
- * This prevents unnecessary refetches when the enterprise learner data when the active enterprise customer
- * is changed external from the current page view (e.g., a page view to another Enterprise Customer in the Learner
- * Portal or Admin Portal). Without this, the refetches data would be for a different enterprise customer than
- * is reflected is in the current page route params.
- *
- * @param {Object} activeEnterpriseCustomer The active enterprise customer for the authenticated user.
- * @param {string} enterpriseSlug The current enterprise slug in the route params.
- * @returns {boolean} Whether the enterprise learner data should be refetched.
- */
-function shouldRefetchEnterpriseLearnerData(activeEnterpriseCustomer, enterpriseSlug) {
-  if (!activeEnterpriseCustomer) {
-    return true;
-  }
-  return activeEnterpriseCustomer.slug === enterpriseSlug;
-}
-
-/**
  * Retrieves the enterprise learner data for the authenticated user.
  *
  * @returns {UseQueryResult} The query results for the enterprise learner data.

--- a/src/components/app/routes/loaders/courseLoader.js
+++ b/src/components/app/routes/loaders/courseLoader.js
@@ -101,7 +101,7 @@ export async function extractActiveEnterpriseId({
   // Retrieve linked enterprise customers for the current user from query cache
   // or fetch from the server if not available.
   const linkedEnterpriseCustomersQuery = makeEnterpriseLearnerQuery(authenticatedUser.username, enterpriseSlug);
-  const enterpriseLearnerData = await queryClient.fetchQuery(linkedEnterpriseCustomersQuery);
+  const enterpriseLearnerData = await queryClient.ensureQueryData(linkedEnterpriseCustomersQuery);
   const {
     activeEnterpriseCustomer,
     allLinkedEnterpriseCustomerUsers,
@@ -112,7 +112,7 @@ export async function extractActiveEnterpriseId({
   }
 
   const foundEnterpriseIdForSlug = allLinkedEnterpriseCustomerUsers.find(
-    (enterprise) => enterprise.enterpriseCustomer.slug === enterpriseSlug,
+    (enterpriseCustomerUser) => enterpriseCustomerUser.enterpriseCustomer.slug === enterpriseSlug,
   )?.enterpriseCustomer.uuid;
 
   if (foundEnterpriseIdForSlug) {
@@ -141,16 +141,16 @@ export default function makeCourseLoader(queryClient) {
     const contentMetadataQuery = makeCourseMetadataQuery(enterpriseId, courseKey);
 
     await Promise.all([
-      queryClient.fetchQuery(contentMetadataQuery).then((courseMetadata) => {
+      queryClient.ensureQueryData(contentMetadataQuery).then((courseMetadata) => {
         if (!courseMetadata) {
           return null;
         }
-        return queryClient.fetchQuery(
+        return queryClient.ensureQueryData(
           makeCanRedeemQuery(enterpriseId, courseMetadata),
         );
       }),
-      queryClient.fetchQuery(makeEnterpriseCourseEnrollmentsQuery(enterpriseId)),
-      queryClient.fetchQuery(makeUserEntitlementsQuery()),
+      queryClient.ensureQueryData(makeEnterpriseCourseEnrollmentsQuery(enterpriseId)),
+      queryClient.ensureQueryData(makeUserEntitlementsQuery()),
     ]);
 
     return null;

--- a/src/components/app/routes/loaders/dashboardLoader.js
+++ b/src/components/app/routes/loaders/dashboardLoader.js
@@ -15,7 +15,7 @@ export default function makeDashboardLoader(queryClient) {
       authenticatedUser,
       enterpriseSlug,
     });
-    await queryClient.fetchQuery(makeEnterpriseCourseEnrollmentsQuery(enterpriseId));
+    await queryClient.ensureQueryData(makeEnterpriseCourseEnrollmentsQuery(enterpriseId));
     return null;
   };
 }

--- a/src/components/app/routes/loaders/rootLoader.js
+++ b/src/components/app/routes/loaders/rootLoader.js
@@ -155,6 +155,12 @@ const fetchEnterpriseLearnerData = async (username, options = {}) => {
   };
 };
 
+/**
+ * TODO
+ * @param {*} username
+ * @param {*} enterpriseSlug
+ * @returns
+ */
 export const makeEnterpriseLearnerQuery = (username, enterpriseSlug) => ({
   queryKey: ['enterprise', 'linked-enterprise-customer-users', username, enterpriseSlug],
   queryFn: async () => fetchEnterpriseLearnerData(username),
@@ -313,27 +319,26 @@ export function getEnterpriseAppData({
 }) {
   return [
     // Enterprise Customer User Subsidies
-    queryClient.fetchQuery(
+    queryClient.ensureQueryData(
       makeSubscriptionsQuery(enterpriseCustomer.uuid),
     ),
-    queryClient.fetchQuery(
+    queryClient.ensureQueryData(
       makeRedeemablePoliciesQuery({
         enterpriseUuid: enterpriseCustomer.uuid,
         lmsUserId: userId,
       }),
     ),
-    queryClient.fetchQuery(
+    queryClient.ensureQueryData(
       makeCouponCodesQuery(enterpriseCustomer.uuid),
     ),
-    queryClient.fetchQuery(
+    queryClient.ensureQueryData(
       makeEnterpriseLearnerOffersQuery(enterpriseCustomer.uuid),
     ),
-    queryClient.fetchQuery(
+    queryClient.ensureQueryData(
       makeBrowseAndRequestConfigurationQuery(enterpriseCustomer.uuid, userEmail),
     ),
     // Content Highlights
-    // TODO: delete a content highlights configuration record and re-test.
-    queryClient.fetchQuery(
+    queryClient.ensureQueryData(
       makeContentHighlightsConfigurationQuery(enterpriseCustomer.uuid),
     ),
   ];
@@ -354,7 +359,7 @@ export default function makeRootLoader(queryClient) {
     // Retrieve linked enterprise customers for the current user from query cache
     // or fetch from the server if not available.
     const linkedEnterpriseCustomersQuery = makeEnterpriseLearnerQuery(username, enterpriseSlug);
-    const enterpriseLearnerData = await queryClient.fetchQuery(linkedEnterpriseCustomersQuery);
+    const enterpriseLearnerData = await queryClient.ensureQueryData(linkedEnterpriseCustomersQuery);
     const { activeEnterpriseCustomer } = enterpriseLearnerData;
 
     // User has no active, linked enterprise customer; return early.

--- a/src/components/app/routes/loaders/rootLoader.js
+++ b/src/components/app/routes/loaders/rootLoader.js
@@ -176,11 +176,9 @@ const fetchEnterpriseLearnerData = async (username, enterpriseSlug, options = {}
     enterpriseCustomer,
     roleAssignments,
   } = determineEnterpriseCustomerUserForDisplay();
-  const enterpriseCustomerUserRoleAssignments = roleAssignments;
-
   return {
     enterpriseCustomer,
-    enterpriseCustomerUserRoleAssignments,
+    enterpriseCustomerUserRoleAssignments: roleAssignments,
     activeEnterpriseCustomer,
     activeEnterpriseCustomerUserRoleAssignments,
     allLinkedEnterpriseCustomerUsers: linkedEnterpriseCustomersUsers,

--- a/src/components/app/routes/loaders/rootLoader.js
+++ b/src/components/app/routes/loaders/rootLoader.js
@@ -156,11 +156,12 @@ const fetchEnterpriseLearnerData = async (username, enterpriseSlug, options = {}
   );
 
   const determineEnterpriseCustomerUserForDisplay = () => {
+    const activeEnterpriseCustomerUser = {
+      enterpriseCustomer: activeEnterpriseCustomer,
+      roleAssignments: activeEnterpriseCustomerUserRoleAssignments,
+    };
     if (!enterpriseSlug) {
-      return {
-        enterpriseCustomer: activeEnterpriseCustomer,
-        roleAssignments: activeEnterpriseCustomerUserRoleAssignments,
-      };
+      return activeEnterpriseCustomerUser;
     }
     if (enterpriseSlug !== activeEnterpriseCustomer.slug && foundEnterpriseCustomerUserForCurrentSlug) {
       return {
@@ -168,10 +169,7 @@ const fetchEnterpriseLearnerData = async (username, enterpriseSlug, options = {}
         roleAssignments: foundEnterpriseCustomerUserForCurrentSlug.roleAssignments,
       };
     }
-    return {
-      enterpriseCustomer: null,
-      roleAssignments: null,
-    };
+    return activeEnterpriseCustomerUser;
   };
 
   const {

--- a/src/components/app/routes/loaders/updateActiveEnterpriseCustomerUserLoader.js
+++ b/src/components/app/routes/loaders/updateActiveEnterpriseCustomerUserLoader.js
@@ -13,9 +13,9 @@ export default function makeUpdateActiveEnterpriseCustomerUserLoader(queryClient
     const requestUrl = new URL(request.url);
     const authenticatedUser = await ensureAuthenticatedUser(requestUrl);
     const { username, userId, email: userEmail } = authenticatedUser;
-    const { enterpriseSlug: nextEnterpriseSlug } = params;
+    const { enterpriseSlug } = params;
 
-    const linkedEnterpriseCustomersQuery = makeEnterpriseLearnerQuery(username, nextEnterpriseSlug);
+    const linkedEnterpriseCustomersQuery = makeEnterpriseLearnerQuery(username, enterpriseSlug);
     const enterpriseLearnerData = await queryClient.fetchQuery(linkedEnterpriseCustomersQuery);
     const {
       activeEnterpriseCustomer,
@@ -27,11 +27,11 @@ export default function makeUpdateActiveEnterpriseCustomerUserLoader(queryClient
       return null;
     }
 
-    if (nextEnterpriseSlug !== activeEnterpriseCustomer.slug) {
+    if (enterpriseSlug !== activeEnterpriseCustomer.slug) {
       // Otherwise, try to find the enterprise customer for the given slug and update it as the active
       // enterprise customer for the learner.
       const foundEnterpriseCustomerForSlug = allLinkedEnterpriseCustomerUsers.find(
-        enterpriseCustomerUser => enterpriseCustomerUser.enterpriseCustomer.slug === nextEnterpriseSlug,
+        enterpriseCustomerUser => enterpriseCustomerUser.enterpriseCustomer.slug === enterpriseSlug,
       );
       if (foundEnterpriseCustomerForSlug) {
         await updateUserActiveEnterprise({

--- a/src/components/app/routes/loaders/updateActiveEnterpriseCustomerUserLoader.js
+++ b/src/components/app/routes/loaders/updateActiveEnterpriseCustomerUserLoader.js
@@ -16,7 +16,7 @@ export default function makeUpdateActiveEnterpriseCustomerUserLoader(queryClient
     const { enterpriseSlug } = params;
 
     const linkedEnterpriseCustomersQuery = makeEnterpriseLearnerQuery(username, enterpriseSlug);
-    const enterpriseLearnerData = await queryClient.fetchQuery(linkedEnterpriseCustomersQuery);
+    const enterpriseLearnerData = await queryClient.ensureQueryData(linkedEnterpriseCustomersQuery);
     const {
       activeEnterpriseCustomer,
       allLinkedEnterpriseCustomerUsers,

--- a/src/components/enterprise-banner/EnterpriseBanner.jsx
+++ b/src/components/enterprise-banner/EnterpriseBanner.jsx
@@ -3,14 +3,14 @@ import { Container } from '@edx/paragon';
 import { useEnterpriseLearner } from '../app/App';
 
 const EnterpriseBanner = () => {
-  const { data: { activeEnterpriseCustomer } } = useEnterpriseLearner();
+  const { data: { enterpriseCustomer } } = useEnterpriseLearner();
 
   return (
     <div className="enterprise-banner bg-brand-secondary border-brand-tertiary">
       <Container size="lg">
         <div className="row banner-content">
           <h1 className="h2 mb-0 py-3 pl-3 text-brand-secondary">
-            {activeEnterpriseCustomer.name}
+            {enterpriseCustomer.name}
           </h1>
           {/* {shouldRecommendCourses && (
             <Button

--- a/src/components/enterprise-banner/EnterpriseBanner.jsx
+++ b/src/components/enterprise-banner/EnterpriseBanner.jsx
@@ -4,7 +4,6 @@ import { useEnterpriseLearner } from '../app/App';
 
 const EnterpriseBanner = () => {
   const { data: { activeEnterpriseCustomer } } = useEnterpriseLearner();
-  // const { shouldRecommendCourses } = useContext(AuthenticatedPageContext);
 
   return (
     <div className="enterprise-banner bg-brand-secondary border-brand-tertiary">

--- a/src/components/site-header/AvatarDropdown.jsx
+++ b/src/components/site-header/AvatarDropdown.jsx
@@ -20,15 +20,15 @@ const AvatarDropdown = ({ showLabel }) => {
   } = useContext(AppContext);
   const {
     data: {
-      activeEnterpriseCustomer,
+      enterpriseCustomer,
       allLinkedEnterpriseCustomerUsers,
     },
   } = useEnterpriseLearner();
-  const enterpriseDashboardLink = `/${activeEnterpriseCustomer.slug}`;
+  const enterpriseDashboardLink = `/${enterpriseCustomer.slug}`;
   const intl = useIntl();
   const location = useLocation();
 
-  const idpPresent = isDefinedAndNotNull(activeEnterpriseCustomer.identityProvider);
+  const idpPresent = isDefinedAndNotNull(enterpriseCustomer.identityProvider);
   // we insert the logout=true in this case to avoid the redirect back to IDP
   // which brings the user right back in, disallowing a proper logout
   const logoutHint = idpPresent ? `${encodeURIComponent('?')}logout=true` : '';

--- a/src/components/site-header/SiteHeader.jsx
+++ b/src/components/site-header/SiteHeader.jsx
@@ -12,7 +12,7 @@ import { useEnterpriseLearner } from '../app/App';
 
 const SiteHeader = () => {
   const config = getConfig();
-  const { data: { activeEnterpriseCustomer } } = useEnterpriseLearner();
+  const { data: { enterpriseCustomer } } = useEnterpriseLearner();
   const intl = useIntl();
 
   const renderDesktopHeader = () => (
@@ -60,12 +60,12 @@ const SiteHeader = () => {
               aria-label="Main"
               className="nav flex-column pin-left pin-right border-top shadow py-2"
             >
-              <SiteHeaderNavMenu enterpriseConfig={activeEnterpriseCustomer} />
+              <SiteHeaderNavMenu enterpriseConfig={enterpriseCustomer} />
             </MenuContent>
           </Menu>
         </div>
         <div className="w-100 d-flex justify-content-center">
-          <SiteHeaderLogos enterpriseConfig={activeEnterpriseCustomer} />
+          <SiteHeaderLogos enterpriseConfig={enterpriseCustomer} />
         </div>
         <div className="w-100 d-flex justify-content-end">
           <AvatarDropdown showLabel={false} />

--- a/src/components/site-header/SiteHeaderLogos.jsx
+++ b/src/components/site-header/SiteHeaderLogos.jsx
@@ -9,21 +9,22 @@ import { useEnterpriseLearner } from '../app/App';
 const SiteHeaderLogos = () => {
   const courseTypeMatch = useMatch('/:enterpriseSlug/:courseType?/course/*');
   const courseType = courseTypeMatch?.params?.courseType;
-  const { data: { activeEnterpriseCustomer } } = useEnterpriseLearner();
+  const { data: { enterpriseCustomer } } = useEnterpriseLearner();
   const courseTypePartnerLogo = courseType && COURSE_TYPE_PARTNER_LOGOS[courseType];
 
   let mainLogo = (
     <img
       className="logo"
-      src={activeEnterpriseCustomer.brandingConfiguration?.logo || edXLogo}
-      alt={`${activeEnterpriseCustomer.name} logo`}
+      src={enterpriseCustomer.brandingConfiguration?.logo || edXLogo}
+      alt={`${enterpriseCustomer.name} logo`}
       data-testid="header-logo-image-id"
     />
   );
 
-  if (!activeEnterpriseCustomer.disableSearch) {
+  // TODO: handle `disableSearch` for enterprise customers in new routing paradigm.
+  if (!enterpriseCustomer.disableSearch) {
     mainLogo = (
-      <Link to={`/${activeEnterpriseCustomer.slug}`} data-testid="header-logo-link-id">
+      <Link to={`/${enterpriseCustomer.slug}`} data-testid="header-logo-link-id">
         {mainLogo}
       </Link>
     );

--- a/src/components/site-header/SiteHeaderNavMenu.jsx
+++ b/src/components/site-header/SiteHeaderNavMenu.jsx
@@ -4,24 +4,25 @@ import { NavLink } from 'react-router-dom';
 import { useEnterpriseLearner } from '../app/App';
 
 const SiteHeaderNavMenu = () => {
-  const { data: { activeEnterpriseCustomer } } = useEnterpriseLearner();
+  const { data: { enterpriseCustomer } } = useEnterpriseLearner();
   const intl = useIntl();
   const mainMenuLinkClassName = 'nav-link';
 
-  if (activeEnterpriseCustomer.disableSearch) {
+  // TODO: handle `disableSearch` upstream
+  if (enterpriseCustomer.disableSearch) {
     return null;
   }
 
   return (
     <>
-      <NavLink to={`/${activeEnterpriseCustomer.slug}`} className={mainMenuLinkClassName} end>
+      <NavLink to={`/${enterpriseCustomer.slug}`} className={mainMenuLinkClassName} end>
         {intl.formatMessage({
           id: 'site.header.nav.dashboard.title',
           defaultMessage: 'Dashboard',
           description: 'Dashboard link title in site header navigation.',
         })}
       </NavLink>
-      <NavLink to={`/${activeEnterpriseCustomer.slug}/search`} className={mainMenuLinkClassName}>
+      <NavLink to={`/${enterpriseCustomer.slug}/search`} className={mainMenuLinkClassName}>
         {intl.formatMessage({
           id: 'site.header.nav.search.title',
           defaultMessage: 'Find a Course',


### PR DESCRIPTION
# Description

* Switches from `queryClient.fetchQuery` to `queryClient.ensureQueryData` ([docs](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientensurequerydata)).

> `ensureQueryData` is an asynchronous function that can be used to get an existing query's cached data. If the query does not exist, `queryClient.fetchQuery` will be called and its results returned.

* Resolves [ENT-8474](https://2u-internal.atlassian.net/browse/ENT-8474), ensuring data for the currently viewed enterprise customer does not change when the user's active enterprise customer user changes external to a session (e.g., viewing Admin/Learner Portal for a different customer and coming back to the same Learner Portal window/tab for the original customer).

Note: failing CI is OK right now.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
