### PR TITLE
feat: add footer SCSS import and use tilde for module resolution

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,10 +1,11 @@
-@import "@edx/brand/paragon/fonts";
-@import "@edx/brand/paragon/variables";
-@import "@openedx/paragon/scss/core/core";
+@import "~@edx/brand/paragon/fonts";
+@import "~@edx/brand/paragon/variables";
+@import "~@openedx/paragon/scss/core/core";
 // frontend-enterprise-* imports must come before the paragon overrides for correct styling
 @import "~@edx/frontend-enterprise-catalog-search";
-@import "@edx/brand/paragon/overrides";
+@import "~@edx/brand/paragon/overrides";
 
+@import "~@edx/frontend-component-footer/dist/footer";
 
 @import "./components/layout/styles/Layout";
 @import "./components/course/styles/CourseHeader";


### PR DESCRIPTION
The webpack's tilde syntax resolves SCSS imports from node_modules to make the development easier.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [x] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [x] <s>Ensure to attach screenshots</s>
- [x] <s>Ensure to have UX team confirm screenshots</s>
