### PR TITLE
feat: display extra course runs when policy allows late redemption

### DIFF
--- a/src/components/course/CoursePage.jsx
+++ b/src/components/course/CoursePage.jsx
@@ -38,6 +38,7 @@ import { SubsidyRequestsContext } from '../enterprise-subsidy-requests';
 import { useSearchCatalogs } from '../search/data/hooks';
 import { useEnterpriseCuration } from '../search/content-highlights/data';
 import CoursePageRoutes from './routes/CoursePageRoutes';
+import { LATE_ENROLLMENTS_BUFFER_DAYS } from '../../config/constants';
 
 const CoursePage = () => {
   const { enterpriseSlug, courseKey } = useParams();
@@ -87,11 +88,20 @@ const CoursePage = () => {
   // the URL query parameters and then remove it to keep the URLs clean.
   const algoliaSearchParams = useExtractAndRemoveSearchParamsFromURL();
 
+  const anyPolicyHasLateRedemptionEnabled = !!redeemableLearnerCreditPolicies?.redeemablePolicies?.some((policy) => (
+    // is_late_redemption_enabled=True on the serialized policy represents the fact that late redemption has been
+    // temporarily enabled by an operator for the policy. It will toggle itself back to False after a finite period
+    // of time.
+    policy.isLateRedemptionEnabled
+  ));
+  const isEnrollableBufferDays = anyPolicyHasLateRedemptionEnabled ? LATE_ENROLLMENTS_BUFFER_DAYS : undefined;
+
   const courseService = useMemo(() => new CourseService({
     enterpriseUuid: enterpriseUUID,
     courseKey,
     courseRunKey,
-  }), [courseKey, courseRunKey, enterpriseUUID]);
+    isEnrollableBufferDays,
+  }), [courseKey, courseRunKey, enterpriseUUID, isEnrollableBufferDays]);
 
   const {
     courseData,
@@ -102,7 +112,7 @@ const CoursePage = () => {
   } = useAllCourseData({ courseService, activeCatalogs });
   const isEMETRedemptionEnabled = getConfig().FEATURE_ENABLE_EMET_REDEMPTION || hasFeatureFlagEnabled('ENABLE_EMET_REDEMPTION');
 
-  const validCourseRunKeys = getAvailableCourseRunKeysFromCourseData(courseData);
+  const validCourseRunKeys = getAvailableCourseRunKeysFromCourseData({ courseData, isEnrollableBufferDays });
 
   const {
     isInitialLoading: isLoadingAccessPolicyRedemptionStatus,
@@ -161,7 +171,7 @@ const CoursePage = () => {
       return {
         course: courseDetails,
         activeCourseRun: getActiveCourseRun(courseDetails),
-        availableCourseRuns: getAvailableCourseRuns(courseDetails),
+        availableCourseRuns: getAvailableCourseRuns({ course: courseDetails, isEnrollableBufferDays }),
         userEnrollments,
         userEntitlements,
         catalog,
@@ -180,6 +190,7 @@ const CoursePage = () => {
       courseRecommendations,
       courseReviews,
       algoliaSearchParams,
+      isEnrollableBufferDays,
     ],
   );
 

--- a/src/components/course/data/service.js
+++ b/src/components/course/data/service.js
@@ -13,6 +13,7 @@ export default class CourseService {
       courseKey,
       courseRunKey,
       enterpriseUuid,
+      isEnrollableBufferDays,
     } = options;
     this.config = getConfig();
 
@@ -25,6 +26,7 @@ export default class CourseService {
     this.courseRunKey = courseRunKey;
     this.enterpriseUuid = enterpriseUuid;
     this.activeCourseRun = activeCourseRun;
+    this.isEnrollableBufferDays = isEnrollableBufferDays;
   }
 
   async fetchAllCourseData() {
@@ -50,7 +52,10 @@ export default class CourseService {
     // Check for the course_run_key URL param and remove all other course run data
     // if the given course run key is for an available course run.
     if (this.courseRunKey) {
-      const availableCourseRuns = getAvailableCourseRuns(courseDetails);
+      const availableCourseRuns = getAvailableCourseRuns({
+        course: courseDetails,
+        isEnrollableBufferDays: this.isEnrollableBufferDays,
+      });
       const availableCourseRunKeys = availableCourseRuns.map(({ key }) => key);
       if (availableCourseRunKeys.includes(this.courseRunKey)) {
         courseDetails.canonicalCourseRunKey = this.courseRunKey;

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -448,6 +448,9 @@ describe('linkToCourse', () => {
 });
 
 describe('getAvailableCourseRuns', () => {
+  afterEach(() => {
+    MockDate.reset();
+  });
   const sampleCourseRunData = {
     courseData: {
       courseRuns: [
@@ -484,28 +487,81 @@ describe('getAvailableCourseRuns', () => {
         // eslint-disable-next-line no-param-reassign
         courseRun.availability = COURSE_AVAILABILITY_MAP[i];
         if (COURSE_AVAILABILITY_MAP[i] === 'Archived') {
-          expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length)
+          expect(getAvailableCourseRuns({ course: sampleCourseRunData.courseData }).length)
             .toEqual(0);
-          expect(getAvailableCourseRuns(sampleCourseRunData.courseData))
+          expect(getAvailableCourseRuns({ course: sampleCourseRunData.courseData }))
             .toEqual([]);
         } else {
-          expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length)
+          expect(getAvailableCourseRuns({ course: sampleCourseRunData.courseData }).length)
             .toEqual(1);
-          expect(getAvailableCourseRuns(sampleCourseRunData.courseData))
+          expect(getAvailableCourseRuns({ course: sampleCourseRunData.courseData }))
             .toEqual(sampleCourseRunData.courseData.courseRuns.slice(0, 1));
         }
       });
     }
   });
+  const sampleCourseRunDataWithRecentRuns = {
+    courseData: {
+      courseRuns: [
+        // Run with normally open enrollment.
+        {
+          key: 'course-v1:edX+DemoX+Demo_Course1',
+          title: 'Demo Course',
+          availability: COURSE_AVAILABILITY_MAP.STARTING_SOON,
+          isMarketable: true,
+          isEnrollable: true,
+          enrollmentStart: '2023-07-01T00:00:00Z',
+          enrollmentEnd: '2023-08-01T00:00:00Z',
+        },
+        // Run with recently closed enrollment.
+        {
+          key: 'course-v1:edX+DemoX+Demo_Course2',
+          title: 'Demo Course',
+          availability: COURSE_AVAILABILITY_MAP.STARTING_SOON,
+          isMarketable: true,
+          isEnrollable: false,
+          enrollmentStart: '2023-06-01T00:00:00Z',
+          enrollmentEnd: '2023-07-01T00:00:00Z',
+        },
+        // Run with long-ago closed enrollment, but somehow still "Starting Soon".  This is very edge-casey.
+        {
+          key: 'course-v1:edX+DemoX+Demo_Course3',
+          title: 'Demo Course',
+          availability: COURSE_AVAILABILITY_MAP.STARTING_SOON,
+          isMarketable: true,
+          isEnrollable: false,
+          enrollmentStart: '2023-01-01T00:00:00Z',
+          enrollmentEnd: '2023-02-01T00:00:00Z',
+        },
+        // Run with long-ago closed enrollment, and now running.
+        {
+          key: 'course-v1:edX+DemoX+Demo_Course4',
+          title: 'Demo Course',
+          availability: COURSE_AVAILABILITY_MAP.CURRENT,
+          isMarketable: true,
+          isEnrollable: false,
+          enrollmentStart: '2023-01-01T00:00:00Z',
+          enrollmentEnd: '2023-02-01T00:00:00Z',
+        },
+      ],
+    },
+  };
+  it('returns object with available course runs', () => {
+    MockDate.set('2023-07-05T00:00:00Z');
+    expect(getAvailableCourseRuns({ course: sampleCourseRunDataWithRecentRuns.courseData }))
+      .toEqual(sampleCourseRunDataWithRecentRuns.courseData.courseRuns.slice(0, 1));
+    expect(getAvailableCourseRuns({ course: sampleCourseRunDataWithRecentRuns.courseData, isEnrollableBufferDays: 60 }))
+      .toEqual(sampleCourseRunDataWithRecentRuns.courseData.courseRuns.slice(0, 2));
+  });
   it('returns empty array if course runs are not available', () => {
     sampleCourseRunData.courseData.courseRuns = [];
-    expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length).toEqual(0);
-    expect(getAvailableCourseRuns(sampleCourseRunData.courseData)).toEqual([]);
+    expect(getAvailableCourseRuns({ course: sampleCourseRunData.courseData }).length).toEqual(0);
+    expect(getAvailableCourseRuns({ course: sampleCourseRunData.courseData })).toEqual([]);
   });
   it('returns an empty array is courseRuns is not defined', () => {
     sampleCourseRunData.courseData.courseRuns = undefined;
-    expect(getAvailableCourseRuns(sampleCourseRunData.courseData).length).toEqual(0);
-    expect(getAvailableCourseRuns(sampleCourseRunData.courseData)).toEqual([]);
+    expect(getAvailableCourseRuns({ course: sampleCourseRunData.courseData }).length).toEqual(0);
+    expect(getAvailableCourseRuns({ course: sampleCourseRunData.courseData })).toEqual([]);
   });
 });
 describe('getAvailableCourseRunKeysFromCourseData', () => {
@@ -546,13 +602,13 @@ describe('getAvailableCourseRunKeysFromCourseData', () => {
     },
   };
   it('returns array with available course run keys', () => {
-    const output = getAvailableCourseRunKeysFromCourseData(sampleCourseDataData.courseData);
+    const output = getAvailableCourseRunKeysFromCourseData({ courseData: sampleCourseDataData.courseData });
     expect(output.length).toEqual(1);
     expect(output).toEqual(['course-v1:edX+DemoX+Demo_Course']);
   });
   it('returns empty array if course runs are not available', () => {
     sampleCourseDataData.courseData.courseDetails = [];
-    const output = getAvailableCourseRunKeysFromCourseData(sampleCourseDataData.courseData);
+    const output = getAvailableCourseRunKeysFromCourseData({ courseData: sampleCourseDataData.courseData });
     expect(output.length).toEqual(0);
     expect(output).toEqual([]);
   });

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -18,3 +18,6 @@ export const SUBSCRIPTION_EXPIRED = 0;
 // Prefix for cookies that determine if the user has seen the modal for that range of expiration
 // Using the same cookie name as Admin Portal so an Admin/Learner only sees the notification once
 export const SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX = 'seen-expiration-modal-';
+
+// [ENT-8519] Late enrollments feature
+export const LATE_ENROLLMENTS_BUFFER_DAYS = 60;


### PR DESCRIPTION
Note: When the "course_run_key" query parameter is supplied with a
qualifying "late" run, the query parameter will behave the way you would
expect: it would show just the requested course run.

Testing table
===

Assume there are three course runs:
* A: enrollment ended more than 60 days ago.
* B: enrollment ended less than 60 days ago.
* C: enrollment is currently open.

```
+----------------------+----------------+-------------+
| any policy with late | course_run_key | course runs |
| redemption enabled   | query param    | displayed   |
+----------------------+----------------+-------------+
| no                   | not supplied   | [C]         |
+----------------------+----------------+-------------+
| no                   | A              | [C]         |
+----------------------+----------------+-------------+
| no                   | B              | [C]         |
+----------------------+----------------+-------------+
| no                   | C              | [C]         |
+----------------------+----------------+-------------+
| yes                  | not supplied   | [B, C]      |
+----------------------+----------------+-------------+
| yes                  | A              | [B, C]      |
+----------------------+----------------+-------------+
| yes                  | B              | [B]         |
+----------------------+----------------+-------------+
| yes                  | C              | [C]         |
+----------------------+----------------+-------------+
```

ENT-8521