### PR TITLE
chore: update late enrollment buffer days to 30

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -20,4 +20,4 @@ export const SUBSCRIPTION_EXPIRED = 0;
 export const SEEN_SUBSCRIPTION_EXPIRATION_MODAL_COOKIE_PREFIX = 'seen-expiration-modal-';
 
 // [ENT-8519] Late enrollments feature
-export const LATE_ENROLLMENTS_BUFFER_DAYS = 60;
+export const LATE_ENROLLMENTS_BUFFER_DAYS = 30;


### PR DESCRIPTION
This keeps the learner portal in sync with the corresponding buffer days behind the GEAG endpoint. If they didn't match, certain course runs would be visible but not enrollable.