### PR TITLE
fix: update variable destructuring for enterprise features

### DIFF
--- a/src/components/app/data/hooks/useEnterpriseFeatures.js
+++ b/src/components/app/data/hooks/useEnterpriseFeatures.js
@@ -4,8 +4,6 @@ export default function useEnterpriseFeatures(queryOptions = {}) {
   const { select, ...queryOptionsRest } = queryOptions;
   return useEnterpriseLearner({
     ...queryOptionsRest,
-    select: (data) => ({
-      enterpriseFeatures: data.enterpriseFeatures,
-    }),
+    select: (data) => data.enterpriseFeatures,
   });
 }

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -63,7 +63,7 @@ function useSearchPathwayModal() {
 const Search = () => {
   const config = getConfig();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const { data: { enterpriseFeatures } } = useEnterpriseFeatures();
+  const { data: enterpriseFeatures } = useEnterpriseFeatures();
   const intl = useIntl();
   const navigate = useNavigate();
 

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -63,7 +63,7 @@ function useSearchPathwayModal() {
 const Search = () => {
   const config = getConfig();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const { data: enterpriseFeatures } = useEnterpriseFeatures();
+  const { data: { enterpriseFeatures } } = useEnterpriseFeatures();
   const intl = useIntl();
   const navigate = useNavigate();
 


### PR DESCRIPTION
Currently, `enterpriseFeatures?.featurePrequerySearchSuggestions` returns `undefined`. To fix this, we need to update the return of `useEnterpriseFeatures` to `data.enterpriseFeatures](select: (data) => data.enterpriseFeatures)`

https://2u-internal.atlassian.net/browse/ENT-8790
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
