### PR TITLE
fix: enable keepPreviousData for all queries by default

### DIFF
--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -34,6 +34,14 @@ const queryClient = new QueryClient({
       // per-query, as needed, if certain queries expect to be more up-to-date than others. Allows
       // `useQuery` to be used as a state manager.
       staleTime: 1000 * 20,
+      // To prevent hard loading states if/when query keys change during automatic query background
+      // re-fetches, we can set `keepPreviousData` to `true` to keep the previous data until the new
+      // data is fetched. By enabling this option, UI components generally will not need to consider
+      // explicit loading states when query keys change. Note: `keepPreviousData` is deprecated, replaced
+      // by `placeholderData` in `@tanstack/react-query` v5 (i.e., for when React is upgraded to v18). See
+      // https://tanstack.com/query/latest/docs/framework/vue/guides/migrating-to-v5#removed-keeppreviousdata-in-favor-of-placeholderdata-identity-function
+      // for more details.
+      keepPreviousData: true,
     },
   },
 });


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8739

When a rendered `useQuery`'s query key changes (e.g., due to a dependent query's automatic background re-fetch returning updated data used as input to another query's `queryKey`), a hard loading state is triggered since the query is new and no existing data is present in the query cache.

In the new routing/data paradigm, UI components generally should assume API data is already resolved (i.e., loading states should generally not need to be considered within UI components). However, if a rendered query observer's `queryKey` changes due to a background re-fetch of a dependent query, this assumption results in trying to access properties on `data`, which changed to `undefined` due to an updated `queryKey`, throwing JS errors in a handful of queries.

Example from the above ticket's comments:

> I got the same error when I assigned content to a learner, tabbed back to the learner's view of the course about page to confirm the price strikeout changed, but instead got the `Q.Xd().data is undefined` error.

By enabling the `keepPreviousData: true` option in the `QueryClient`, we change the behavior of all `useQuery` hooks to rely on the previous `queryKey`'s data while the new data is loaded in the background (i.e., `keepPreviousData: true` triggers a background re-fetch instead of a hard loading state change). From the `@tanstack/react-query` [docs](https://tanstack.com/query/v4/docs/framework/react/reference/useQuery) regarding `keepPreviousData`:

> If set, any previous data will be kept when fetching new data because the query key changed.

In the above use case previously triggering the error, assigning content to a learner and then tabbing back to the learner's view of the course about page will result in the `queryKey` changing for the `queryCourseRecommendations` query as the `searchCatalogs` array input has changed to include the enterprise catalog uuid associated with the assignment's budget, previously triggering a hard loading state. Now, with `keepPreviousData: true`, the previous query's data continues to return while the new data loads in the background for the updated `queryKey`.

The primary tradeoff with enabling `keepPreviousData` by default for all queries is that our `useQuery` usages (assuming the query is pre-seeded in a route loader) will never trigger a hard loading state. In the majority of cases, this is the intent for the re-architecture (i.e., improve the developer experience by not having to consider hard loading states). In rare cases, some specific `useQuery` hooks may want to trigger hard loading states. The default `keepPreviousData` query option may be overridden by any individual `useQuery` hooks, as needed.

Even though `keepPreviousData` is technically deprecated, it's behavior has a one-to-one replacement in the next version of the `@tanstack/react-query` for when this MFE upgrades to React 18 (see https://tanstack.com/query/latest/docs/framework/vue/guides/migrating-to-v5#removed-keeppreviousdata-in-favor-of-placeholderdata-identity-function for more details).

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
