### PR TITLE
ENT-8621: Replace /Search with One Academy

### DIFF
--- a/src/components/academies/GoToAcademy.jsx
+++ b/src/components/academies/GoToAcademy.jsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom';
+import { Button } from '@openedx/paragon';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import React from 'react';
+import useEnterpriseCustomer from '../app/data/hooks/useEnterpriseCustomer';
+import { useAcademies } from '../app/data';
+
+const GoToAcademy = () => {
+  const { data: academies } = useAcademies();
+  const { data: enterpriseCustomer } = useEnterpriseCustomer();
+
+  return (
+    <>
+      <p>
+        <FormattedMessage
+          id="enterprise.dashboard.tab.courses.go.to.academy.message"
+          defaultMessage="Getting started with edX is easy. Simply find a course from your Academy, request enrollment, and get started on your learning journey."
+          description="Default message shown to a learner on enterprise dashboard."
+        />
+      </p>
+      <Button
+        as={Link}
+        to={`/${enterpriseCustomer.slug}/academies/${academies[0].uuid}`}
+        className="btn-brand-primary d-block d-md-inline-block"
+      >
+        <FormattedMessage
+          id="enterprise.dashboard.tab.courses.go.to.academy"
+          defaultMessage="Go to Academy"
+          description="Label to go to academy button on enterprise dashboard."
+        />
+      </Button>
+    </>
+  );
+};
+
+export default GoToAcademy;

