### PR TITLE
refactor: extractEnterpriseId to extractEnterpriseCustomer

### DIFF
--- a/src/components/app/data/queries/extractEnterpriseCustomer.js
+++ b/src/components/app/data/queries/extractEnterpriseCustomer.js
@@ -8,7 +8,7 @@ import { queryEnterpriseLearner } from './queries';
  * @param {string} params.enterpriseSlug - The enterprise slug.
  * @returns {Promise<string>} - The enterprise ID to use for subsquent queries in route loaders.
  */
-async function extractEnterpriseId({
+async function extractEnterpriseCustomer({
   queryClient,
   authenticatedUser,
   enterpriseSlug,
@@ -26,24 +26,24 @@ async function extractEnterpriseId({
   // If there is no slug provided (i.e., on the root page route `/`), use
   // the currently active enterprise customer user.
   if (!enterpriseSlug) {
-    return activeEnterpriseCustomer.uuid;
+    return activeEnterpriseCustomer;
   }
 
-  const foundEnterpriseIdForSlug = allLinkedEnterpriseCustomerUsers.find(
+  const foundEnterpriseCustomerForSlug = allLinkedEnterpriseCustomerUsers.find(
     (enterpriseCustomerUser) => enterpriseCustomerUser.enterpriseCustomer?.slug === enterpriseSlug,
-  )?.enterpriseCustomer.uuid;
+  )?.enterpriseCustomer;
 
   // Otherwise, there is a slug provided for a specific enterprise customer. If the
   // user is linked to the enterprise customer for the given slug, return the enterprise
   // enterprise ID for that enterprise customer. If there is no linked enterprise customer
   // for the given slug, but the user is staff, return the enterprise ID from the staff-only
   // enterprise customer metadata.
-  if (foundEnterpriseIdForSlug || staffEnterpriseCustomer) {
-    return foundEnterpriseIdForSlug || staffEnterpriseCustomer.uuid;
+  if (foundEnterpriseCustomerForSlug || staffEnterpriseCustomer) {
+    return foundEnterpriseCustomerForSlug || staffEnterpriseCustomer;
   }
 
   // If no enterprise customer is found for the given user/slug, throw an error.
-  throw new Error(`Could not find enterprise customer for user ${authenticatedUser.userId} and slug ${enterpriseSlug}`);
+  throw new Error(`Could not find enterprise customer for slug ${enterpriseSlug}`);
 }
 
-export default extractEnterpriseId;
+export default extractEnterpriseCustomer;

--- a/src/components/app/data/queries/index.js
+++ b/src/components/app/data/queries/index.js
@@ -1,4 +1,4 @@
-export { default as extractEnterpriseId } from './extractEnterpriseId';
+export { default as extractEnterpriseCustomer } from './extractEnterpriseCustomer';
 export { default as queries } from './queryKeyFactory';
 
 export * from './queries';

--- a/src/components/app/routes/loaders/tests/enterpriseInviteLoader.test.jsx
+++ b/src/components/app/routes/loaders/tests/enterpriseInviteLoader.test.jsx
@@ -106,7 +106,7 @@ describe('enterpriseInviteLoader', () => {
     expect(screen.queryByTestId('invite-link')).not.toBeInTheDocument();
   });
 
-  it.only('does NOT redirect to dashboard when error occurs during linking of user <> enterprise customer', async () => {
+  it('does NOT redirect to dashboard when error occurs during linking of user <> enterprise customer', async () => {
     postLinkEnterpriseLearner.mockRejectedValue(new Error('test-error'));
     renderWithRouterProvider({
       path: '/invite/:enterpriseCustomerInviteKey',

--- a/src/components/app/routes/loaders/tests/enterpriseInviteLoader.test.jsx
+++ b/src/components/app/routes/loaders/tests/enterpriseInviteLoader.test.jsx
@@ -1,11 +1,12 @@
 import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { getConfig } from '@edx/frontend-platform';
 
 import { renderWithRouterProvider } from '../../../../../utils/tests';
 import makeEnterpriseInviteLoader from '../enterpriseInviteLoader';
 import {
-  extractEnterpriseId, postLinkEnterpriseLearner,
+  extractEnterpriseCustomer, postLinkEnterpriseLearner,
 } from '../../../data';
 import EnterpriseInviteRoute from '../../EnterpriseInviteRoute';
 import { ensureAuthenticatedUser } from '../../data';
@@ -16,7 +17,7 @@ jest.mock('../../data', () => ({
 }));
 jest.mock('../../../data', () => ({
   ...jest.requireActual('../../../data'),
-  extractEnterpriseId: jest.fn(),
+  extractEnterpriseCustomer: jest.fn(),
   postLinkEnterpriseLearner: jest.fn(),
 }));
 jest.mock('@edx/frontend-platform/auth', () => ({
@@ -29,8 +30,8 @@ jest.mock('@edx/frontend-platform/logging', () => ({
   getLoggingService: jest.fn(),
   logError: jest.fn(),
 }));
-jest.mock('@edx/frontend-platform/config', () => ({
-  ...jest.requireActual('@edx/frontend-platform/config'),
+jest.mock('@edx/frontend-platform', () => ({
+  ...jest.requireActual('@edx/frontend-platform'),
   getConfig: jest.fn().mockReturnValue({
     LEARNER_SUPPORT_URL: 'https://test-learner-support-url',
     MARKETING_SITE_BASE_URL: 'https://test-marketing-site-base-url',
@@ -40,9 +41,13 @@ jest.mock('@edx/frontend-platform/config', () => ({
 const mockEnterpriseId = 'test-enterprise-uuid';
 const mockEnterpriseSlug = 'test-enterprise-slug';
 const mockEnterpriseCustomerInviteKey = 'test-enterprise-customer-invite-key';
-extractEnterpriseId.mockResolvedValue(mockEnterpriseId);
+extractEnterpriseCustomer.mockResolvedValue({ uuid: mockEnterpriseId });
 postLinkEnterpriseLearner.mockResolvedValue({
   enterpriseCustomerSlug: mockEnterpriseSlug,
+});
+getConfig.mockReturnValue({
+  LEARNER_SUPPORT_URL: 'https://test-learner-support-url',
+  MARKETING_SITE_BASE_URL: 'https://test-marketing-site-base-url',
 });
 
 const EnterpriseInviteRouteWrapper = () => (
@@ -101,7 +106,7 @@ describe('enterpriseInviteLoader', () => {
     expect(screen.queryByTestId('invite-link')).not.toBeInTheDocument();
   });
 
-  it('does NOT redirect to dashboard when error occurs during linking of user <> enterprise customer', async () => {
+  it.only('does NOT redirect to dashboard when error occurs during linking of user <> enterprise customer', async () => {
     postLinkEnterpriseLearner.mockRejectedValue(new Error('test-error'));
     renderWithRouterProvider({
       path: '/invite/:enterpriseCustomerInviteKey',

--- a/src/components/app/routes/loaders/tests/rootLoader.test.jsx
+++ b/src/components/app/routes/loaders/tests/rootLoader.test.jsx
@@ -8,7 +8,7 @@ import { renderWithRouterProvider } from '../../../../../utils/tests';
 import makeRootLoader from '../rootLoader';
 import { ensureAuthenticatedUser } from '../../data';
 import {
-  extractEnterpriseId,
+  extractEnterpriseCustomer,
   queryBrowseAndRequestConfiguration,
   queryContentHighlightsConfiguration,
   queryCouponCodeRequests,
@@ -28,7 +28,7 @@ jest.mock('../../data', () => ({
 }));
 jest.mock('../../../data', () => ({
   ...jest.requireActual('../../../data'),
-  extractEnterpriseId: jest.fn(),
+  extractEnterpriseCustomer: jest.fn(),
   updateUserActiveEnterprise: jest.fn(),
 }));
 
@@ -64,7 +64,7 @@ describe('rootLoader', () => {
     jest.clearAllMocks();
     localStorage.clear();
     ensureAuthenticatedUser.mockResolvedValue(mockAuthenticatedUser);
-    extractEnterpriseId.mockResolvedValue(mockEnterpriseCustomer.uuid);
+    extractEnterpriseCustomer.mockResolvedValue(mockEnterpriseCustomer);
   });
 
   it('does nothing if the user is not authenticated', async () => {

--- a/src/components/course/data/courseLoader.test.jsx
+++ b/src/components/course/data/courseLoader.test.jsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { renderWithRouterProvider } from '../../../utils/tests';
 import makeCourseLoader from './courseLoader';
 import {
-  extractEnterpriseId,
+  extractEnterpriseCustomer,
   queryBrowseAndRequestConfiguration,
   queryCanRedeem,
   queryCouponCodeRequests,
@@ -31,7 +31,7 @@ jest.mock('../../app/routes/data', () => ({
 }));
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
-  extractEnterpriseId: jest.fn(),
+  extractEnterpriseCustomer: jest.fn(),
 }));
 jest.mock('@edx/frontend-platform/auth', () => ({
   ...jest.requireActual('@edx/frontend-platform/auth'),
@@ -46,7 +46,7 @@ jest.mock('@edx/frontend-platform/logging', () => ({
 const mockCourseKey = 'edX+DemoX';
 const mockSubscriptionCatalog = 'test-subscription-catalog-uuid';
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
-extractEnterpriseId.mockResolvedValue(mockEnterpriseCustomer.uuid);
+extractEnterpriseCustomer.mockResolvedValue(mockEnterpriseCustomer);
 
 const mockAuthenticatedUser = authenticatedUserFactory();
 

--- a/src/components/course/routes/externalCourseEnrollmentLoader.js
+++ b/src/components/course/routes/externalCourseEnrollmentLoader.js
@@ -1,7 +1,7 @@
 import { generatePath, redirect } from 'react-router-dom';
 
 import {
-  extractEnterpriseId,
+  extractEnterpriseCustomer,
   getLateRedemptionBufferDays,
   queryCanRedeem,
   queryCourseMetadata,
@@ -24,7 +24,7 @@ export default function makeExternalCourseEnrollmentLoader(queryClient) {
       courseKey,
       courseRunKey,
     } = params;
-    const enterpriseId = await extractEnterpriseId({
+    const enterpriseCustomer = await extractEnterpriseCustomer({
       queryClient,
       authenticatedUser,
       enterpriseSlug,
@@ -38,12 +38,12 @@ export default function makeExternalCourseEnrollmentLoader(queryClient) {
         return;
       }
       const redeemableLearnerCreditPolicies = await queryClient.ensureQueryData(queryRedeemablePolicies({
-        enterpriseUuid: enterpriseId,
+        enterpriseUuid: enterpriseCustomer.uuid,
         lmsUserId: authenticatedUser.userId,
       }));
       const isEnrollableBufferDays = getLateRedemptionBufferDays(redeemableLearnerCreditPolicies.redeemablePolicies);
       const canRedeem = await queryClient.ensureQueryData(
-        queryCanRedeem(enterpriseId, courseMetadata, isEnrollableBufferDays),
+        queryCanRedeem(enterpriseCustomer.uuid, courseMetadata, isEnrollableBufferDays),
       );
       const hasSuccessfulRedemption = !!canRedeem.find(r => r.contentKey === courseRunKey)?.hasSuccessfulRedemption;
       if (hasSuccessfulRedemption) {

--- a/src/components/dashboard/data/dashboardLoader.js
+++ b/src/components/dashboard/data/dashboardLoader.js
@@ -1,6 +1,6 @@
 import { ensureAuthenticatedUser } from '../../app/routes/data';
 import {
-  extractEnterpriseId,
+  extractEnterpriseCustomer,
   queryEnterpriseCourseEnrollments,
   queryEnterprisePathwaysList,
   queryEnterpriseProgramsList,
@@ -21,15 +21,15 @@ export default function makeDashboardLoader(queryClient) {
     }
 
     const { enterpriseSlug } = params;
-    const enterpriseId = await extractEnterpriseId({
+    const enterpriseCustomer = await extractEnterpriseCustomer({
       queryClient,
       authenticatedUser,
       enterpriseSlug,
     });
     await Promise.all([
-      queryClient.ensureQueryData(queryEnterpriseCourseEnrollments(enterpriseId)),
-      queryClient.ensureQueryData(queryEnterpriseProgramsList(enterpriseId)),
-      queryClient.ensureQueryData(queryEnterprisePathwaysList(enterpriseId)),
+      queryClient.ensureQueryData(queryEnterpriseCourseEnrollments(enterpriseCustomer.uuid)),
+      queryClient.ensureQueryData(queryEnterpriseProgramsList(enterpriseCustomer.uuid)),
+      queryClient.ensureQueryData(queryEnterprisePathwaysList(enterpriseCustomer.uuid)),
     ]);
 
     return null;

--- a/src/components/dashboard/data/dashboardLoader.test.jsx
+++ b/src/components/dashboard/data/dashboardLoader.test.jsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { renderWithRouterProvider } from '../../../utils/tests';
 import makeDashboardLoader from './dashboardLoader';
 import {
-  extractEnterpriseId,
+  extractEnterpriseCustomer,
   queryEnterpriseCourseEnrollments,
   queryEnterprisePathwaysList,
   queryEnterpriseProgramsList,
@@ -17,7 +17,7 @@ jest.mock('../../app/routes/data', () => ({
 }));
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
-  extractEnterpriseId: jest.fn(),
+  extractEnterpriseCustomer: jest.fn(),
 }));
 jest.mock('@edx/frontend-platform/auth', () => ({
   ...jest.requireActual('@edx/frontend-platform/auth'),
@@ -30,7 +30,7 @@ jest.mock('@edx/frontend-platform/logging', () => ({
 }));
 
 const mockEnterpriseId = 'test-enterprise-uuid';
-extractEnterpriseId.mockResolvedValue(mockEnterpriseId);
+extractEnterpriseCustomer.mockResolvedValue({ uuid: mockEnterpriseId });
 
 const mockQueryClient = {
   ensureQueryData: jest.fn().mockResolvedValue({}),

--- a/src/components/program/data/programLoader.js
+++ b/src/components/program/data/programLoader.js
@@ -1,5 +1,5 @@
 import { ensureAuthenticatedUser } from '../../app/routes/data';
-import { extractEnterpriseId, queryEnterpriseProgram } from '../../app/data';
+import { extractEnterpriseCustomer, queryEnterpriseProgram } from '../../app/data';
 
 export default function makeProgramLoader(queryClient) {
   return async function programLoader({ params = {}, request }) {
@@ -12,13 +12,13 @@ export default function makeProgramLoader(queryClient) {
 
     const { enterpriseSlug, programUUID } = params;
 
-    const enterpriseId = await extractEnterpriseId({
+    const enterpriseCustomer = await extractEnterpriseCustomer({
       queryClient,
       authenticatedUser,
       enterpriseSlug,
     });
 
-    await queryClient.ensureQueryData(queryEnterpriseProgram(enterpriseId, programUUID));
+    await queryClient.ensureQueryData(queryEnterpriseProgram(enterpriseCustomer.uuid, programUUID));
 
     return null;
   };

--- a/src/components/program/data/programLoader.test.js
+++ b/src/components/program/data/programLoader.test.js
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/extend-expect';
 
 import { renderWithRouterProvider } from '../../../utils/tests';
 import { ensureAuthenticatedUser } from '../../app/routes/data';
-import { extractEnterpriseId, queryEnterpriseProgram } from '../../app/data';
+import { extractEnterpriseCustomer, queryEnterpriseProgram } from '../../app/data';
 import makeProgramLoader from './programLoader';
 
 jest.mock('../../app/routes/data', () => ({
@@ -14,14 +14,14 @@ jest.mock('../../app/routes/data', () => ({
 
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
-  extractEnterpriseId: jest.fn(),
+  extractEnterpriseCustomer: jest.fn(),
 }));
 
 const mockEnterpriseId = 'test-enterprise-uuid';
 const mockProgramUUID = 'test-program-uuid';
 const mockProgramsURL = `/${mockEnterpriseId}/program/${mockProgramUUID}`;
 
-extractEnterpriseId.mockResolvedValue(mockEnterpriseId);
+extractEnterpriseCustomer.mockResolvedValue({ uuid: mockEnterpriseId });
 
 const mockQueryClient = {
   ensureQueryData: jest.fn().mockResolvedValue({}),

--- a/src/components/search/data/searchLoader.js
+++ b/src/components/search/data/searchLoader.js
@@ -1,6 +1,6 @@
 import { getConfig } from '@edx/frontend-platform/config';
 import { ensureAuthenticatedUser } from '../../app/routes/data';
-import { extractEnterpriseId, queryAcademiesList, queryContentHighlightSets } from '../../app/data';
+import { extractEnterpriseCustomer, queryAcademiesList, queryContentHighlightSets } from '../../app/data';
 
 export default function makeSearchLoader(queryClient) {
   return async function searchLoader({ params = {}, request }) {
@@ -13,20 +13,20 @@ export default function makeSearchLoader(queryClient) {
 
     const { enterpriseSlug } = params;
 
-    const enterpriseId = await extractEnterpriseId({
+    const enterpriseCustomer = await extractEnterpriseCustomer({
       queryClient,
       authenticatedUser,
       enterpriseSlug,
     });
     const searchData = [
       queryClient.ensureQueryData(
-        queryAcademiesList(enterpriseId),
+        queryAcademiesList(enterpriseCustomer.uuid),
       ),
     ];
     if (getConfig().FEATURE_CONTENT_HIGHLIGHTS) {
       searchData.push(
         queryClient.ensureQueryData(
-          queryContentHighlightSets(enterpriseId),
+          queryContentHighlightSets(enterpriseCustomer.uuid),
         ),
       );
     }


### PR DESCRIPTION
To have access to enterprise customer metadata within route loaders, refactors `extractEnterpriseId` to `extractEnterpriseCustomer` instead.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
