### PR TITLE
fix: ensure staff users can view unlinked customer portals

### DIFF
--- a/src/components/app/data/queries/extractEnterpriseId.js
+++ b/src/components/app/data/queries/extractEnterpriseId.js
@@ -20,23 +20,26 @@ async function extractEnterpriseId({
   const {
     activeEnterpriseCustomer,
     allLinkedEnterpriseCustomerUsers,
+    staffEnterpriseCustomer,
   } = enterpriseLearnerData;
 
   // If there is no slug provided (i.e., on the root page route `/`), use
-  // the currently active enterprise customer.
+  // the currently active enterprise customer user.
   if (!enterpriseSlug) {
     return activeEnterpriseCustomer.uuid;
   }
 
-  // Otherwise, there is a slug provided for a specific enterprise customer. If the
-  // enterprise customer for the given slug is associated to one linked to the learner,
-  // return the enterprise ID for that enterprise customer.
   const foundEnterpriseIdForSlug = allLinkedEnterpriseCustomerUsers.find(
     (enterpriseCustomerUser) => enterpriseCustomerUser.enterpriseCustomer.slug === enterpriseSlug,
   )?.enterpriseCustomer.uuid;
 
-  if (foundEnterpriseIdForSlug) {
-    return foundEnterpriseIdForSlug;
+  // Otherwise, there is a slug provided for a specific enterprise customer. If the
+  // user is linked to the enterprise customer for the given slug, return the enterprise
+  // enterprise ID for that enterprise customer. If there is no linked enterprise customer
+  // for the given slug, but the user is staff, return the enterprise ID from the staff-only
+  // enterprise customer metadata.
+  if (foundEnterpriseIdForSlug || staffEnterpriseCustomer) {
+    return foundEnterpriseIdForSlug || staffEnterpriseCustomer.uuid;
   }
 
   // If no enterprise customer is found for the given user/slug, throw an error.

--- a/src/components/app/data/queries/queries.js
+++ b/src/components/app/data/queries/queries.js
@@ -5,7 +5,7 @@ import queries from './queryKeyFactory';
 /**
  * Helper function to assist querying with useQuery package
  * queries.user.entitlements
- * @returns
+ * @returns {Types.QueryOptions}
  */
 export function queryUserEntitlements() {
   return queries.user.entitlements;
@@ -14,9 +14,7 @@ export function queryUserEntitlements() {
 /**
  * Helper function to assist querying with useQuery package
  *
- * @property {[string]} QueryObject.queryKey - The query key for the object
- * @property {func} QueryObject.queryFn - The asynchronous API request "fetchNotices"
- * @returns {Types.QueryObject} - The query object for notices.
+ * @returns {Types.QueryOptions}
  */
 export function queryNotices() {
   return queries.user.notices;
@@ -27,7 +25,7 @@ export function queryNotices() {
  * queries
  * .enterprise
  * .enterpriseLearner(username, enterpriseSlug)
- * @returns {Types.QueryObject}
+ * @returns {Types.QueryOptions}
  */
 export function queryEnterpriseLearner(username, enterpriseSlug) {
   return queries.enterprise.enterpriseLearner(username, enterpriseSlug);
@@ -39,7 +37,7 @@ export function queryEnterpriseLearner(username, enterpriseSlug) {
  * .enterprise
  * .enterpriseCustomer(enterpriseUuid)
  * ._ctx.enrollments
- * @returns
+ * @returns {Types.QueryOptions}
  */
 export function queryEnterpriseCourseEnrollments(enterpriseUuid) {
   return queries
@@ -55,7 +53,7 @@ export function queryEnterpriseCourseEnrollments(enterpriseUuid) {
  * .enterpriseCustomer(enterpriseUuid)
  * ._ctx.course
  * ._ctx.contentMetadata(courseKey)
- * @returns
+ * @returns {Types.QueryOptions}
  */
 export function queryCourseMetadata(enterpriseUuid, courseKey) {
   return queries
@@ -72,7 +70,7 @@ export function queryCourseMetadata(enterpriseUuid, courseKey) {
  * .enterpriseCustomer(enterpriseUuid)
  * ._ctx.contentHighlights
  * ._ctx.configuration
- * @returns
+ * @returns {Types.QueryOptions}
  */
 export function queryContentHighlightsConfiguration(enterpriseUuid) {
   return queries
@@ -89,7 +87,7 @@ export function queryContentHighlightsConfiguration(enterpriseUuid) {
  * .enterpriseCustomer(enterpriseUuid)
  * ._ctx.course
  * ._ctx.canRedeem(availableCourseRunKeys)
- * @returns
+ * @returns {Types.QueryOptions}
  */
 export function queryCanRedeem(enterpriseUuid, courseMetadata) {
   const availableCourseRunKeys = getAvailableCourseRuns(courseMetadata).map(courseRun => courseRun.key);
@@ -107,7 +105,7 @@ export function queryCanRedeem(enterpriseUuid, courseMetadata) {
  * .enterpriseCustomer(enterpriseUuid)
  * ._ctx.subsidies
  * ._ctx.subscriptions
- * @returns
+ * @returns {Types.QueryOptions}
  */
 export function querySubscriptions(enterpriseUuid) {
   return queries
@@ -125,7 +123,7 @@ export function querySubscriptions(enterpriseUuid) {
  * ._ctx.subsidies
  * ._ctx.policy
  * ._ctx.redeemablePolicies(lmsUserId)
- * @returns
+ * @returns {Types.QueryOptions}
  */
 export function queryRedeemablePolicies({ enterpriseUuid, lmsUserId }) {
   return queries
@@ -143,7 +141,7 @@ export function queryRedeemablePolicies({ enterpriseUuid, lmsUserId }) {
  * .enterpriseCustomer(enterpriseUuid)
  * ._ctx.subsidies
  * ._ctx.enterpriseOffers
- * @returns
+ * @returns {Types.QueryOptions}
  */
 export function queryEnterpriseLearnerOffers(enterpriseUuid) {
   return queries
@@ -160,7 +158,7 @@ export function queryEnterpriseLearnerOffers(enterpriseUuid) {
  * .enterpriseCustomer(enterpriseUuid)
  * ._ctx.subsidies
  * ._ctx.couponCodes
- * @returns
+ * @returns {Types.QueryOptions}
  */
 export function queryCouponCodes(enterpriseUuid) {
   return queries
@@ -174,10 +172,7 @@ export function queryCouponCodes(enterpriseUuid) {
  * Helper function to assist querying with useQuery package.
  *
  * @param {string} enterpriseUuid - The UUID of the enterprise.
- * @param {string} userEmail - The email of the user.
- * @returns {QueryObject} - The query object for the enterprise configuration.
- * @property {[string]} QueryObject.queryKey - The query key for the object
- * @property {func} QueryObject.queryFn - The asynchronous API request "fetchBrowseAndRequestConfiguration"
+ * @returns {Types.QueryOptions}
  */
 export function queryBrowseAndRequestConfiguration(enterpriseUuid) {
   return queries
@@ -197,7 +192,7 @@ export function queryBrowseAndRequestConfiguration(enterpriseUuid) {
  * ._ctx.browseAndRequest(userEmail)
  * ._ctx.requests(state)
  * ._ctx.licenseRequests
- * @returns
+ * @returns {Types.QueryOptions}
  */
 export function queryLicenseRequests(enterpriseUuid, userEmail, state = SUBSIDY_REQUEST_STATE.REQUESTED) {
   return queries
@@ -219,7 +214,7 @@ export function queryLicenseRequests(enterpriseUuid, userEmail, state = SUBSIDY_
  * ._ctx.browseAndRequest(userEmail)
  * ._ctx.requests(state)
  * ._ctx.couponCodeRequests
- * @returns
+ * @returns {Types.QueryOptions}
  */
 export function queryCouponCodeRequests(enterpriseUuid, userEmail, state = SUBSIDY_REQUEST_STATE.REQUESTED) {
   return queries

--- a/src/components/app/data/services/subsidies/subscriptions.test.js
+++ b/src/components/app/data/services/subsidies/subscriptions.test.js
@@ -178,6 +178,9 @@ describe('activateOrAutoApplySubscriptionLicense', () => {
     };
     const result = await activateOrAutoApplySubscriptionLicense({
       enterpriseCustomer: mockEnterpriseCustomer,
+      allLinkedEnterpriseCustomerUsers: [{
+        enterpriseCustomer: mockEnterpriseCustomer,
+      }],
       subscriptionsData: mockSubscriptionsData,
       requestUrl: {
         pathname: `/${mockEnterpriseSlug}`,
@@ -198,6 +201,9 @@ describe('activateOrAutoApplySubscriptionLicense', () => {
     };
     const result = await activateOrAutoApplySubscriptionLicense({
       enterpriseCustomer: mockEnterpriseCustomer,
+      allLinkedEnterpriseCustomerUsers: [{
+        enterpriseCustomer: mockEnterpriseCustomer,
+      }],
       subscriptionsData: mockSubscriptionsData,
       requestUrl: {
         pathname: `/${mockEnterpriseSlug}`,
@@ -238,6 +244,9 @@ describe('activateOrAutoApplySubscriptionLicense', () => {
             ? `/${mockEnterpriseSlug}/licenses/${mockLicenseActivationKey}/activate`
             : `/${mockEnterpriseSlug}`,
         },
+        allLinkedEnterpriseCustomerUsers: [{
+          enterpriseCustomer: mockEnterpriseCustomer,
+        }],
       });
       expect(response).toEqual({
         ...mockSubscriptionLicense,
@@ -255,26 +264,37 @@ describe('activateOrAutoApplySubscriptionLicense', () => {
     {
       identityProvider: null,
       subscriptionForAutoAppliedLicenses: null,
+      isLinkedToEnterpriseCustomer: false,
       shouldAutoApply: false,
     },
     {
       identityProvider: null,
       subscriptionForAutoAppliedLicenses: mockSubscriptionPlanUUID,
+      isLinkedToEnterpriseCustomer: false,
       shouldAutoApply: false,
     },
     {
       identityProvider: 'identity-provider',
       subscriptionForAutoAppliedLicenses: null,
+      isLinkedToEnterpriseCustomer: false,
       shouldAutoApply: false,
     },
     {
       identityProvider: 'identity-provider',
       subscriptionForAutoAppliedLicenses: mockSubscriptionPlanUUID,
+      isLinkedToEnterpriseCustomer: false,
+      shouldAutoApply: false,
+    },
+    {
+      identityProvider: 'identity-provider',
+      subscriptionForAutoAppliedLicenses: mockSubscriptionPlanUUID,
+      isLinkedToEnterpriseCustomer: true,
       shouldAutoApply: true,
     },
   ])('auto-applies subscription license (%s)', async ({
     identityProvider,
     subscriptionForAutoAppliedLicenses,
+    isLinkedToEnterpriseCustomer,
     shouldAutoApply,
   }) => {
     const mockLicensesByStatus = {
@@ -310,6 +330,9 @@ describe('activateOrAutoApplySubscriptionLicense', () => {
       requestUrl: {
         pathname: `/${mockEnterpriseSlug}`,
       },
+      allLinkedEnterpriseCustomerUsers: isLinkedToEnterpriseCustomer ? [{
+        enterpriseCustomer: mockEnterpriseCustomer,
+      }] : [],
     });
     if (shouldAutoApply) {
       expect(response).toEqual(mockAutoAppliedSubscriptionLicense);

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -94,20 +94,35 @@ export function determineEnterpriseCustomerUserForDisplay({
   activeEnterpriseCustomerUserRoleAssignments,
   enterpriseSlug,
   foundEnterpriseCustomerUserForCurrentSlug,
+  staffEnterpriseCustomer,
 }) {
   const activeEnterpriseCustomerUser = {
     enterpriseCustomer: activeEnterpriseCustomer,
     roleAssignments: activeEnterpriseCustomerUserRoleAssignments,
   };
+  // No enterprise slug in the URL, so return the active enterprise customer user.
   if (!enterpriseSlug) {
     return activeEnterpriseCustomerUser;
   }
+
+  // If the enterprise slug in the URL does not match the active enterprise
+  // customer user's slug and there is a linked enterprise customer user for
+  // the requested slug, return the linked enterprise customer user.
   if (enterpriseSlug !== activeEnterpriseCustomer?.slug && foundEnterpriseCustomerUserForCurrentSlug) {
     return {
       enterpriseCustomer: foundEnterpriseCustomerUserForCurrentSlug.enterpriseCustomer,
       roleAssignments: foundEnterpriseCustomerUserForCurrentSlug.roleAssignments,
     };
   }
+
+  if (staffEnterpriseCustomer) {
+    return {
+      enterpriseCustomer: staffEnterpriseCustomer,
+      roleAssignments: [],
+    };
+  }
+
+  // Otherwise, return no enterprise customer metadata.
   return activeEnterpriseCustomerUser;
 }
 
@@ -198,7 +213,7 @@ export function transformEnterpriseCustomer(enterpriseCustomer) {
   // If the learner portal is not enabled for the displayed enterprise customer, return null. This
   // results in the enterprise learner portal not being accessible for the user, showing a 404 page.
   if (!enterpriseCustomer.enableLearnerPortal) {
-    return null;
+    return undefined;
   }
 
   // Otherwise, learner portal is enabled, so transform the enterprise customer data.

--- a/src/components/app/routes/data/utils.js
+++ b/src/components/app/routes/data/utils.js
@@ -253,8 +253,8 @@ export async function ensureActiveEnterpriseCustomerUser({
   allLinkedEnterpriseCustomerUsers,
   requestUrl,
 }) {
-  // If the enterprise slug in the URL matches the active enterprise customer user's slug OR the
-  // slug returned by the staff metadata, return early.
+  // If the enterprise slug in the URL matches the active enterprise customer user's slug OR no
+  // active enterprise customer exists, return early.
   if (!activeEnterpriseCustomer || activeEnterpriseCustomer.slug === enterpriseSlug) {
     return null;
   }

--- a/src/components/app/routes/data/utils.js
+++ b/src/components/app/routes/data/utils.js
@@ -20,7 +20,6 @@ import {
   queryContentHighlightsConfiguration,
   queryCouponCodeRequests,
   queryCouponCodes,
-  queryEnterpriseLearner,
   queryEnterpriseLearnerOffers,
   queryLicenseRequests,
   queryNotices,
@@ -36,6 +35,7 @@ import {
  */
 export async function ensureEnterpriseAppData({
   enterpriseCustomer,
+  allLinkedEnterpriseCustomerUsers,
   userId,
   userEmail,
   queryClient,
@@ -49,6 +49,7 @@ export async function ensureEnterpriseAppData({
       // Auto-activate the user's subscription license, if applicable.
       const activatedOrAutoAppliedLicense = await activateOrAutoApplySubscriptionLicense({
         enterpriseCustomer,
+        allLinkedEnterpriseCustomerUsers,
         subscriptionsData,
         requestUrl,
       });
@@ -179,6 +180,14 @@ export function redirectToRemoveTrailingSlash(requestUrl) {
   throw redirect(requestUrl.pathname.slice(0, -1));
 }
 
+configureLogging(NewRelicLoggingService, {
+  config: getConfig(),
+});
+configureAuth(AxiosJwtAuthService, {
+  loggingService: getLoggingService(),
+  config: getConfig(),
+});
+
 /**
  * Ensures that the user is authenticated. If not, redirects to the login page.
  * @param {URL} requestUrl - The current request URL to redirect back to if the
@@ -186,14 +195,6 @@ export function redirectToRemoveTrailingSlash(requestUrl) {
  * @param {Object} params - The parameters object.
  */
 export async function ensureAuthenticatedUser(requestUrl, params) {
-  configureLogging(NewRelicLoggingService, {
-    config: getConfig(),
-  });
-  configureAuth(AxiosJwtAuthService, {
-    loggingService: getLoggingService(),
-    config: getConfig(),
-  });
-
   const {
     enterpriseSlug,
     enterpriseCustomerInviteKey,
@@ -240,23 +241,21 @@ export async function ensureAuthenticatedUser(requestUrl, params) {
  * TODO
  * @param {*} enterpriseSlug
  * @param {*} activeEnterpriseCustomer
+ * @param {*} staffEnterpriseCustomer
  * @param {*} allLinkedEnterpriseCustomerUsers
  * @param {*} requestUrl
- * @param {*} queryClient
- * @param {*} updateUserActiveEnterprise
  * @returns
  */
 export async function ensureActiveEnterpriseCustomerUser({
   enterpriseSlug,
   activeEnterpriseCustomer,
+  staffEnterpriseCustomer,
   allLinkedEnterpriseCustomerUsers,
   requestUrl,
-  queryClient,
-  username,
-  // updateUserActiveEnterprise,
 }) {
-  // If the enterprise slug in the URL matches the active enterprise customer's slug, return early.
-  if (enterpriseSlug === activeEnterpriseCustomer.slug) {
+  // If the enterprise slug in the URL matches the active enterprise customer user's slug OR the
+  // slug returned by the staff metadata, return early.
+  if (!activeEnterpriseCustomer || activeEnterpriseCustomer.slug === enterpriseSlug) {
     return null;
   }
 
@@ -265,45 +264,33 @@ export async function ensureActiveEnterpriseCustomerUser({
   const foundEnterpriseCustomerUserForSlug = allLinkedEnterpriseCustomerUsers.find(
     enterpriseCustomerUser => enterpriseCustomerUser.enterpriseCustomer.slug === enterpriseSlug,
   );
-  if (!foundEnterpriseCustomerUserForSlug) {
-    throw redirect(generatePath('/:enterpriseSlug/*', {
-      enterpriseSlug: activeEnterpriseCustomer.slug,
-      '*': requestUrl.pathname.split('/').filter(pathPart => !!pathPart).slice(1).join('/'),
-    }));
+  if (foundEnterpriseCustomerUserForSlug) {
+    const {
+      enterpriseCustomer: nextActiveEnterpriseCustomer,
+    } = foundEnterpriseCustomerUserForSlug;
+    // Makes the POST API request to update the active enterprise customer
+    // for the learner in the backend for future sessions.
+    await updateUserActiveEnterprise({
+      enterpriseCustomer: nextActiveEnterpriseCustomer,
+    });
+    const updatedLinkedEnterpriseCustomerUsers = allLinkedEnterpriseCustomerUsers.map(
+      ecu => ({
+        ...ecu,
+        active: (
+          ecu.enterpriseCustomer.uuid === nextActiveEnterpriseCustomer.uuid
+        ),
+      }),
+    );
+    return {
+      enterpriseCustomer: nextActiveEnterpriseCustomer,
+      updatedLinkedEnterpriseCustomerUsers,
+    };
   }
-
-  const {
-    enterpriseCustomer: nextActiveEnterpriseCustomer,
-    roleAssignments: nextActiveEnterpriseCustomerRoleAssignments,
-  } = foundEnterpriseCustomerUserForSlug;
-  // Makes the POST API request to update the active enterprise customer
-  // for the learner in the backend for future sessions.
-  await updateUserActiveEnterprise({
-    enterpriseCustomer: nextActiveEnterpriseCustomer,
-  });
-  const nextEnterpriseLearnerQuery = queryEnterpriseLearner(username, nextActiveEnterpriseCustomer.slug);
-  const updatedLinkedEnterpriseCustomerUsers = allLinkedEnterpriseCustomerUsers.map(
-    ecu => ({
-      ...ecu,
-      active: (
-        ecu.enterpriseCustomer.uuid === nextActiveEnterpriseCustomer.uuid
-      ),
-    }),
-  );
-
-  // Perform optimistic update of the query cache to avoid duplicate API request for the same data. The only
-  // difference is that the query key now contains the new enterprise slug, so we can proactively set the query
-  // cache for with the enterprise learner data we already have before resolving the loader.
-  queryClient.setQueryData(nextEnterpriseLearnerQuery.queryKey, {
-    enterpriseCustomer: nextActiveEnterpriseCustomer,
-    enterpriseCustomerUserRoleAssignments: nextActiveEnterpriseCustomerRoleAssignments,
-    activeEnterpriseCustomer: nextActiveEnterpriseCustomer,
-    activeEnterpriseCustomerUserRoleAssignments: nextActiveEnterpriseCustomerRoleAssignments,
-    allLinkedEnterpriseCustomerUsers: updatedLinkedEnterpriseCustomerUsers,
-  });
-
-  return {
-    enterpriseCustomer: nextActiveEnterpriseCustomer,
-    updatedLinkedEnterpriseCustomerUsers,
-  };
+  if (staffEnterpriseCustomer) {
+    return null;
+  }
+  throw redirect(generatePath('/:enterpriseSlug/*', {
+    enterpriseSlug: activeEnterpriseCustomer.slug,
+    '*': requestUrl.pathname.split('/').filter(pathPart => !!pathPart).slice(1).join('/'),
+  }));
 }

--- a/src/components/app/routes/data/utils.test.js
+++ b/src/components/app/routes/data/utils.test.js
@@ -6,7 +6,7 @@ describe('transformEnterpriseCustomer', () => {
       enableLearnerPortal: false,
     };
     const result = transformEnterpriseCustomer(enterpriseCustomer);
-    expect(result).toEqual(null);
+    expect(result).toBeUndefined();
   });
 
   it.each([

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,12 @@
-import { queries } from './utils/queryKeyFactory'
+import { queries } from './components/app/data';
 
 export type UseQueryResult = import('@tanstack/react-query').UseQueryResult;
+export type QueryObserverOptions  = import('@tanstack/react-query').QueryObserverOptions;
+export type QueryClient = import('@tanstack/react-query').QueryClient;
+export type QueryObserverResult = import('@tanstack/react-query').QueryObserverResult;
+export type Query = import('@tanstack/react-query').Query;
+export type QueryOptions = import('@tanstack/react-query').QueryOptions
+
 export type QueryKeys = import('@lukemorales/query-key-factory').inferQueryKeyStore<typeof queries>;
 
 export as namespace Types;


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8597

Currently, on `master`, authenticated staff users can view the learner portal for enterprise customers they are not explicitly linked to. This partial masquerading is occasionally used to QA customer issues (e.g., verify expected content is returning in Algolia) and most staff assume to be able to access customer portals, similar to Admin Portal.

By removing `enterprise-customer` API call to solely rely on `enterprise-learner`, we effectively removed the ability for staff users to view the learner portal for enterprise customers they are not explicitly linked to.

This PR brings back that expected functionality by only relying on `enterprise-customer` API if the user is staff, an enterprise slug is specified in the route URL, and the user is not explicitly linked to the customer. It will has no performance impact on learners; only unlinked staff users.

This approach of making an extra API call to `enterprise-customer` to support partial masquerading of enterprise customers' learner portals was favored over backend changes to either of the APIs to get around the issue of retrieving customer metadata when not explicitly linked for staff users (i.e., less scope and only impacts internal staff users).

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
