### PR TITLE
fix: update nprogress color and height styles

### DIFF
--- a/src/styles/nprogress.scss
+++ b/src/styles/nprogress.scss
@@ -1,14 +1,15 @@
 @import "nprogress/nprogress";
 
 #nprogress .bar {
-  background: $primary;
+  background: $brand-500;
+  height: 3px;
 }
 
 #nprogress .peg {
-  box-shadow: 0 0 10px $primary, 0 0 5px $primary;
+  box-shadow: 0 0 10px $brand-500, 0 0 5px $brand-500;
 }
 
 #nprogress .spinner-icon {
-  border-top-color: $primary;
-  border-left-color: $primary;
+  border-top-color: $brand-500;
+  border-left-color: $brand-500;
 }


### PR DESCRIPTION
Updates the `nprogress` loader progress bar to use `$brand-500` (instead of `$primary-500`) and makes it slightly taller with `3px` height:

https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/c6975dfd-baa7-4637-bd90-f43b3f9f5821

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
