### PR TITLE
fix: cannot read property 'catalogContentProgram' of null fix

### DIFF
--- a/src/components/program/ProgramPage.jsx
+++ b/src/components/program/ProgramPage.jsx
@@ -21,7 +21,7 @@ const ProgramPage = () => {
   const { data: program } = useProgramDetails();
 
   // if there is not even single course that does not belongs to the enterprise customer's catalog
-  if (!program.catalogContainsProgram) {
+  if (!program?.catalogContainsProgram) {
     return (
       <NotFoundPage
         pageTitle={PROGRAM_NOT_FOUND_TITLE}


### PR DESCRIPTION
During QA of the performance implementation, a [New Relic error](https://onenr.io/0VRV3lXevja) directed us to an instance where the `useProgramDetails` hook would return null, but an object was still being referenced even if the object was undefined. This PR aims to put an additional check on the program details object to return a `NotFoundError` component.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
