### PR TITLE
feat: enable suspense for React Query and wrap RouterProvider with Suspense

### DIFF
--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -48,9 +48,7 @@ const Root = () => {
     <>
       <ToastsProvider>
         <Toasts />
-        <Suspense fallback={<DelayedFallbackContainer />}>
-          <Outlet />
-        </Suspense>
+        <Outlet />
       </ToastsProvider>
       <ScrollRestoration />
     </>

--- a/src/components/app/Root.jsx
+++ b/src/components/app/Root.jsx
@@ -1,13 +1,12 @@
 import {
   Outlet, ScrollRestoration, useParams, Link,
 } from 'react-router-dom';
-import { Suspense, useContext } from 'react';
+import { useContext } from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform';
 import { getLoginRedirectUrl } from '@edx/frontend-platform/auth';
 import { Hyperlink } from '@openedx/paragon';
 
-import DelayedFallbackContainer from '../DelayedFallback/DelayedFallbackContainer';
 import { Toasts, ToastsProvider } from '../Toasts';
 import { ErrorPage } from '../error-page';
 import { useNProgressLoader } from './data';

--- a/src/components/app/routes/AppSuspenseFallback.jsx
+++ b/src/components/app/routes/AppSuspenseFallback.jsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import nprogress from 'accessible-nprogress';
+
+import { NPROGRESS_DELAY_MS } from '../data/hooks/useNProgressLoader';
+
+export function useNProgressLoaderWithoutRouter() {
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      nprogress.start();
+    }, NPROGRESS_DELAY_MS);
+    return () => {
+      clearTimeout(timeoutId);
+      nprogress.done();
+    };
+  }, []);
+}
+
+const AppSuspenseFallback = () => {
+  useNProgressLoaderWithoutRouter();
+  return null;
+};
+
+export default AppSuspenseFallback;

--- a/src/components/app/routes/index.js
+++ b/src/components/app/routes/index.js
@@ -1,4 +1,5 @@
 export { default as RouterFallback } from './RouterFallback';
+export { default as AppSuspenseFallback } from './AppSuspenseFallback';
 export { default as RouteErrorBoundary } from './RouteErrorBoundary';
 export { default as createAppRouter } from './createAppRouter';
 


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8604

To simulate React Query's garbage collection after the default 5 minutes for inactive queries, you can use the React Query Devtools to "reset" a query (simulates garbage collection). Previously, resetting a query would trigger JS errors as its consuming UI components/hooks assume the data exists when it no longer does due to React Query's garbage collection.

With `suspense: true` and a wrapping `Suspense` with a fallback integrated with the NProgress global progress loader bar, we can now catch these garbage collected queries to "suspend" with the global loading state while the garbage collected queries are re-fetched.

https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/667d4c5a-4198-482f-aeed-00846a52ba42


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
