### PR TITLE
fix: extend default garbage collection time (`cacheTime`) to 30 minutes

### DIFF
--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -30,20 +30,19 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: defaultQueryClientRetryHandler,
-      // Suspense mode on queries enables loading/error states to be caught and handled by a surrounding
-      // `Suspense` component from React, with a fallback UI component to display while the query is resolving.
-      // Generally, queries should be resolved within a route loader so it's "guaranteed" to exist within the UI
-      // components. However, `@tanstack/react-query` removes queries from the query cache when they are inactive
-      // (i.e., not rendered) for more than the default `cacheTime` (garbage collection time). To prevent this, by
-      // suspense, we can trigger a loading state with a `Suspense` fallback component while queries that were garbage
-      // collected are re-fetched again, instead of throwing a JS error.
-      suspense: true,
       // Specifying a longer `staleTime` of 20 seconds means queries will not refetch their data
       // as often; mitigates making duplicate queries when within the `staleTime` window, instead
       // relying on the cached data until the `staleTime` window has exceeded. This may be modified
       // per-query, as needed, if certain queries expect to be more up-to-date than others. Allows
       // `useQuery` to be used as a state manager.
-      staleTime: 1000 * 20,
+      staleTime: 1000 * 20, // 20 seconds
+      // By extending `cacheTime`from the default of 5 minutes, we can prevent inactive queries from being garbage
+      // collected for a longer duration of time. Inactive queries are those that have no rendered query observers
+      // (e.g., `useQuery` hooks). Since most UI component assumes data will be available and returned by queries
+      // without having to consider hard loading states, extending the `cacheTime` can help prevent JS errors around
+      // accessing properties on `undefined` data (due to it being in a hard loading state, `isLoading: true`) by
+      // delaying when `@tanstack/react-query` garbage collects inactive queries.
+      cacheTime: 1000 * 60 * 30, // 30 minutes
       // To prevent hard loading states if/when query keys change during automatic query background
       // re-fetches, we can set `keepPreviousData` to `true` to keep the previous data until the new
       // data is fetched. By enabling this option, UI components generally will not need to consider
@@ -52,6 +51,14 @@ const queryClient = new QueryClient({
       // https://tanstack.com/query/latest/docs/framework/vue/guides/migrating-to-v5#removed-keeppreviousdata-in-favor-of-placeholderdata-identity-function
       // for more details.
       keepPreviousData: true,
+      // Suspense mode on queries enables loading/error states to be caught and handled by a surrounding
+      // `Suspense` component from React, with a fallback UI component to display while the query is resolving.
+      // Generally, queries should be resolved within a route loader so it's "guaranteed" to exist within the UI
+      // components. However, in some cases (e.g., if a query is reset), we attempt to access object properties
+      // on `undefined` data (i.e., `isLoading: true`) resulting in JS errors. To prevent this error from throwing,
+      // by enabling suspenseful queries, we can trigger a loading state via a `Suspense` fallback component while
+      // queries that were removed/reset/garbage collected are re-fetched.
+      suspense: true,
     },
   },
 });

--- a/src/components/enterprise-banner/EnterpriseBanner.jsx
+++ b/src/components/enterprise-banner/EnterpriseBanner.jsx
@@ -7,10 +7,10 @@ import {
 import { Link, generatePath } from 'react-router-dom';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
-import { useEnterpriseLearner, useRecommendCoursesForMe } from '../app/data';
+import { useEnterpriseCustomer, useRecommendCoursesForMe } from '../app/data';
 
 const EnterpriseBanner = () => {
-  const { data: { enterpriseCustomer } } = useEnterpriseLearner();
+  const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { shouldRecommendCourses } = useRecommendCoursesForMe();
 
   return (

--- a/src/components/enterprise-banner/tests/EnterpriseBanner.test.jsx
+++ b/src/components/enterprise-banner/tests/EnterpriseBanner.test.jsx
@@ -7,38 +7,22 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import EnterpriseBanner from '../EnterpriseBanner';
 import {
-  useEnterpriseLearner,
+  useEnterpriseCustomer,
   useRecommendCoursesForMe,
 } from '../../app/data';
+import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
 
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
-  useEnterpriseLearner: jest.fn(),
+  useEnterpriseCustomer: jest.fn(),
   useRecommendCoursesForMe: jest.fn(),
 }));
-useEnterpriseLearner.mockReturnValue({
-  data: {
-    enterpriseCustomer: {
-      name: 'Test Enterprise',
-      slug: 'test-enterprise-slug',
-    },
-  },
-});
-useRecommendCoursesForMe.mockReturnValue({
-  shouldRecommendCourses: false,
-});
 
-const mockEnterpriseSlug = 'test-enterprise-slug';
+const mockAuthenticatedUser = authenticatedUserFactory();
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
 
 const defaultAppContextValue = {
-  authenticatedUser: {
-    username: 'edx',
-    userId: 3,
-  },
-  enterpriseConfig: {
-    slug: mockEnterpriseSlug,
-    uuid: 'uuid',
-  },
+  authenticatedUser: mockAuthenticatedUser,
 };
 
 const EnterpriseBannerWrapper = ({
@@ -52,6 +36,21 @@ const EnterpriseBannerWrapper = ({
 );
 
 describe('<EnterpriseBanner />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({
+      data: mockEnterpriseCustomer,
+    });
+    useRecommendCoursesForMe.mockReturnValue({
+      shouldRecommendCourses: false,
+    });
+  });
+
+  it('renders the enterprise customer name', () => {
+    renderWithRouter(<EnterpriseBannerWrapper />);
+    expect(screen.getByText(mockEnterpriseCustomer.name)).toBeInTheDocument();
+  });
+
   it('does not render recommend courses for me by default', () => {
     renderWithRouter(<EnterpriseBannerWrapper />);
     expect(screen.queryByText('Recommend courses for me')).not.toBeInTheDocument();
@@ -64,6 +63,6 @@ describe('<EnterpriseBanner />', () => {
     renderWithRouter(<EnterpriseBannerWrapper />);
     const recommendCoursesCTA = screen.getByText('Recommend courses for me', { selector: 'a' });
     expect(recommendCoursesCTA).toBeInTheDocument();
-    expect(recommendCoursesCTA).toHaveAttribute('href', `/${mockEnterpriseSlug}/skills-quiz`);
+    expect(recommendCoursesCTA).toHaveAttribute('href', `/${mockEnterpriseCustomer.slug}/skills-quiz`);
   });
 });


### PR DESCRIPTION
# Description

* Extends default garbage collection time from 5 minutes to 30 minutes. 30 minutes is roughly the 75th percentile of session duration for the last 5000 sessions in the Learner Portal.
* Replaces `useEnterpriseLearner` with `useEnterpriseCustomer`.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