--- a/src/components/app/data/hooks/useRecommendCoursesForMe.js
+++ b/src/components/app/data/hooks/useRecommendCoursesForMe.js
@@ -2,6 +2,7 @@ import { useMatch } from 'react-router-dom';
 
 import useContentHighlightsConfiguration from './useContentHighlightsConfiguration';
 import useIsAssignmentsOnlyLearner from './useIsAssignmentsOnlyLearner';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
 
 /**
  * Keeps track of whether the enterprise banner should include the "Recommend courses for me" button.
@@ -12,9 +13,10 @@ export default function useRecommendCoursesForMe() {
   const { data: contentHighlightsConfiguration } = useContentHighlightsConfiguration();
   const canOnlyViewHighlightSets = !!contentHighlightsConfiguration?.canOnlyViewHighlightSets;
   const isAssignmentsOnlyLearner = useIsAssignmentsOnlyLearner();
-  // If user is not on the search page route, or users are restricted to only viewing highlight sets,
-  // the "Recommend courses for me" button should not be shown.
-  if (!isSearchPage || canOnlyViewHighlightSets) {
+  const { data: enterpriseCustomer } = useEnterpriseCustomer();
+  // If user is not on the search page route, or users are restricted to only viewing highlight sets or
+  // if the enterprise customer has enabled one academy, the "Recommend courses for me" button should not be shown.
+  if (!isSearchPage || canOnlyViewHighlightSets || enterpriseCustomer.enableOneAcademy) {
     return {
       shouldRecommendCourses: false,
     };

--- a/src/components/app/data/hooks/useRecommendCoursesForMe.test.jsx
+++ b/src/components/app/data/hooks/useRecommendCoursesForMe.test.jsx
@@ -5,7 +5,8 @@ import { AppContext } from '@edx/frontend-platform/react';
 import useRecommendCoursesForMe from './useRecommendCoursesForMe';
 import useContentHighlightsConfiguration from './useContentHighlightsConfiguration';
 import useIsAssignmentsOnlyLearner from './useIsAssignmentsOnlyLearner';
-import { authenticatedUserFactory } from '../services/data/__factories__';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { authenticatedUserFactory, enterpriseCustomerFactory } from '../services/data/__factories__';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -18,8 +19,10 @@ jest.mock('./useContentHighlightsConfiguration', () => jest.fn().mockReturnValue
   },
 }));
 jest.mock('./useIsAssignmentsOnlyLearner', () => jest.fn().mockReturnValue(false));
+jest.mock('./useEnterpriseCustomer', () => jest.fn());
 
 const mockAuthenticatedUser = authenticatedUserFactory();
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
 
 const wrapper = ({ children }) => (
   <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
@@ -30,6 +33,7 @@ const wrapper = ({ children }) => (
 describe('useRecommendCoursesForMe', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
   });
 
   it('should not show recommend course CTA by default', () => {
@@ -44,24 +48,35 @@ describe('useRecommendCoursesForMe', () => {
       mockRouteMatch: null, // simulates non-search page route
       canOnlyViewHighlightSets: false,
       isAssignmentsOnlyLearner: false,
+      enableOneAcademy: false,
       hasRecommendCourseCTA: false,
     },
     {
       mockRouteMatch: { path: '/search' }, // simulates search page route
       canOnlyViewHighlightSets: false,
       isAssignmentsOnlyLearner: false,
+      enableOneAcademy: false,
       hasRecommendCourseCTA: true,
     },
     {
       mockRouteMatch: { path: '/search' }, // simulates search page route
       canOnlyViewHighlightSets: true,
       isAssignmentsOnlyLearner: false,
+      enableOneAcademy: false,
+      hasRecommendCourseCTA: false,
+    },
+    {
+      mockRouteMatch: { path: '/search' }, // simulates search page route
+      canOnlyViewHighlightSets: false,
+      isAssignmentsOnlyLearner: false,
+      enableOneAcademy: true,
       hasRecommendCourseCTA: false,
     },
   ])('should support showing recommend course CTA, when appropriate (%s)', async ({
     mockRouteMatch,
     canOnlyViewHighlightSets,
     isAssignmentsOnlyLearner,
+    enableOneAcademy,
     hasRecommendCourseCTA,
   }) => {
     useMatch.mockReturnValue(mockRouteMatch);
@@ -71,6 +86,7 @@ describe('useRecommendCoursesForMe', () => {
       },
     });
     useIsAssignmentsOnlyLearner.mockReturnValue(isAssignmentsOnlyLearner);
+    useEnterpriseCustomer.mockReturnValue({ data: { ...mockEnterpriseCustomer, enableOneAcademy } });
 
     const { result } = renderHook(() => useRecommendCoursesForMe(), { wrapper });
 

--- a/src/components/app/data/services/data/__factories__/academies.factory.js
+++ b/src/components/app/data/services/data/__factories__/academies.factory.js
@@ -1,0 +1,20 @@
+import { Factory } from 'rosie'; // eslint-disable-line import/no-extraneous-dependencies
+import { faker } from '@faker-js/faker'; // eslint-disable-line import/no-extraneous-dependencies
+import { camelCaseObject } from '@edx/frontend-platform';
+import { v4 as uuidv4 } from 'uuid';
+
+Factory.define('academy')
+  .attr('uuid', uuidv4())
+  .attr('title', faker.lorem.words())
+  .attr('short_description', faker.lorem.sentence(50))
+  .attr('long_description', faker.lorem.sentence(20))
+  .attr('image', faker.image.urlPlaceholder())
+  .attr('tags', []);
+
+export function academyFactory(overrides = {}) {
+  return camelCaseObject(Factory.build('academy', overrides));
+}
+
+export function academiesFactory(count = 1, overrides = {}) {
+  return Array.from({ length: count }, () => academyFactory(overrides));
+}

--- a/src/components/app/data/services/data/__factories__/enterpriseCustomerUser.factory.js
+++ b/src/components/app/data/services/data/__factories__/enterpriseCustomerUser.factory.js
@@ -28,6 +28,7 @@ Factory.define('enterpriseCustomer')
   .attr('enable_data_sharing_consent', true)
   .attr('admin_users', [{ email: faker.internet.email() }])
   .attr('disable_search', false)
+  .attr('enable_one_academy', false)
   .attr('branding_configuration', {
     logo: faker.image.urlPlaceholder(),
     primary_color: faker.internet.color(),

--- a/src/components/app/data/services/data/__factories__/index.js
+++ b/src/components/app/data/services/data/__factories__/index.js
@@ -1,3 +1,4 @@
 import './enterpriseCustomerUser.factory';
 
 export * from './enterpriseCustomerUser.factory';
+export * from './academies.factory';

--- a/src/components/dashboard/main-content/DashboardMainContent.test.jsx
+++ b/src/components/dashboard/main-content/DashboardMainContent.test.jsx
@@ -7,14 +7,24 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import DashboardMainContent from './DashboardMainContent';
 import { queryClient, renderWithRouter } from '../../../utils/tests';
 import { features } from '../../../config';
-import { useCanOnlyViewHighlights, useEnterpriseCourseEnrollments, useEnterpriseCustomer } from '../../app/data';
-import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
+import {
+  useCanOnlyViewHighlights,
+  useEnterpriseCourseEnrollments,
+  useEnterpriseCustomer,
+  useAcademies,
+} from '../../app/data';
+import {
+  authenticatedUserFactory,
+  enterpriseCustomerFactory,
+  academiesFactory,
+} from '../../app/data/services/data/__factories__';
 
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
   useEnterpriseCustomer: jest.fn(),
   useCanOnlyViewHighlights: jest.fn(),
   useEnterpriseCourseEnrollments: jest.fn(),
+  useAcademies: jest.fn(),
 }));
 
 jest.mock('../../../config', () => ({
@@ -41,6 +51,7 @@ describe('DashboardMainContent', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    useAcademies.mockReturnValue({ data: academiesFactory(3) });
     useCanOnlyViewHighlights.mockReturnValue({ data: false });
     useEnterpriseCourseEnrollments.mockReturnValue({
       data: {

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollmentsEmptyState.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollmentsEmptyState.jsx
@@ -4,13 +4,16 @@ import { Link } from 'react-router-dom';
 
 import {
   useEnterpriseCustomer,
-  useCanOnlyViewHighlights,
+  useCanOnlyViewHighlights, useAcademies,
 } from '../../../app/data';
 import CourseRecommendations from '../CourseRecommendations';
+import GoToAcademy from '../../../academies/GoToAcademy';
 
 const CourseEnrollmentsEmptyState = () => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { data: canOnlyViewHighlightSets } = useCanOnlyViewHighlights();
+  const { data: academies } = useAcademies();
+
   if (enterpriseCustomer.disableSearch) {
     return (
       <p>
@@ -25,6 +28,11 @@ const CourseEnrollmentsEmptyState = () => {
       </p>
     );
   }
+
+  if (enterpriseCustomer.enableOneAcademy && academies?.length === 1) {
+    return <GoToAcademy />;
+  }
+
   return (
     <>
       <p>
@@ -45,7 +53,6 @@ const CourseEnrollmentsEmptyState = () => {
           description="Label for Find a course button on enterprise dashboard's courses tab."
         />
       </Button>
-
       <br />
       {canOnlyViewHighlightSets === false && <CourseRecommendations />}
     </>

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -25,6 +25,7 @@ import {
   useCouponCodes,
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
+  useAcademies,
   useEnterpriseOffers,
   useEnterprisePathwaysList,
   useEnterpriseProgramsList,
@@ -33,7 +34,11 @@ import {
   useSubscriptions,
   useHasAvailableSubsidiesOrRequests,
 } from '../../app/data';
-import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
+import {
+  authenticatedUserFactory,
+  enterpriseCustomerFactory,
+  academiesFactory,
+} from '../../app/data/services/data/__factories__';
 
 const dummyProgramData = {
   uuid: 'test-uuid',
@@ -98,6 +103,7 @@ jest.mock('../../app/data', () => ({
   useBrowseAndRequest: jest.fn(),
   useIsAssignmentsOnlyLearner: jest.fn(),
   useHasAvailableSubsidiesOrRequests: jest.fn(),
+  useAcademies: jest.fn(),
 }));
 
 jest.mock('@edx/frontend-enterprise-utils', () => ({
@@ -200,6 +206,7 @@ describe('<Dashboard />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    useAcademies.mockReturnValue({ data: academiesFactory(3) });
     useSubscriptions.mockReturnValue({
       data: {
         subscriptionLicense: undefined,

--- a/src/components/site-header/SiteHeaderNavMenu.jsx
+++ b/src/components/site-header/SiteHeaderNavMenu.jsx
@@ -1,12 +1,14 @@
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { NavLink } from 'react-router-dom';
 import { useEnterpriseCustomer, useIsAssignmentsOnlyLearner } from '../app/data';
+import { useContentDiscoveryNavLink } from './data';
 
 const SiteHeaderNavMenu = () => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const isAssignmentOnlyLearner = useIsAssignmentsOnlyLearner();
   const intl = useIntl();
   const mainMenuLinkClassName = 'nav-link';
+  const contentDiscoveryNavLink = useContentDiscoveryNavLink(mainMenuLinkClassName);
 
   if (enterpriseCustomer.disableSearch) {
     return null;
@@ -21,15 +23,7 @@ const SiteHeaderNavMenu = () => {
           description: 'Dashboard link title in site header navigation.',
         })}
       </NavLink>
-      {!isAssignmentOnlyLearner && (
-        <NavLink to={`/${enterpriseCustomer.slug}/search`} className={mainMenuLinkClassName}>
-          {intl.formatMessage({
-            id: 'site.header.nav.search.title',
-            defaultMessage: 'Find a Course',
-            description: 'Find a course link in site header navigation.',
-          })}
-        </NavLink>
-      )}
+      {!isAssignmentOnlyLearner && contentDiscoveryNavLink}
     </>
   );
 };

--- a/src/components/site-header/data/hooks/index.js
+++ b/src/components/site-header/data/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as useContentDiscoveryNavLink } from './useContentDiscoveryNavLink';

--- a/src/components/site-header/data/hooks/useContentDiscoveryNavLink.jsx
+++ b/src/components/site-header/data/hooks/useContentDiscoveryNavLink.jsx
@@ -1,0 +1,28 @@
+import { NavLink } from 'react-router-dom';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { useAcademies, useEnterpriseCustomer } from '../../../app/data';
+
+export default function useContentDiscoveryNavLink(mainMenuLinkClassName) {
+  const { data: enterpriseCustomer } = useEnterpriseCustomer();
+  const { data: academies } = useAcademies();
+  if (enterpriseCustomer.enableOneAcademy && academies.length === 1) {
+    return (
+      <NavLink to={`/${enterpriseCustomer.slug}/academies/${academies[0].uuid}`} className={mainMenuLinkClassName}>
+        <FormattedMessage
+          id="site.header.nav.search.title"
+          defaultMessage="Go to Academy"
+          description="Go to academy link in site header navigation."
+        />
+      </NavLink>
+    );
+  }
+  return (
+    <NavLink to={`/${enterpriseCustomer.slug}/search`} className={mainMenuLinkClassName}>
+      <FormattedMessage
+        id="site.header.nav.search.title"
+        defaultMessage="Find a Course"
+        description="Find a course link in site header navigation."
+      />
+    </NavLink>
+  );
+}

--- a/src/components/site-header/data/index.js
+++ b/src/components/site-header/data/index.js
@@ -1,0 +1,1 @@
+export * from './hooks';

--- a/src/components/site-header/tests/SiteHeader.test.jsx
+++ b/src/components/site-header/tests/SiteHeader.test.jsx
@@ -10,12 +10,17 @@ import { getConfig } from '@edx/frontend-platform/config';
 import SiteHeader from '../SiteHeader';
 
 import { renderWithRouter, renderWithRouterProvider } from '../../../utils/tests';
-import { useEnterpriseCustomer, useEnterpriseLearner } from '../../app/data';
-import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
+import { useAcademies, useEnterpriseCustomer, useEnterpriseLearner } from '../../app/data';
+import {
+  academiesFactory,
+  authenticatedUserFactory,
+  enterpriseCustomerFactory,
+} from '../../app/data/services/data/__factories__';
 
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
   useEnterpriseLearner: jest.fn(),
+  useAcademies: jest.fn(),
   useEnterpriseCustomer: jest.fn(),
   useIsAssignmentsOnlyLearner: jest.fn(),
 }));
@@ -88,6 +93,7 @@ describe('<SiteHeader />', () => {
         ],
       },
     });
+    useAcademies.mockReturnValue({ data: academiesFactory(3) });
   });
 
   test('renders link with logo to dashboard', () => {


### PR DESCRIPTION
__Jira Ticket:__ [ENT-8621]()

__Description:__
We anticipate some customers are going to want to purchase only one Academy and the content associated with it. In that case, the Academy detail page becomes a sufficient (and better) alternative to the search page.

**Acceptance Criteria:**
1. SearchPage is replaced with a new component `RedirectToAcademy`
2. "Skills Quiz" CTA is removed.
3. "Find a course" is replaced with "Go to Academy"


# Screenshots:
1. Screenshot of the dashboard page.
<img width="1512" alt="Screenshot 2024-04-15 at 11 10 08 AM" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/7114956/40d71ba1-80f9-4530-9e19-653970cc03a1">

2. Screenshots for error scenarios
<img width="757" alt="Screenshot 2024-04-15 at 11 09 26 AM" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/7114956/b7ece9b0-d982-44b4-9cf0-868eab2366ee">
<img width="1512" alt="Screenshot 2024-04-15 at 11 09 35 AM" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/7114956/c464a575-e297-4d1d-846d-035d1cc0f2f6">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
