### PR TITLE
fix: null enterprise customer bug in AvatarDropdown

### DIFF
--- a/src/components/site-header/AvatarDropdown.jsx
+++ b/src/components/site-header/AvatarDropdown.jsx
@@ -63,7 +63,11 @@ const AvatarDropdown = ({ showLabel }) => {
           })}
         </Dropdown.Item>
         {allLinkedEnterpriseCustomerUsers
-          .sort((a, b) => a.enterpriseCustomer.name.localeCompare(b.enterpriseCustomer.name))
+          .sort((a, b) => {
+            const nameA = a.enterpriseCustomer?.name || ''; // Fallback to empty string if enterpriseCustomer or its name is undefined
+            const nameB = b.enterpriseCustomer?.name || ''; // Fallback to empty string if enterpriseCustomer or its name is undefined
+            return nameA.localeCompare(nameB);
+          })
           .map((enterpriseCustomerUser) => (
             <Dropdown.Item
               key={enterpriseCustomerUser.enterpriseCustomer.slug}


### PR DESCRIPTION
Error triggered when linked to customers that do not have the Learner Portal enabled. Potentially impacting more staff than myself.

<img width="1910" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/9ccbda1f-df5d-4f47-a46b-d48e4e1400fd">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
