### PR TITLE
feat: gracefully handle ChunkLoadError and stop logging it as an error

### DIFF
--- a/src/components/app/routes/RouteErrorBoundary.jsx
+++ b/src/components/app/routes/RouteErrorBoundary.jsx
@@ -60,23 +60,23 @@ const RouteErrorBoundary = ({
     if (!routeError) {
       return;
     }
+    // eslint-disable-next-line no-console
+    console.error('[RouteErrorBoundary] routeError:', routeError);
     if (routeError.name === 'ChunkLoadError') {
       logInfo(routeError);
       openAppUpdateAvailableModal();
       return;
     }
     logError(routeError);
-    // eslint-disable-next-line no-console
-    console.error('[RouteErrorBoundary] routeError:', routeError);
   }, [routeError, openAppUpdateAvailableModal]);
 
   useEffect(() => {
     if (!asyncError) {
       return;
     }
-    logError(asyncError);
     // eslint-disable-next-line no-console
     console.error('[RouteErrorBoundary] asyncError:', asyncError);
+    logError(asyncError);
   }, [asyncError]);
 
   const error = routeError || asyncError;

--- a/src/components/app/routes/RouteErrorBoundary.test.jsx
+++ b/src/components/app/routes/RouteErrorBoundary.test.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { useAsyncError, useRouteError } from 'react-router-dom';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+import { renderWithRouterProvider } from '../../../utils/tests';
+import RouteErrorBoundary from './RouteErrorBoundary';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useRouteError: jest.fn(),
+  useAsyncError: jest.fn(),
+}));
+
+const RouteErrorBoundaryWrapper = () => (
+  <IntlProvider locale="en">
+    <RouteErrorBoundary />
+  </IntlProvider>
+);
+
+describe('RouteErrorBoundary', () => {
+  beforeEach(() => {
+    useRouteError.mockReturnValue(null);
+    useAsyncError.mockReturnValue(null);
+
+    // Mock global.location.href
+    delete global.location;
+    global.location = { href: 'https://example.com/slug' };
+  });
+
+  it('displays the error page correctly when there is a route error', () => {
+    useRouteError.mockReturnValue(new Error('RouteError'));
+    renderWithRouterProvider(<RouteErrorBoundaryWrapper />);
+    expect(screen.getByText('An error occurred while processing your request')).toBeInTheDocument();
+    expect(screen.getByText('We apologize for the inconvenience. Please try again later.')).toBeInTheDocument();
+  });
+
+  it('displays the error page correctly when there is an async error', () => {
+    useAsyncError.mockReturnValue(new Error('AsyncError'));
+    renderWithRouterProvider(<RouteErrorBoundaryWrapper />);
+    expect(screen.getByText('An error occurred while processing your request')).toBeInTheDocument();
+    expect(screen.getByText('We apologize for the inconvenience. Please try again later.')).toBeInTheDocument();
+  });
+
+  it('displays the update available modal correctly when there is a ChunkLoadError route error', async () => {
+    const chunkLoadError = new Error('ChunkLoadError');
+    chunkLoadError.name = 'ChunkLoadError';
+    useRouteError.mockReturnValue(chunkLoadError);
+    renderWithRouterProvider(<RouteErrorBoundaryWrapper />);
+    expect(screen.getByText('Update: New Version Available')).toBeInTheDocument();
+    expect(screen.getByText('Attention: A new version of the website was released. To leverage the latest features and improvements, please perform a page refresh.')).toBeInTheDocument();
+    const refreshButton = screen.getByText('Refresh', { selector: 'a' });
+    // Click on the "Refresh" button; should still be on same location href.
+    userEvent.click(refreshButton);
+    expect(global.location.href).toBe('https://example.com/slug');
+  });
+
+  it('refreshes the page when "Try again" button is clicked', () => {
+    renderWithRouterProvider(<RouteErrorBoundaryWrapper />);
+
+    // Click on the "Try again" button; should still be on same location href.
+    userEvent.click(screen.getByText('Try again'));
+    expect(global.location.href).toBe('https://example.com/slug');
+  });
+});


### PR DESCRIPTION
If users have the app loaded in their browser when a new production deployment is released and then try navigating to a new page route, due to the code splitting by route for frontend performance reasons, a JS `ChunkLoadError` is thrown because the browser is trying to download a file chunk that no longer exists in the S3 bucket due to the new deployment (i.e., all previous chunks were removed from S3).

At least in the short term, we will catch `ChunkLoadError` and gracefully handle it by displaying a blocking `AlertModal`, encouraging users to refresh the page to leverage latest features/improvements. Long term, we may explore a more infrastructure related fix such as keeping files from previous deployments around longer.

https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/d71d4290-60b4-419a-b8f6-9c70a39e50d5

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [x] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
