### PR TITLE
fix: dont redirect to activation page user is already on

### DIFF
--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -49,7 +49,7 @@ const DashboardPage = () => {
   const PAGE_TITLE = intl.formatMessage(
     {
       id: 'enterprise.dashboard.page.title',
-      defaultMessage: 'Dashboard - {enterpriseName}!',
+      defaultMessage: 'Dashboard - {enterpriseName}',
       description: 'Page title for an enterprise dashboard.',
     },
     {
@@ -87,7 +87,7 @@ const DashboardPage = () => {
           onSelect={onSelectHandler}
           onMouseOverCapture={prefetchTab}
         >
-          {tabs}
+          {tabs.map((tab) => React.cloneElement(tab, { key: tab.props.eventKey }))}
         </Tabs>
         {enterpriseConfig.showIntegrationWarning && <IntegrationWarningModal isOpen />}
         {subscriptionPlan && showExpirationNotifications && <SubscriptionExpirationModal />}

--- a/src/components/enterprise-user-subsidy/AutoActivateLicense.jsx
+++ b/src/components/enterprise-user-subsidy/AutoActivateLicense.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation, useMatch } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import { UserSubsidyContext } from './UserSubsidy';
@@ -13,12 +13,20 @@ const AutoActivateLicense = () => {
   const { subscriptionLicense } = useContext(UserSubsidyContext);
   const location = useLocation();
 
+  const isLicenseActivationRouteMatch = useMatch('/:enterpriseSlug/licenses/:activationKey/activate');
+  // If user is on the license activation page, do not redirect them to the
+  // same license activation page again.
+  if (isLicenseActivationRouteMatch) {
+    return null;
+  }
+
+  // If the user does not have an assigned license or their license status is not assigned, do not redirect them.
   if (!subscriptionLicense?.activationKey || subscriptionLicense?.status !== LICENSE_STATUS.ASSIGNED) {
     return null;
   }
 
+  // Redirect to license activation page.
   const activationPath = `/${enterpriseConfig.slug}/licenses/${subscriptionLicense.activationKey}/activate`;
-
   return (
     <Navigate
       to={activationPath}

--- a/src/components/enterprise-user-subsidy/data/hooks/hooks.js
+++ b/src/components/enterprise-user-subsidy/data/hooks/hooks.js
@@ -167,11 +167,10 @@ export function useSubscriptionLicense({
           autoActivated,
         },
       );
-
-      setLicense({
-        ...license,
+      setLicense((prevLicense) => ({
+        ...prevLicense,
         status: LICENSE_STATUS.ACTIVATED,
-      });
+      }));
     } catch (error) {
       logError(error);
       throw error;

--- a/src/components/enterprise-user-subsidy/tests/AutoActivateLicense.test.jsx
+++ b/src/components/enterprise-user-subsidy/tests/AutoActivateLicense.test.jsx
@@ -17,7 +17,6 @@ const initialPathname = `/${TEST_ENTERPRISE_SLUG}`;
 jest.mock('react-router-dom', () => {
   const mockNavigation = jest.fn();
 
-  // eslint-disable-next-line react/prop-types
   const Navigate = ({ to, state }) => {
     mockNavigation(to, state);
     return <div />;
@@ -46,7 +45,7 @@ const AutoActivateLicenseWrapper = ({ subscriptionLicense }) => (
 );
 
 describe('<AutoActivationLicense />', () => {
-  afterEach(() => jest.clearAllMocks());
+  beforeEach(() => jest.clearAllMocks());
 
   it('does not render when no license exists', () => {
     const { history } = renderWithRouter(<AutoActivateLicenseWrapper subscriptionLicense={null} />, {
@@ -59,6 +58,14 @@ describe('<AutoActivationLicense />', () => {
     ['activated', 'revoked'],
   )('does not render when license status is %s', (status) => {
     const subscriptionLicense = { status };
+    const { history } = renderWithRouter(<AutoActivateLicenseWrapper subscriptionLicense={subscriptionLicense} />, {
+      route: initialPathname,
+    });
+    expect(history.location.pathname).toEqual(initialPathname);
+  });
+
+  test('does not render when user is on the license activation page', () => {
+    const subscriptionLicense = { status: 'assigned', activationKey: 'test-uuid' };
     const { history } = renderWithRouter(<AutoActivateLicenseWrapper subscriptionLicense={subscriptionLicense} />, {
       route: initialPathname,
     });

--- a/src/components/license-activation/LicenseActivation.jsx
+++ b/src/components/license-activation/LicenseActivation.jsx
@@ -35,8 +35,7 @@ const LicenseActivation = () => {
   }, [activateUserLicense, fromLocation]);
 
   if (activationSuccess) {
-    const redirectToPath = location.state?.from ?? `/${enterpriseConfig.slug}`;
-
+    const redirectToPath = fromLocation ?? `/${enterpriseConfig.slug}`;
     return (
       <Navigate
         to={redirectToPath}


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8554

Resolves a infinite redirect bug where the license activation route was effectively redirecting to itself. Not quite sure why this suddenly started appearing, but also deferring on figuring that out, given these related code paths will be refactored with the route loader frontend performance work anyways.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
