### PR TITLE
fix: resolve "View course" CTA link location on course page

### DIFF
--- a/src/components/course/CourseMaterialsButton.jsx
+++ b/src/components/course/CourseMaterialsButton.jsx
@@ -30,7 +30,7 @@ const CourseMaterialsButton = ({ className }) => {
       className={className}
       variant="brand"
       as={Hyperlink}
-      destination={userEnrollment.resumeCourseRunUrl || userEnrollment.linkToCourse}
+      destination={userEnrollment.linkToCourse}
       target="_blank"
     >
       {intl.formatMessage({

--- a/src/components/course/course-header/CourseRunCard.jsx
+++ b/src/components/course/course-header/CourseRunCard.jsx
@@ -31,7 +31,7 @@ const CourseRunCard = ({ courseRun }) => {
     course: courseMetadata,
     courseRun,
     userEnrollment: userEnrollmentForCourseRun,
-    courseRunUrl: userEnrollmentForCourseRun.linkToCourse,
+    courseRunUrl: userEnrollmentForCourseRun?.linkToCourse,
     userCanRequestSubsidyForCourse,
     subsidyAccessPolicy: userSubsidyApplicableToCourse,
   });

--- a/src/components/course/course-header/CourseRunCard.jsx
+++ b/src/components/course/course-header/CourseRunCard.jsx
@@ -31,7 +31,7 @@ const CourseRunCard = ({ courseRun }) => {
     course: courseMetadata,
     courseRun,
     userEnrollment: userEnrollmentForCourseRun,
-    courseRunUrl: userEnrollmentForCourseRun?.resumeCourseRunUrl || userEnrollmentForCourseRun?.linkToCourse,
+    courseRunUrl: userEnrollmentForCourseRun.linkToCourse,
     userCanRequestSubsidyForCourse,
     subsidyAccessPolicy: userSubsidyApplicableToCourse,
   });

--- a/src/components/course/enrollment/components/ToCoursewarePage.jsx
+++ b/src/components/course/enrollment/components/ToCoursewarePage.jsx
@@ -17,7 +17,7 @@ const ToCoursewarePage = ({
     subscriptionLicense,
     enrollmentUrl,
   });
-  const landingUrl = shouldUseEnrollmentUrl ? enrollmentUrl : userEnrollment.courseRunUrl;
+  const landingUrl = shouldUseEnrollmentUrl ? enrollmentUrl : userEnrollment.linkToCourse;
   const handleClick = useTrackSearchConversionClickHandler({
     href: landingUrl,
     eventName: 'edx.ui.enterprise.learner_portal.course.enroll_button.to_courseware.clicked',


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8730

Resolves the "View course" CTA not being a link to courseware: 

<img width="1169" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/f3fb0f86-bf7c-4c6b-900a-8dc92326925c">

Note: At the moment, CI is expected to fail.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
