### PR TITLE
feat: reintegrate the skills quiz page

### DIFF
--- a/src/components/app/routes/createAppRouter.jsx
+++ b/src/components/app/routes/createAppRouter.jsx
@@ -78,11 +78,9 @@ export default function createAppRouter(queryClient) {
           <Route
             path="skills-quiz"
             lazy={async () => {
-              const { makeSearchLoader } = await import('../../search');
               const { SkillsQuizPage } = await import('../../skills-quiz');
               return {
                 Component: SkillsQuizPage,
-                loader: makeSearchLoader(queryClient),
               };
             }}
             errorElement={(

--- a/src/components/app/routes/createAppRouter.jsx
+++ b/src/components/app/routes/createAppRouter.jsx
@@ -76,6 +76,23 @@ export default function createAppRouter(queryClient) {
             )}
           />
           <Route
+            path="skills-quiz"
+            lazy={async () => {
+              const { makeSearchLoader } = await import('../../search');
+              const { SkillsQuizPage } = await import('../../skills-quiz');
+              return {
+                Component: SkillsQuizPage,
+                loader: makeSearchLoader(queryClient),
+              };
+            }}
+            errorElement={(
+              <RouteErrorBoundary
+                showSiteHeader={false}
+                showSiteFooter={false}
+              />
+            )}
+          />
+          <Route
             path=":courseType?/course/:courseKey/*"
             lazy={async () => {
               const { default: CourseRoute } = await import('./CourseRoute');

--- a/src/components/my-career/tests/SkillsRecommendationCourses.test.jsx
+++ b/src/components/my-career/tests/SkillsRecommendationCourses.test.jsx
@@ -5,25 +5,16 @@ import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClientProvider } from '@tanstack/react-query';
-import { UserSubsidyContext } from '../../enterprise-user-subsidy';
-import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import {
   defaultSubsidyHooksData,
   mockSubsidyHooksReturnValues,
-  queryClient,
-  renderWithRouter
+  renderWithRouter,
 } from '../../../utils/tests';
 import SkillsRecommendationCourses from '../SkillsRecommendationCourses';
 import { TEST_IMAGE_URL } from '../../search/tests/constants';
 import {
-  useCouponCodes,
   useEnterpriseCustomer,
-  useEnterpriseOffers,
-  useRedeemablePolicies,
-  useSubscriptions,
 } from '../../app/data';
-import { useCatalogsForSubsidyRequests } from '../../hooks';
 
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
@@ -113,40 +104,22 @@ const defaultSearchContext = {
   dispatch: () => null,
 };
 
-const defaultUserSubsidyState = {
-  couponCodes: {
-    couponCodes: [],
-    loading: false,
-    couponCodesCount: 0,
-  },
-};
-
-const defaultSubsidyRequestState = {
-  catalogsForSubsidyRequests: [],
-};
-
 const SkillsRecommendationCoursesWithContext = ({
   index = coursesIndex,
   subCategoryName = TEST_SUB_CATEGORY_NAME,
   subCategorySkills = TEST_SKILLS,
 }) => (
-  <QueryClientProvider client={queryClient()}>
-    <IntlProvider locale="en">
-      <AppContext.Provider value={defaultAppState}>
-        <SearchContext.Provider value={defaultSearchContext}>
-          <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
-            <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
-              <SkillsRecommendationCourses
-                index={index}
-                subCategoryName={subCategoryName}
-                subCategorySkills={subCategorySkills}
-              />
-            </SubsidyRequestsContext.Provider>
-          </UserSubsidyContext.Provider>
-        </SearchContext.Provider>
-      </AppContext.Provider>
-    </IntlProvider>
-  </QueryClientProvider>
+  <IntlProvider locale="en">
+    <AppContext.Provider value={defaultAppState}>
+      <SearchContext.Provider value={defaultSearchContext}>
+        <SkillsRecommendationCourses
+          index={index}
+          subCategoryName={subCategoryName}
+          subCategorySkills={subCategorySkills}
+        />
+      </SearchContext.Provider>
+    </AppContext.Provider>
+  </IntlProvider>
 );
 
 const mockEnterpriseCustomer = {

--- a/src/components/pathway/tests/PathwayModal.test.jsx
+++ b/src/components/pathway/tests/PathwayModal.test.jsx
@@ -55,7 +55,7 @@ const nodePageLink = (node) => {
 const mockEnterpriseCustomer = {
   name: 'test-enterprise',
   slug: TEST_ENTERPRISE_SLUG,
-  uuid: '12345',
+  uuid: 'test-enterprise-uuid',
 };
 
 describe('<PathwayModal />', () => {

--- a/src/components/search/content-highlights/tests/ContentHighlightSet.test.jsx
+++ b/src/components/search/content-highlights/tests/ContentHighlightSet.test.jsx
@@ -47,8 +47,8 @@ const ContentHighlightSetWrapper = ({
 
 const mockEnterpriseCustomer = {
   name: 'test-enterprise',
-  slug: 'test',
-  uuid: '12345',
+  slug: 'test-enterprise-slug',
+  uuid: 'test-enterprise-uuid',
 };
 
 describe('ContentHighlightSet', () => {

--- a/src/components/search/content-highlights/tests/ContentHighlights.test.jsx
+++ b/src/components/search/content-highlights/tests/ContentHighlights.test.jsx
@@ -64,8 +64,8 @@ const ContentHighlightsWrapper = ({
 
 const mockEnterpriseCustomer = {
   name: 'test-enterprise',
-  slug: 'test',
-  uuid: '12345',
+  slug: 'test-enterprise-slug',
+  uuid: 'test-enterprise-uuid',
 };
 
 describe('ContentHighlights', () => {

--- a/src/components/search/content-highlights/tests/HighlightedContentCard.test.jsx
+++ b/src/components/search/content-highlights/tests/HighlightedContentCard.test.jsx
@@ -36,8 +36,8 @@ jest.mock('../../../app/data', () => ({
 
 const mockEnterpriseCustomer = {
   name: 'test-enterprise',
-  slug: 'test',
-  uuid: '12345',
+  slug: 'test-enterprise-slug',
+  uuid: 'test-enterprise-uuid',
 };
 
 const defaultAppContextValue = {

--- a/src/components/search/data/hooks/useDefaultSearchFilters.test.js
+++ b/src/components/search/data/hooks/useDefaultSearchFilters.test.js
@@ -57,7 +57,8 @@ describe('useDefaultSearchFilters', () => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
-  })
+  });
+
   const refinementsShowAll = { refinements: { [SHOW_ALL_NAME]: 1 } };
 
   it('should set SHOW_ALL_NAME to 1 if searchCatalogs.length === 0', () => {

--- a/src/components/search/data/hooks/useDefaultSearchFilters.test.js
+++ b/src/components/search/data/hooks/useDefaultSearchFilters.test.js
@@ -4,14 +4,10 @@ import React from 'react';
 import { SearchContext, SHOW_ALL_NAME } from '@edx/frontend-enterprise-catalog-search';
 import { useDefaultSearchFilters } from './index';
 import {
-  useCouponCodes,
   useEnterpriseCustomer,
-  useEnterpriseOffers,
-  useRedeemablePolicies,
-  useSubscriptions,
 } from '../../../app/data';
 import useSearchCatalogs from './useSearchCatalogs';
-import { useCatalogsForSubsidyRequests } from '../../../hooks';
+import { defaultSubsidyHooksData, mockSubsidyHooksReturnValues } from '../../../../utils/tests';
 
 const TEST_ENTERPRISE_UUID = 'test-enterprise-uuid';
 
@@ -55,31 +51,13 @@ const mockEnterpriseCustomer = {
   uuid: TEST_ENTERPRISE_UUID,
 };
 
-const defaultData = {
-  mockRedeemablePolicies: [],
-  mockCatalogsForSubsidyRequest: [],
-  mockCurrentEnterpriseOffers: [],
-  mockSubscriptionLicense: null,
-  mockCouponCodeAssignments: [],
-};
-useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-const mockSubsidyHooksReturnValues = ({
-  mockRedeemablePolicies = [],
-  mockCatalogsForSubsidyRequest = [],
-  mockCurrentEnterpriseOffers = [],
-  mockSubscriptionLicense = null,
-  mockCouponCodeAssignments = [],
-}) => {
-  useRedeemablePolicies.mockReturnValue({ data: { redeemablePolicies: mockRedeemablePolicies } });
-  useCatalogsForSubsidyRequests.mockReturnValue({ catalogsForSubsidyRequests: mockCatalogsForSubsidyRequest });
-  useEnterpriseOffers.mockReturnValue({ data: { currentEnterpriseOffers: mockCurrentEnterpriseOffers } });
-  useSubscriptions.mockReturnValue({ data: { subscriptionLicense: mockSubscriptionLicense } });
-  useCouponCodes.mockReturnValue({ data: { couponCodeAssignments: mockCouponCodeAssignments } });
-};
-mockSubsidyHooksReturnValues(defaultData);
-
 // TODO: Test and hook may have to be refactored
 describe('useDefaultSearchFilters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
+  })
   const refinementsShowAll = { refinements: { [SHOW_ALL_NAME]: 1 } };
 
   it('should set SHOW_ALL_NAME to 1 if searchCatalogs.length === 0', () => {

--- a/src/components/search/data/hooks/useSearchCatalogs.test.js
+++ b/src/components/search/data/hooks/useSearchCatalogs.test.js
@@ -8,7 +8,7 @@ import { features } from '../../../../config';
 import {
   useEnterpriseCustomer,
 } from '../../../app/data';
-import { defaultSubsidyHooksData, mockSubsidyHooksReturnValues } from "../../../../utils/tests";
+import { defaultSubsidyHooksData, mockSubsidyHooksReturnValues } from '../../../../utils/tests';
 
 const TEST_ENTERPRISE_UUID = 'test-enterprise-uuid';
 
@@ -55,7 +55,8 @@ describe('useSearchCatalogs', () => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
-  })
+  });
+
   it.each('should include catalog from subscription (%s)', ({ isSubscriptionPlanExpired }) => {
     const mockSubscriptionLicense = {
       status: LICENSE_STATUS.ACTIVATED,

--- a/src/components/search/data/hooks/useSearchCatalogs.test.js
+++ b/src/components/search/data/hooks/useSearchCatalogs.test.js
@@ -6,11 +6,9 @@ import {
 import { LICENSE_STATUS } from '../../../enterprise-user-subsidy/data/constants';
 import { features } from '../../../../config';
 import {
-  useCouponCodes,
-  useSubscriptions,
-  useEnterpriseCustomer, useEnterpriseOffers, useRedeemablePolicies,
+  useEnterpriseCustomer,
 } from '../../../app/data';
-import { useCatalogsForSubsidyRequests } from '../../../hooks';
+import { defaultSubsidyHooksData, mockSubsidyHooksReturnValues } from "../../../../utils/tests";
 
 const TEST_ENTERPRISE_UUID = 'test-enterprise-uuid';
 
@@ -48,28 +46,16 @@ const mockEnterpriseCustomer = {
   uuid: TEST_ENTERPRISE_UUID,
 };
 
-useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-
-const mockSubsidyHooksReturnValues = ({
-  mockRedeemablePolicies = [],
-  mockCatalogsForSubsidyRequest = [],
-  mockCurrentEnterpriseOffers = [],
-  mockSubscriptionLicense = null,
-  mockCouponCodeAssignments = [],
-}) => {
-  useRedeemablePolicies.mockReturnValue({ data: { redeemablePolicies: mockRedeemablePolicies } });
-  useCatalogsForSubsidyRequests.mockReturnValue({ catalogsForSubsidyRequests: mockCatalogsForSubsidyRequest });
-  useEnterpriseOffers.mockReturnValue({ data: { currentEnterpriseOffers: mockCurrentEnterpriseOffers } });
-  useSubscriptions.mockReturnValue({ data: { subscriptionLicense: mockSubscriptionLicense } });
-  useCouponCodes.mockReturnValue({ data: { couponCodeAssignments: mockCouponCodeAssignments } });
-};
-
 describe('useSearchCatalogs', () => {
   const mockSubscriptionCatalog = 'test-subscription-catalog-uuid';
   const mockCouponCodeCatalog = 'test-coupon-code-catalog-uuid';
   const mockEnterpriseOfferCatalog = 'test-enterprise-offer-catalog-uuid';
   const mockPolicyCatalog = 'test-policy-catalog-uuid';
-
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
+  })
   it.each('should include catalog from subscription (%s)', ({ isSubscriptionPlanExpired }) => {
     const mockSubscriptionLicense = {
       status: LICENSE_STATUS.ACTIVATED,

--- a/src/components/search/tests/SearchCourseCard.test.jsx
+++ b/src/components/search/tests/SearchCourseCard.test.jsx
@@ -60,7 +60,7 @@ const propsForLoading = {
 const mockEnterpriseCustomer = {
   name: 'test-enterprise',
   slug: 'test-enterprise-slug',
-  uuid: '12345',
+  uuid: 'test-enterprise-uuid',
 };
 
 describe('<SearchCourseCard />', () => {

--- a/src/components/search/tests/SearchResults.test.jsx
+++ b/src/components/search/tests/SearchResults.test.jsx
@@ -188,7 +188,7 @@ const propsForNoResults = {
 const mockEnterpriseCustomer = {
   name: 'BearsRUs',
   slug: TEST_ENTERPRISE_SLUG,
-  uuid: '12345',
+  uuid: 'test-enterprise-uuid',
 };
 
 describe('<SearchResults />', () => {

--- a/src/components/search/tests/SearchSections.test.jsx
+++ b/src/components/search/tests/SearchSections.test.jsx
@@ -74,8 +74,8 @@ const SearchWrapper = ({
 const mockFilter = 'enterprise_customer_uuids: test-uuid';
 const mockEnterpriseCustomer = {
   name: 'test-enterprise',
-  slug: 'test',
-  uuid: '12345',
+  slug: 'test-enterprise-slug',
+  uuid: 'test-enterprise-uuid',
 };
 
 describe('<Search />', () => {

--- a/src/components/skills-quiz-v2/tests/SkillsQuiz.test.jsx
+++ b/src/components/skills-quiz-v2/tests/SkillsQuiz.test.jsx
@@ -4,11 +4,15 @@ import { screen } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { SearchData } from '@edx/frontend-enterprise-catalog-search';
-import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import { SkillsContextProvider } from '../../skills-quiz/SkillsContextProvider';
 import { renderWithRouter } from '../../../utils/tests';
 import SkillsQuizV2 from '../SkillsQuiz';
-import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
+import { useEnterpriseCustomer } from '../../app/data';
+
+jest.mock('../../app/data', () => ({
+  ...jest.requireActual('../../app/data'),
+  useEnterpriseCustomer: jest.fn(),
+}));
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -21,25 +25,18 @@ jest.mock('@edx/frontend-enterprise-utils', () => ({
 }));
 
 const defaultAppState = {
-  enterpriseConfig: {
-    name: 'test-enterprise',
-    slug: 'test',
-    uuid: '12345',
-  },
   authenticatedUser: {
     userId: '123',
   },
 };
 
-const defaultUserSubsidyState = {
-  couponCodes: [],
-  loading: false,
-  couponCodesCount: 0,
+const mockEnterpriseCustomer = {
+  name: 'test-enterprise',
+  slug: 'test-enterprise-slug',
+  uuid: 'test-enterprise-uuid',
 };
 
-const defaultSubsidyRequestState = {
-  catalogsForSubsidyRequests: [],
-};
+useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
 
 describe('<SkillsQuizV2 />', () => {
   it('renders SkillsQuizV2 component correctly', () => {
@@ -48,11 +45,7 @@ describe('<SkillsQuizV2 />', () => {
         <SkillsContextProvider>
           <IntlProvider locale="en">
             <AppContext.Provider value={defaultAppState}>
-              <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
-                <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
-                  <SkillsQuizV2 />
-                </SubsidyRequestsContext.Provider>
-              </UserSubsidyContext.Provider>
+              <SkillsQuizV2 />
             </AppContext.Provider>
           </IntlProvider>,
         </SkillsContextProvider>

--- a/src/components/skills-quiz-v2/tests/SkillsQuizForm.test.jsx
+++ b/src/components/skills-quiz-v2/tests/SkillsQuizForm.test.jsx
@@ -14,7 +14,7 @@ import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 const defaultAppState = {
   enterpriseConfig: {
     name: 'test-enterprise',
-    slug: 'test',
+    slug: 'test-enterprise-slug',
   },
   config: {
     LMS_BASE_URL: process.env.LMS_BASE_URL,

--- a/src/components/skills-quiz/GoalDropdown.jsx
+++ b/src/components/skills-quiz/GoalDropdown.jsx
@@ -13,7 +13,7 @@ const GoalDropdown = () => {
   const selectGoal = (selectedGoal) => {
     dispatch({ type: SET_KEY_VALUE, key: 'goal', value: selectedGoal });
   };
-  const gaolDropdownOptions = [GOAL_DROPDOWN_DEFAULT_OPTION, DROPDOWN_OPTION_CHANGE_CAREERS,
+  const goalDropdownOptions = [GOAL_DROPDOWN_DEFAULT_OPTION, DROPDOWN_OPTION_CHANGE_CAREERS,
     DROPDOWN_OPTION_GET_PROMOTED, DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE, DROPDOWN_OPTION_OTHER];
 
   return (
@@ -21,12 +21,13 @@ const GoalDropdown = () => {
       <Dropdown.Toggle
         variant="outline-primary"
         id="skills-quiz-goal-dropdown-toggle"
+        data-testid="skills-quiz-goal-dropdown-toggle"
       >
         {goal}
       </Dropdown.Toggle>
       <Dropdown.Menu>
-        {gaolDropdownOptions?.map(option => (
-          <Dropdown.Item key={option} as="label" onClick={() => selectGoal(option)}>
+        {goalDropdownOptions?.map(option => (
+          <Dropdown.Item key={option} onClick={() => selectGoal(option)}>
             {option}
           </Dropdown.Item>
         ))}

--- a/src/components/skills-quiz/GoalDropdown.jsx
+++ b/src/components/skills-quiz/GoalDropdown.jsx
@@ -27,7 +27,7 @@ const GoalDropdown = () => {
       </Dropdown.Toggle>
       <Dropdown.Menu>
         {goalDropdownOptions?.map(option => (
-          <Dropdown.Item key={option} onClick={() => selectGoal(option)}>
+          <Dropdown.Item key={option} as="label" onClick={() => selectGoal(option)}>
             {option}
           </Dropdown.Item>
         ))}

--- a/src/components/skills-quiz/tests/SearchCourseCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchCourseCard.test.jsx
@@ -8,24 +8,21 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import SearchCourseCard from '../SearchCourseCard';
 
-import { defaultSubsidyHooksData, mockSubsidyHooksReturnValues, renderWithRouter } from '../../../utils/tests';
+import { renderWithRouter } from '../../../utils/tests';
 import { TEST_IMAGE_URL, TEST_ENTERPRISE_SLUG } from '../../search/tests/constants';
 import { NO_COURSES_ALERT_MESSAGE } from '../constants';
 import { SkillsContext } from '../SkillsContextProvider';
 import { useEnterpriseCustomer } from '../../app/data';
+import { useDefaultSearchFilters } from '../../search';
 
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
   useEnterpriseCustomer: jest.fn(),
-  useSubscriptions: jest.fn(),
-  useRedeemablePolicies: jest.fn(),
-  useCouponCodes: jest.fn(),
-  useEnterpriseOffers: jest.fn(),
 }));
 
-jest.mock('../../hooks', () => ({
-  ...jest.requireActual('../../hooks'),
-  useCatalogsForSubsidyRequests: jest.fn(),
+jest.mock('../../search', () => ({
+  ...jest.requireActual('../../search'),
+  useDefaultSearchFilters: jest.fn(),
 }));
 
 jest.mock('@edx/frontend-enterprise-utils', () => ({
@@ -125,7 +122,7 @@ describe('<SearchCourseCard />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
+    useDefaultSearchFilters.mockReturnValue({ filters: `enterprise_customer_uuids:${mockEnterpriseCustomer.uuid}` });
   });
 
   test('renders the correct data', async () => {

--- a/src/components/skills-quiz/tests/SearchCourseCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchCourseCard.test.jsx
@@ -121,11 +121,13 @@ const mockEnterpriseCustomer = {
   uuid: 'test-enterprise-uuid',
 };
 
-useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-
-mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
-
 describe('<SearchCourseCard />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
+  });
+
   test('renders the correct data', async () => {
     const { container } = renderWithRouter(
       <SearchCourseCardWithContext

--- a/src/components/skills-quiz/tests/SearchCurrentJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchCurrentJobCard.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, act, render } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { AppContext } from '@edx/frontend-platform/react';
@@ -88,7 +88,7 @@ const mockEnterpriseCustomer = {
 };
 
 describe('<SearchCurrentJobCard />', () => {
-  test('renders the data in job cards correctly', () => {.
+  test('renders the data in job cards correctly', async () => {
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     renderWithRouter(
       <SearchCurrentJobCardWithContext
@@ -97,7 +97,7 @@ describe('<SearchCurrentJobCard />', () => {
         initialJobsState={initialJobsState}
       />,
     );
-    expect(screen.getByText(TEST_JOB_TITLE)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(TEST_JOB_TITLE)).toBeInTheDocument());
     expect(screen.getByText(TRANSFORMED_MEDIAN_SALARY)).toBeInTheDocument();
     expect(screen.getByText(TRANSFORMED_JOB_POSTINGS)).toBeInTheDocument();
   });

--- a/src/components/skills-quiz/tests/SearchCurrentJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchCurrentJobCard.test.jsx
@@ -88,8 +88,12 @@ const mockEnterpriseCustomer = {
 };
 
 describe('<SearchCurrentJobCard />', () => {
-  test('renders the data in job cards correctly', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+  });
+
+  test('renders the data in job cards correctly', async () => {
     renderWithRouter(
       <SearchCurrentJobCardWithContext
         index={testIndex}

--- a/src/components/skills-quiz/tests/SearchFilters.test.jsx
+++ b/src/components/skills-quiz/tests/SearchFilters.test.jsx
@@ -18,49 +18,42 @@ import {
 import '../__mocks__/react-instantsearch-dom';
 import SkillsQuizStepper from '../SkillsQuizStepper';
 import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
+import { useEnterpriseCustomer } from '../../app/data';
+
+jest.mock('../../app/data', () => ({
+  ...jest.requireActual('../../app/data'),
+  useEnterpriseCustomer: jest.fn(),
+}));
 
 jest.mock('@edx/frontend-enterprise-utils', () => ({
   ...jest.requireActual('@edx/frontend-enterprise-utils'),
   sendEnterpriseTrackEvent: jest.fn(),
 }));
 
+const mockEnterpriseCustomer = {
+  name: 'BearsRUs',
+  slug: 'BearsRYou',
+};
+
+useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+
 const facetsToTest = [DESIRED_JOB_FACET, INDUSTRY_FACET, CURRENT_JOB_FACET];
 describe('<SkillsQuizStepper />', () => {
   const defaultAppState = {
-    enterpriseConfig: {
-      slug: 'test-enterprise-slug',
-    },
     authenticatedUser: {
       username: 'myspace-tom',
     },
-  };
-  const defaultCouponCodesState = {
-    couponCodes: [],
-    loading: false,
-    couponCodesCount: 0,
-  };
-
-  const defaultUserSubsidyState = {
-    couponCodes: defaultCouponCodesState,
-  };
-
-  const defaultSubsidyRequestState = {
-    catalogsForSubsidyRequests: [],
   };
 
   test('renders skills and jobs dropdown with a label', async () => {
     renderWithRouter(
       <IntlProvider locale="en">
         <AppContext.Provider value={defaultAppState}>
-          <UserSubsidyContext.Provider value={defaultUserSubsidyState}>
-            <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
-              <SearchData>
-                <SkillsContextProvider>
-                  <SkillsQuizStepper />
-                </SkillsContextProvider>
-              </SearchData>
-            </SubsidyRequestsContext.Provider>
-          </UserSubsidyContext.Provider>
+          <SearchData>
+            <SkillsContextProvider>
+              <SkillsQuizStepper />
+            </SkillsContextProvider>
+          </SearchData>
         </AppContext.Provider>
       </IntlProvider>,
       { route: '/test/skills-quiz/' },

--- a/src/components/skills-quiz/tests/SearchFilters.test.jsx
+++ b/src/components/skills-quiz/tests/SearchFilters.test.jsx
@@ -6,7 +6,6 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { SearchData } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { SkillsContextProvider } from '../SkillsContextProvider';
-import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import {
   DESIRED_JOB_FACET,
   INDUSTRY_FACET,
@@ -17,7 +16,6 @@ import {
 
 import '../__mocks__/react-instantsearch-dom';
 import SkillsQuizStepper from '../SkillsQuizStepper';
-import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
 import { useEnterpriseCustomer } from '../../app/data';
 
 jest.mock('../../app/data', () => ({

--- a/src/components/skills-quiz/tests/SearchJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchJobCard.test.jsx
@@ -91,9 +91,10 @@ const mockEnterpriseCustomer = {
 describe('<SearchJobCard />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-  test('renders the data in job cards correctly', async () => {
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+  });
+
+  test('renders the data in job cards correctly', async () => {
     await act(async () => {
       render(
         <SearchJobCardWithContext

--- a/src/components/skills-quiz/tests/SearchJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchJobCard.test.jsx
@@ -65,7 +65,6 @@ const hitObject = {
   ],
 };
 
-
 const testIndex = {
   indexName: 'test-index-name',
   search: jest.fn().mockImplementation(() => Promise.resolve(hitObject)),

--- a/src/components/skills-quiz/tests/SearchPathways.test.jsx
+++ b/src/components/skills-quiz/tests/SearchPathways.test.jsx
@@ -96,11 +96,13 @@ const mockEnterpriseCustomer = {
   uuid: 'test-enterprise-uuid',
 };
 
-useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-
-mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
-
 describe('<SearchPathways />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
+  });
+
   test('renders the correct data', async () => {
     renderWithRouter(<SearchPathwaysWithContext index={testIndex} />);
     await waitFor(() => {

--- a/src/components/skills-quiz/tests/SearchPathways.test.jsx
+++ b/src/components/skills-quiz/tests/SearchPathways.test.jsx
@@ -6,12 +6,25 @@ import '@testing-library/jest-dom/extend-expect';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
-import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import SearchPathways from '../SearchPathways';
-import { renderWithRouter } from '../../../utils/tests';
+import { defaultSubsidyHooksData, mockSubsidyHooksReturnValues, renderWithRouter } from '../../../utils/tests';
 import { TEST_ENTERPRISE_SLUG } from '../../search/tests/constants';
 import { SkillsContext } from '../SkillsContextProvider';
-import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
+import { useEnterpriseCustomer } from "../../app/data";
+
+jest.mock('../../app/data', () => ({
+  ...jest.requireActual('../../app/data'),
+  useEnterpriseCustomer: jest.fn(),
+  useSubscriptions: jest.fn(),
+  useRedeemablePolicies: jest.fn(),
+  useCouponCodes: jest.fn(),
+  useEnterpriseOffers: jest.fn(),
+}));
+
+jest.mock('../../hooks', () => ({
+  ...jest.requireActual('../../hooks'),
+  useCatalogsForSubsidyRequests: jest.fn(),
+}));
 
 jest.mock('@edx/frontend-enterprise-utils', () => ({
   ...jest.requireActual('@edx/frontend-enterprise-utils'),
@@ -39,12 +52,7 @@ const testIndex = {
   search: jest.fn().mockImplementation(() => Promise.resolve(pathways)),
 };
 
-const defaultAppState = {
-  enterpriseConfig: {
-    slug: TEST_ENTERPRISE_SLUG,
-    uuid: '5d3v5ee2-761b-49b4-8f47-f6f51589d815',
-  },
-};
+const defaultAppState = {};
 
 const defaultSearchContext = {
   refinements: { },
@@ -71,42 +79,32 @@ const defaultSkillsState = {
   },
 };
 
-const defaultCouponCodesState = {
-  couponCodes: [],
-  loading: false,
-  couponCodesCount: 0,
-};
-
-const defaultUserSubsidyState = {
-  couponCodes: defaultCouponCodesState,
-};
-
-const defaultSubsidyRequestState = {
-  catalogsForSubsidyRequests: [],
-};
-
 const SearchPathwaysWithContext = ({
   initialAppState = defaultAppState,
   initialSkillsState = defaultSkillsState,
-  initialUserSubsidyState = defaultUserSubsidyState,
-  initialSubsidyRequestState = defaultSubsidyRequestState,
   initialSearchContext = defaultSearchContext,
   index,
 }) => (
   <IntlProvider locale="en">
     <AppContext.Provider value={initialAppState}>
-      <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-        <SubsidyRequestsContext.Provider value={initialSubsidyRequestState}>
-          <SearchContext.Provider value={initialSearchContext}>
-            <SkillsContext.Provider value={initialSkillsState}>
-              <SearchPathways index={index} />
-            </SkillsContext.Provider>
-          </SearchContext.Provider>
-        </SubsidyRequestsContext.Provider>
-      </UserSubsidyContext.Provider>
+      <SearchContext.Provider value={initialSearchContext}>
+        <SkillsContext.Provider value={initialSkillsState}>
+          <SearchPathways index={index} />
+        </SkillsContext.Provider>
+      </SearchContext.Provider>
     </AppContext.Provider>
   </IntlProvider>
 );
+
+const mockEnterpriseCustomer = {
+  name: 'test-enterprise',
+  slug: TEST_ENTERPRISE_SLUG,
+  uuid: 'test-enterprise-uuid',
+};
+
+useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+
+mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
 
 describe('<SearchPathways />', () => {
   test('renders the correct data', async () => {

--- a/src/components/skills-quiz/tests/SearchPathways.test.jsx
+++ b/src/components/skills-quiz/tests/SearchPathways.test.jsx
@@ -10,7 +10,7 @@ import SearchPathways from '../SearchPathways';
 import { defaultSubsidyHooksData, mockSubsidyHooksReturnValues, renderWithRouter } from '../../../utils/tests';
 import { TEST_ENTERPRISE_SLUG } from '../../search/tests/constants';
 import { SkillsContext } from '../SkillsContextProvider';
-import { useEnterpriseCustomer } from "../../app/data";
+import { useEnterpriseCustomer } from '../../app/data';
 
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),

--- a/src/components/skills-quiz/tests/SearchPathways.test.jsx
+++ b/src/components/skills-quiz/tests/SearchPathways.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
-import { AppContext } from '@edx/frontend-platform/react';
 import '@testing-library/jest-dom/extend-expect';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
@@ -52,8 +51,6 @@ const testIndex = {
   search: jest.fn().mockImplementation(() => Promise.resolve(pathways)),
 };
 
-const defaultAppState = {};
-
 const defaultSearchContext = {
   refinements: { },
   dispatch: () => null,
@@ -80,19 +77,16 @@ const defaultSkillsState = {
 };
 
 const SearchPathwaysWithContext = ({
-  initialAppState = defaultAppState,
   initialSkillsState = defaultSkillsState,
   initialSearchContext = defaultSearchContext,
   index,
 }) => (
   <IntlProvider locale="en">
-    <AppContext.Provider value={initialAppState}>
-      <SearchContext.Provider value={initialSearchContext}>
-        <SkillsContext.Provider value={initialSkillsState}>
-          <SearchPathways index={index} />
-        </SkillsContext.Provider>
-      </SearchContext.Provider>
-    </AppContext.Provider>
+    <SearchContext.Provider value={initialSearchContext}>
+      <SkillsContext.Provider value={initialSkillsState}>
+        <SearchPathways index={index} />
+      </SkillsContext.Provider>
+    </SearchContext.Provider>
   </IntlProvider>
 );
 

--- a/src/components/skills-quiz/tests/SearchProgramCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchProgramCard.test.jsx
@@ -6,17 +6,28 @@ import { AppContext } from '@edx/frontend-platform/react';
 import '@testing-library/jest-dom/extend-expect';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import SearchProgramCard from '../SearchProgramCard';
 
-import { renderWithRouter } from '../../../utils/tests';
+import { defaultSubsidyHooksData, mockSubsidyHooksReturnValues, renderWithRouter } from '../../../utils/tests';
 import { TEST_ENTERPRISE_SLUG } from '../../search/tests/constants';
 import { NO_PROGRAMS_ALERT_MESSAGE } from '../constants';
 import { SkillsContext } from '../SkillsContextProvider';
-import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
+import { useEnterpriseCustomer } from '../../app/data';
 
 const userId = 'batman';
+jest.mock('../../app/data', () => ({
+  ...jest.requireActual('../../app/data'),
+  useEnterpriseCustomer: jest.fn(),
+  useSubscriptions: jest.fn(),
+  useRedeemablePolicies: jest.fn(),
+  useCouponCodes: jest.fn(),
+  useEnterpriseOffers: jest.fn(),
+}));
 
+jest.mock('../../hooks', () => ({
+  ...jest.requireActual('../../hooks'),
+  useCatalogsForSubsidyRequests: jest.fn(),
+}));
 jest.mock('@edx/frontend-enterprise-utils', () => ({
   ...jest.requireActual('@edx/frontend-enterprise-utils'),
   sendEnterpriseTrackEvent: jest.fn(),
@@ -64,10 +75,6 @@ const testIndex = {
 };
 
 const defaultAppState = {
-  enterpriseConfig: {
-    slug: TEST_ENTERPRISE_SLUG,
-    uuid: '5d3v5ee2-761b-49b4-8f47-f6f51589d815',
-  },
   authenticatedUser: {
     username: 'b.wayne',
     userId,
@@ -99,41 +106,32 @@ const defaultSkillsState = {
   },
 };
 
-const defaultCouponCodesState = {
-  couponCodes: [],
-  loading: false,
-  couponCodesCount: 0,
-};
-
-const defaultUserSubsidyState = {
-  couponCodes: defaultCouponCodesState,
-};
-
-const defaultSubsidyRequestState = {
-  catalogsForSubsidyRequests: [],
-};
-
 const SearchProgramCardWithContext = ({
   initialAppState = defaultAppState,
   initialSkillsState = defaultSkillsState,
-  initialUserSubsidyState = defaultUserSubsidyState,
   initialSearchContext = defaultSearchContext,
   index,
 }) => (
   <IntlProvider locale="en">
     <AppContext.Provider value={initialAppState}>
-      <UserSubsidyContext.Provider value={initialUserSubsidyState}>
-        <SubsidyRequestsContext.Provider value={defaultSubsidyRequestState}>
-          <SearchContext.Provider value={initialSearchContext}>
-            <SkillsContext.Provider value={initialSkillsState}>
-              <SearchProgramCard index={index} />
-            </SkillsContext.Provider>
-          </SearchContext.Provider>
-        </SubsidyRequestsContext.Provider>
-      </UserSubsidyContext.Provider>
+      <SearchContext.Provider value={initialSearchContext}>
+        <SkillsContext.Provider value={initialSkillsState}>
+          <SearchProgramCard index={index} />
+        </SkillsContext.Provider>
+      </SearchContext.Provider>
     </AppContext.Provider>
   </IntlProvider>
 );
+
+const mockEnterpriseCustomer = {
+  name: 'test-enterprise',
+  slug: TEST_ENTERPRISE_SLUG,
+  uuid: 'test-enterprise-uuid',
+};
+
+useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+
+mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
 
 describe('<SearchProgramCard />', () => {
   test('renders the correct data', async () => {

--- a/src/components/skills-quiz/tests/SearchProgramCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchProgramCard.test.jsx
@@ -129,11 +129,13 @@ const mockEnterpriseCustomer = {
   uuid: 'test-enterprise-uuid',
 };
 
-useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-
-mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
-
 describe('<SearchProgramCard />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
+  });
+
   test('renders the correct data', async () => {
     const { container } = renderWithRouter(
       <SearchProgramCardWithContext

--- a/src/components/skills-quiz/tests/SelectJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SelectJobCard.test.jsx
@@ -8,6 +8,7 @@ import { SkillsContextProvider } from '../SkillsContextProvider';
 import SelectJobCard from '../SelectJobCard';
 import { NOT_AVAILABLE } from '../constants';
 import { useEnterpriseCustomer } from '../../app/data';
+import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
@@ -48,8 +49,6 @@ const mockEnterpriseCustomer = {
   hideLaborMarketData: false,
 };
 
-useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-
 describe('<SelectJobCard />', () => {
   test('renders job card', () => {
     const initialJobCardState = {
@@ -67,7 +66,7 @@ describe('<SelectJobCard />', () => {
       ],
     };
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    render(
+    renderWithRouter(
       <SelectJobCardWithContext
         initialAppState={initialAppState}
         initialJobCardState={initialJobCardState}
@@ -98,7 +97,7 @@ describe('<SelectJobCard />', () => {
       hideLaborMarketData: true,
     };
     useEnterpriseCustomer.mockReturnValue({ data: hideLaborMarketConfig });
-    render(
+    renderWithRouter(
       <SelectJobCardWithContext
         initialJobCardState={initialJobCardState}
       />,
@@ -135,7 +134,7 @@ describe('<SelectJobCard />', () => {
       ],
     };
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    render(
+    renderWithRouter(
       <SelectJobCardWithContext
         initialJobCardState={initialJobCardState}
       />,
@@ -162,7 +161,7 @@ describe('<SelectJobCard />', () => {
       ],
     };
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    render(
+    renderWithRouter(
       <SelectJobCardWithContext
         initialJobCardState={initialJobCardStateWithOutJobs}
       />,
@@ -188,7 +187,7 @@ describe('<SelectJobCard />', () => {
       ],
     };
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    render(
+    renderWithRouter(
       <SelectJobCardWithContext
         initialJobCardState={initialJobCardStateWithOutSalary}
       />,
@@ -205,7 +204,7 @@ describe('<SelectJobCard />', () => {
       interestedJobs: [],
     };
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    render(
+    renderWithRouter(
       <SelectJobCardWithContext
         initialJobCardState={initialJobCardState}
       />,

--- a/src/components/skills-quiz/tests/SelectJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SelectJobCard.test.jsx
@@ -7,10 +7,21 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { SkillsContextProvider } from '../SkillsContextProvider';
 import SelectJobCard from '../SelectJobCard';
 import { NOT_AVAILABLE } from '../constants';
+import { useEnterpriseCustomer } from '../../app/data';
+
+jest.mock('../../app/data', () => ({
+  ...jest.requireActual('../../app/data'),
+  useEnterpriseCustomer: jest.fn(),
+}));
+
+const initialAppState = {
+  config: {
+    LMS_BASE_URL: process.env.LMS_BASE_URL,
+  },
+};
 
 const SelectJobCardWithContext = ({
   initialJobCardState = {},
-  initialAppState,
 }) => (
   <IntlProvider locale="en">
     <AppContext.Provider value={initialAppState}>
@@ -32,15 +43,12 @@ const TRANSFORMED_MEDIAN_SALARY_2 = '$250,000';
 const MEDIAN_SALARY = 'Median U.S. Salary:';
 const JOB_POSTINGS = 'Job Postings:';
 
-const initialAppState = {
-  enterpriseConfig: {
-    name: 'BearsRUs',
-    hideLaborMarketData: false,
-  },
-  config: {
-    LMS_BASE_URL: process.env.LMS_BASE_URL,
-  },
+const mockEnterpriseCustomer = {
+  name: 'BearsRUs',
+  hideLaborMarketData: false,
 };
+
+useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
 
 describe('<SelectJobCard />', () => {
   test('renders job card', () => {
@@ -58,6 +66,7 @@ describe('<SelectJobCard />', () => {
       },
       ],
     };
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     render(
       <SelectJobCardWithContext
         initialAppState={initialAppState}
@@ -84,15 +93,13 @@ describe('<SelectJobCard />', () => {
       },
       ],
     };
-    const appState = {
-      enterpriseConfig: {
-        name: 'BearsRUs',
-        hideLaborMarketData: true,
-      },
+    const hideLaborMarketConfig = {
+      ...mockEnterpriseCustomer,
+      hideLaborMarketData: true,
     };
+    useEnterpriseCustomer.mockReturnValue({ data: hideLaborMarketConfig });
     render(
       <SelectJobCardWithContext
-        initialAppState={appState}
         initialJobCardState={initialJobCardState}
       />,
     );
@@ -127,9 +134,9 @@ describe('<SelectJobCard />', () => {
       },
       ],
     };
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     render(
       <SelectJobCardWithContext
-        initialAppState={initialAppState}
         initialJobCardState={initialJobCardState}
       />,
     );
@@ -154,9 +161,9 @@ describe('<SelectJobCard />', () => {
       },
       ],
     };
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     render(
       <SelectJobCardWithContext
-        initialAppState={initialAppState}
         initialJobCardState={initialJobCardStateWithOutJobs}
       />,
     );
@@ -180,9 +187,9 @@ describe('<SelectJobCard />', () => {
       },
       ],
     };
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     render(
       <SelectJobCardWithContext
-        initialAppState={initialAppState}
         initialJobCardState={initialJobCardStateWithOutSalary}
       />,
     );
@@ -197,9 +204,9 @@ describe('<SelectJobCard />', () => {
     const initialJobCardState = {
       interestedJobs: [],
     };
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     render(
       <SelectJobCardWithContext
-        initialAppState={initialAppState}
         initialJobCardState={initialJobCardState}
       />,
     );

--- a/src/components/skills-quiz/tests/SelectJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SelectJobCard.test.jsx
@@ -26,7 +26,7 @@ const SelectJobCardWithContext = ({
 }) => (
   <IntlProvider locale="en">
     <AppContext.Provider value={initialAppState}>
-      <SearchContext.Provider>
+      <SearchContext.Provider value={{}}>
         <SkillsContextProvider initialState={initialJobCardState}>
           <SelectJobCard />
         </SkillsContextProvider>
@@ -50,6 +50,11 @@ const mockEnterpriseCustomer = {
 };
 
 describe('<SelectJobCard />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+  });
+
   test('renders job card', () => {
     const initialJobCardState = {
       interestedJobs: [{
@@ -65,7 +70,6 @@ describe('<SelectJobCard />', () => {
       },
       ],
     };
-    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     renderWithRouter(
       <SelectJobCardWithContext
         initialAppState={initialAppState}
@@ -133,7 +137,6 @@ describe('<SelectJobCard />', () => {
       },
       ],
     };
-    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     renderWithRouter(
       <SelectJobCardWithContext
         initialJobCardState={initialJobCardState}
@@ -160,7 +163,6 @@ describe('<SelectJobCard />', () => {
       },
       ],
     };
-    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     renderWithRouter(
       <SelectJobCardWithContext
         initialJobCardState={initialJobCardStateWithOutJobs}
@@ -186,7 +188,6 @@ describe('<SelectJobCard />', () => {
       },
       ],
     };
-    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     renderWithRouter(
       <SelectJobCardWithContext
         initialJobCardState={initialJobCardStateWithOutSalary}
@@ -203,7 +204,6 @@ describe('<SelectJobCard />', () => {
     const initialJobCardState = {
       interestedJobs: [],
     };
-    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     renderWithRouter(
       <SelectJobCardWithContext
         initialJobCardState={initialJobCardState}

--- a/src/components/skills-quiz/tests/SelectJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SelectJobCard.test.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
-import { screen, render } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 import { SkillsContextProvider } from '../SkillsContextProvider';
 import SelectJobCard from '../SelectJobCard';
 import { NOT_AVAILABLE } from '../constants';
 import { useEnterpriseCustomer } from '../../app/data';
-import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),

--- a/src/components/skills-quiz/tests/SkillsCourses.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsCourses.test.jsx
@@ -109,9 +109,13 @@ const mockEnterpriseCustomer = {
   slug: 'test-enterprise-slug',
   uuid: 'test-enterprise-uuid',
 };
-useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
 
 describe('<SkillsCourses />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+  });
+
   test('renders the correct data', async () => {
     const { container } = renderWithRouter(
       <SkillsCoursesWithContext

--- a/src/components/skills-quiz/tests/SkillsCourses.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsCourses.test.jsx
@@ -6,17 +6,13 @@ import { AppContext } from '@edx/frontend-platform/react';
 import '@testing-library/jest-dom/extend-expect';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { QueryClientProvider } from '@tanstack/react-query';
-import { UserSubsidyContext } from '../../enterprise-user-subsidy';
 import SkillsCourses from '../SkillsCourses';
 
-import { queryClient, renderWithRouter } from '../../../utils/tests';
+import { renderWithRouter } from '../../../utils/tests';
 import { TEST_IMAGE_URL, TEST_ENTERPRISE_SLUG } from '../../search/tests/constants';
 import { NO_COURSES_ALERT_MESSAGE_AGAINST_SKILLS } from '../constants';
 import { SkillsContext } from '../SkillsContextProvider';
-import { SubsidyRequestsContext } from '../../enterprise-subsidy-requests';
-import { useEnterpriseCustomer } from "../../app/data";
-import { useDefaultSearchFilters } from "../../search";
+import { useEnterpriseCustomer } from '../../app/data';
 
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
@@ -97,22 +93,23 @@ const SkillsCoursesWithContext = ({
   searchContext = defaultSearchContext,
   index,
 }) => (
-    <IntlProvider locale="en">
-      <AppContext.Provider value={initialAppState}>
-            <SearchContext.Provider value={searchContext}>
-              <SkillsContext.Provider value={initialSkillsState}>
-                <SkillsCourses index={index} />
-              </SkillsContext.Provider>
-            </SearchContext.Provider>
-      </AppContext.Provider>
-    </IntlProvider>
+  <IntlProvider locale="en">
+
+    <AppContext.Provider value={initialAppState}>
+      <SearchContext.Provider value={searchContext}>
+        <SkillsContext.Provider value={initialSkillsState}>
+          <SkillsCourses index={index} />
+        </SkillsContext.Provider>
+      </SearchContext.Provider>
+    </AppContext.Provider>
+  </IntlProvider>
 );
 
 const mockEnterpriseCustomer = {
   slug: 'test-enterprise-slug',
   uuid: 'test-enterprise-uuid',
 };
-useEnterpriseCustomer.mockReturnValue({data: mockEnterpriseCustomer})
+useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
 
 describe('<SkillsCourses />', () => {
   test('renders the correct data', async () => {

--- a/src/components/skills-quiz/tests/SkillsQuiz.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsQuiz.test.jsx
@@ -61,11 +61,15 @@ const defaultAppState = {
 const SkillsQuizWithContext = ({
   initialAppState = defaultAppState,
 }) => (
-  <IntlProvider locale="en">
-    <AppContext.Provider value={initialAppState}>
-      <SkillsQuiz />
-    </AppContext.Provider>
-  </IntlProvider>
+  <SearchData>
+    <SkillsContextProvider>
+      <IntlProvider locale="en">
+        <AppContext.Provider value={initialAppState}>
+          <SkillsQuiz />
+        </AppContext.Provider>
+      </IntlProvider>
+    </SkillsContextProvider>
+  </SearchData>
 );
 
 mockSubsidyHooksReturnValues(defaultSubsidyHooksData);
@@ -84,11 +88,7 @@ describe('<SkillsQuiz />', () => {
 
   it('renders skills quiz V1 page successfully.', () => {
     renderWithRouter(
-      <SearchData>
-        <SkillsContextProvider>
-          <SkillsQuizWithContext />
-        </SkillsContextProvider>
-      </SearchData>,
+      <SkillsQuizWithContext />,
       { route: '/test/skills-quiz/' },
     );
     expect(screen.getByText(SKILLS_QUIZ_SEARCH_PAGE_MESSAGE)).toBeTruthy();
@@ -98,11 +98,7 @@ describe('<SkillsQuiz />', () => {
     hasFeatureFlagEnabled.mockReturnValue(true);
 
     renderWithRouter(
-      <SearchData>
-        <SkillsContextProvider>
-          <SkillsQuizWithContext />
-        </SkillsContextProvider>
-      </SearchData>,
+      <SkillsQuizWithContext />,
       { route: '/test/skills-quiz/' },
     );
     expect(screen.getByText('What roles are you interested in ?')).toBeInTheDocument();

--- a/src/components/skills-quiz/tests/SkillsQuizStepper.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsQuizStepper.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { SearchContext, SearchData } from '@edx/frontend-enterprise-catalog-search';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
@@ -89,11 +89,10 @@ const mockEnterpriseCustomer = {
   slug: 'BearsRYou',
 };
 
-useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-
 describe('<SkillsQuizStepper />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
   });
 
   it('checks header is correctly rendered', () => {

--- a/src/utils/tests.jsx
+++ b/src/utils/tests.jsx
@@ -6,6 +6,13 @@ import dayjs from 'dayjs';
 import { render } from '@testing-library/react';
 import { QueryCache, QueryClient } from '@tanstack/react-query';
 import { queryCacheOnErrorHandler } from './common';
+import {
+  useCouponCodes,
+  useEnterpriseOffers,
+  useRedeemablePolicies,
+  useSubscriptions,
+} from '../components/app/data';
+import { useCatalogsForSubsidyRequests } from '../components/hooks';
 
 /**
  * TODO
@@ -121,3 +128,24 @@ export function queryClient(options = {}) {
     },
   });
 }
+
+export const defaultSubsidyHooksData = {
+  mockRedeemablePolicies: [],
+  mockCatalogsForSubsidyRequest: [],
+  mockCurrentEnterpriseOffers: [],
+  mockSubscriptionLicense: null,
+  mockCouponCodeAssignments: [],
+};
+export const mockSubsidyHooksReturnValues = ({
+  mockRedeemablePolicies = [],
+  mockCatalogsForSubsidyRequest = [],
+  mockCurrentEnterpriseOffers = [],
+  mockSubscriptionLicense = null,
+  mockCouponCodeAssignments = [],
+}) => {
+  useRedeemablePolicies.mockReturnValue({ data: { redeemablePolicies: mockRedeemablePolicies } });
+  useCatalogsForSubsidyRequests.mockReturnValue({ catalogsForSubsidyRequests: mockCatalogsForSubsidyRequest });
+  useEnterpriseOffers.mockReturnValue({ data: { currentEnterpriseOffers: mockCurrentEnterpriseOffers } });
+  useSubscriptions.mockReturnValue({ data: { subscriptionLicense: mockSubscriptionLicense } });
+  useCouponCodes.mockReturnValue({ data: { couponCodeAssignments: mockCouponCodeAssignments } });
+};


### PR DESCRIPTION
Reintegrates the skills quiz page to the router.
Update tests to use `useQuery` as the source of data and remove context references within the tests.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
