### PR TITLE
fix: disables courses dropdown item not associated with catalog for programs

### DIFF
--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -314,7 +314,7 @@ describe('<Dashboard />', () => {
   });
 
   it('renders programs tab', async () => {
-    useEnterpriseProgramsList.mockReturnValue({ data: camelCaseObject(dummyProgramData) });
+    useEnterpriseProgramsList.mockReturnValue({ data: [camelCaseObject(dummyProgramData)] });
     renderWithRouter(
       <DashboardWithContext />,
     );

--- a/src/components/program-progress/ProgramListingCard.jsx
+++ b/src/components/program-progress/ProgramListingCard.jsx
@@ -54,6 +54,7 @@ const ProgramListingCard = ({ program }) => {
       isClickable
       as={Link}
       to={`/${enterpriseCustomer.slug}/program/${program.uuid}/progress`}
+      data-testid="program-listing-card"
     >
       <Card.ImageCap
         src={getBannerImageURL() || cardFallbackImg}

--- a/src/components/program-progress/tests/ProgramListingPage.test.jsx
+++ b/src/components/program-progress/tests/ProgramListingPage.test.jsx
@@ -74,7 +74,7 @@ describe('<ProgramListing />', () => {
     jest.clearAllMocks();
     useCanOnlyViewHighlights.mockReturnValue({ data: false });
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    useEnterpriseProgramsList.mockReturnValue({ data: [], error: null });
+    useEnterpriseProgramsList.mockReturnValue({ data: [] });
   });
 
   it('renders all program cards', async () => {
@@ -91,46 +91,16 @@ describe('<ProgramListing />', () => {
     });
   });
 
-  it('renders program error.', async () => {
-    useEnterpriseProgramsList.mockReturnValue({
-      data: [],
-      error: { message: 'This is a test message.' },
-    });
-    renderWithRouter(
-      <ProgramListingWithContext />,
-    );
-    await waitFor(() => {
-      expect(screen.getByTestId('error-page')).toBeInTheDocument();
-    });
-  });
-
-  it('renders no programs message when data received is empty', async () => {
-    renderWithRouter(
-      <ProgramListingWithContext />,
-    );
-    await waitFor(() => {
-      expect(screen.getByText('You are not enrolled in any programs yet.')).toBeInTheDocument();
-      expect(screen.getByText('Explore programs')).toBeInTheDocument();
-    });
-  });
-
   it('redirects to correct url when clicked on explore programs', async () => {
-    renderWithRouter(
-      <ProgramListingWithContext />,
-    );
-    await waitFor(() => {
-      expect(screen.getByText('Explore programs')).toBeInTheDocument();
-    });
-    userEvent.click(screen.getByText('Explore programs'));
-    expect(window.location.pathname).toEqual(`/${mockEnterpriseCustomer.slug}/search`);
-    expect(window.location.search).toEqual(`?content_type=${CONTENT_TYPE_PROGRAM}`);
-  });
+    useEnterpriseProgramsList.mockReturnValue({ data: [dummyProgramData] });
 
-  it('does not render button when canOnlyViewHighlightSets is true', () => {
-    useCanOnlyViewHighlights.mockReturnValue({ data: true });
     renderWithRouter(
       <ProgramListingWithContext />,
     );
-    expect(screen.queryByText('Explore programs')).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByTestId('program-listing-card'));
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual(`/${mockEnterpriseCustomer.slug}/program/test-uuid/progress`);
+    });
   });
 });

--- a/src/components/program/ProgramCTA.jsx
+++ b/src/components/program/ProgramCTA.jsx
@@ -184,7 +184,7 @@ const ProgramCTA = () => {
                   {course.title}
                 </Dropdown.Item>
               ) : (
-                <Dropdown.Item key={course.title} className="wrap-word">{course.title}</Dropdown.Item>
+                <Dropdown.Item key={course.title} className="wrap-word" disabled>{course.title}</Dropdown.Item>
               )
             ))}
           </Dropdown.Menu>


### PR DESCRIPTION
Previously, if a course was not associated with a catalog but appeared in a program, in the `Enrolling Now` dropdown, the course was clickable but did not redirect anywhere (non interactive button).
We now disable the clickability of the dropdown item by disabling them. This disabled dropdown items only correspond to courses not in the customer catalog. 

Before:
<img width="1270" alt="Screenshot 2024-04-05 at 8 38 02 AM" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/82611798/32727399-e35a-4aa2-9cfa-5e751677fc37">

Updated:
![Screenshot 2024-04-04 at 6 28 20 PM](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/82611798/b264c576-a3e9-4890-b1dc-7bbdb11d9c67)

The disabled buttons now appeared greyed out and non clickable. 
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
