### PR TITLE
feat: Improve code coverage 2

### DIFF
--- a/src/components/app/data/hooks/useContentHighlightSets.test.jsx
+++ b/src/components/app/data/hooks/useContentHighlightSets.test.jsx
@@ -70,46 +70,64 @@ describe('useContentHighlightSets', () => {
       }),
     );
   });
-  it(
-    'should handle resolved value correctly when select is not passed as a parameter and FEATURE_CONTENT_HIGHLIGHTS is disabled',
-    () => {
-      getConfig.mockReturnValue({
-        FEATURE_CONTENT_HIGHLIGHTS: false,
-      });
-      const { result } = renderHook(() => useContentHighlightSets(), { wrapper: Wrapper });
+  it('should handle resolved value correctly when select is not passed as a parameter and filters out empty sets', async () => {
+    const updatedMockContentHighlightSets = [
+      ...mockContentHighlightSets,
+      {
+        uuid: 'empty-test-highlight-set',
+        title: 'sample highlight',
+        isPublished: true,
+        enterpriseCuration: 'test-curation-uuid',
+        cardImageUrl: 'https://placehold.co/400',
+        highlightedContent: [],
+      },
+    ];
+    fetchContentHighlights.mockResolvedValue(updatedMockContentHighlightSets);
+    const { result, waitForNextUpdate } = renderHook(() => useContentHighlightSets(), { wrapper: Wrapper });
+    await waitForNextUpdate();
 
-      expect(result.current).toEqual(
-        expect.objectContaining({
-          data: undefined,
-        }),
-      );
-    },
-  );
-  it(
-    'should handle resolved value correctly when select is passed as a parameter, and filters empty highlight sets',
-    async () => {
-      const mockUpdatedContentHighlightSets = [
-        ...mockContentHighlightSets,
-        {
-          uuid: 'test-highlight-set-2',
-          title: 'sample highlight',
-          isPublished: true,
-          enterpriseCuration: 'test-curation-uuid',
-          cardImageUrl: 'https://placehold.co/400',
-          highlightedContent: [],
-        },
-      ];
-      fetchContentHighlights.mockResolvedValue(mockUpdatedContentHighlightSets);
-      const { result, waitForNextUpdate } = renderHook(() => useContentHighlightSets({
-        select: (data) => data,
-      }), { wrapper: Wrapper });
-      await waitForNextUpdate();
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockContentHighlightSets,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+  it('should handle resolved value correctly when select is not passed as a parameter and FEATURE_CONTENT_HIGHLIGHTS is disabled', () => {
+    getConfig.mockReturnValue({
+      FEATURE_CONTENT_HIGHLIGHTS: false,
+    });
+    const { result } = renderHook(() => useContentHighlightSets(), { wrapper: Wrapper });
 
-      expect(result.current.data.original).toEqual(mockUpdatedContentHighlightSets);
-      expect(result.current.data.transformed).not.toEqual(mockUpdatedContentHighlightSets);
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: undefined,
+      }),
+    );
+  });
+  it('should handle resolved value correctly when select is passed as a parameter, and filters empty highlight sets', async () => {
+    const mockUpdatedContentHighlightSets = [
+      ...mockContentHighlightSets,
+      {
+        uuid: 'empty-test-highlight-set',
+        title: 'sample highlight',
+        isPublished: true,
+        enterpriseCuration: 'test-curation-uuid',
+        cardImageUrl: 'https://placehold.co/400',
+        highlightedContent: [],
+      },
+    ];
+    fetchContentHighlights.mockResolvedValue(mockUpdatedContentHighlightSets);
+    const { result, waitForNextUpdate } = renderHook(() => useContentHighlightSets({
+      select: (data) => data,
+    }), { wrapper: Wrapper });
+    await waitForNextUpdate();
 
-      expect(result.current.data.original.length).toEqual(2);
-      expect(result.current.data.transformed.length).toEqual(1);
-    },
-  );
+    expect(result.current.data.original).toEqual(mockUpdatedContentHighlightSets);
+    expect(result.current.data.transformed).not.toEqual(mockUpdatedContentHighlightSets);
+
+    expect(result.current.data.original.length).toEqual(2);
+    expect(result.current.data.transformed.length).toEqual(1);
+  });
 });

--- a/src/components/app/data/hooks/useContentHighlightSets.test.jsx
+++ b/src/components/app/data/hooks/useContentHighlightSets.test.jsx
@@ -1,0 +1,115 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { getConfig } from '@edx/frontend-platform';
+import { enterpriseCustomerFactory } from '../services/data/__factories__';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { queryClient } from '../../../../utils/tests';
+import { fetchContentHighlights } from '../services';
+import useContentHighlightSets from './useContentHighlightSets';
+
+jest.mock('./useEnterpriseCustomer');
+
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchContentHighlights: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(),
+}));
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockContentHighlightSets = [
+  {
+    uuid: 'test-highlight-set',
+    title: 'sample highlight',
+    isPublished: true,
+    enterpriseCuration: 'test-curation-uuid',
+    cardImageUrl: 'https://placehold.co/400',
+    highlightedContent: [
+      {
+        uuid: 'test-course1',
+        aggregationKey: 'edX+DemoX',
+        contentType: 'course',
+        title: 'Sample Course 1',
+        cardImageUrl: 'https://placehold.co/500',
+        authoringOrganizations: [
+          {
+            uuid: 'test-organization-uuid1',
+            name: 'edx',
+            logoImageUrl: 'https://placehold.co/600',
+          },
+        ],
+        courseRunStatuses: ['published'],
+      },
+    ],
+  },
+];
+
+describe('useContentHighlightSets', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchContentHighlights.mockResolvedValue(mockContentHighlightSets);
+    getConfig.mockReturnValue({
+      FEATURE_CONTENT_HIGHLIGHTS: true,
+    });
+  });
+  it('should handle resolved value correctly when select is not passed as a parameter', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useContentHighlightSets(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockContentHighlightSets,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+  it(
+    'should handle resolved value correctly when select is not passed as a parameter and FEATURE_CONTENT_HIGHLIGHTS are disabled',
+    () => {
+      getConfig.mockReturnValue({
+        FEATURE_CONTENT_HIGHLIGHTS: false,
+      });
+      const { result } = renderHook(() => useContentHighlightSets(), { wrapper: Wrapper });
+
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          data: undefined,
+        }),
+      );
+    },
+  );
+  it(
+    'should handle resolved value correctly when select is passed as a parameter, and filters empty highlight sets',
+    async () => {
+      const mockUpdatedContentHighlightSets = [
+        ...mockContentHighlightSets,
+        {
+          uuid: 'test-highlight-set-2',
+          title: 'sample highlight',
+          isPublished: true,
+          enterpriseCuration: 'test-curation-uuid',
+          cardImageUrl: 'https://placehold.co/400',
+          highlightedContent: [],
+        },
+      ];
+      fetchContentHighlights.mockResolvedValue(mockUpdatedContentHighlightSets);
+      const { result, waitForNextUpdate } = renderHook(() => useContentHighlightSets({
+        select: (data) => data,
+      }), { wrapper: Wrapper });
+      await waitForNextUpdate();
+
+      expect(result.current.data.original).toEqual(mockUpdatedContentHighlightSets);
+      expect(result.current.data.transformed).not.toEqual(mockUpdatedContentHighlightSets);
+
+      expect(result.current.data.original.length).toEqual(2);
+      expect(result.current.data.transformed.length).toEqual(1);
+    },
+  );
+});

--- a/src/components/app/data/hooks/useContentHighlightSets.test.jsx
+++ b/src/components/app/data/hooks/useContentHighlightSets.test.jsx
@@ -71,7 +71,7 @@ describe('useContentHighlightSets', () => {
     );
   });
   it(
-    'should handle resolved value correctly when select is not passed as a parameter and FEATURE_CONTENT_HIGHLIGHTS are disabled',
+    'should handle resolved value correctly when select is not passed as a parameter and FEATURE_CONTENT_HIGHLIGHTS is disabled',
     () => {
       getConfig.mockReturnValue({
         FEATURE_CONTENT_HIGHLIGHTS: false,

--- a/src/components/app/data/hooks/useContentHighlightsConfiguration.test.jsx
+++ b/src/components/app/data/hooks/useContentHighlightsConfiguration.test.jsx
@@ -66,9 +66,23 @@ describe('useCanOnlyViewHighlights', () => {
   it('should handle resolved value correctly when isHighlightFeatureActive is disabled', async () => {
     const updatedMockEnterpriseCuration = {
       ...mockEnterpriseCurations,
-      hasHighlightFeatureActive: false,
+      isHighlightFeatureActive: false,
     };
     fetchEnterpriseCuration.mockResolvedValue(updatedMockEnterpriseCuration);
+    const { result, waitForNextUpdate } = renderHook(() => useCanOnlyViewHighlights(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: false,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+  it('should handle resolved value correctly when isHighlightFeatureActive is not present in the object', async () => {
+    delete mockEnterpriseCurations.isHighlightFeatureActive;
+    fetchEnterpriseCuration.mockResolvedValue(mockEnterpriseCurations);
     const { result, waitForNextUpdate } = renderHook(() => useCanOnlyViewHighlights(), { wrapper: Wrapper });
     await waitForNextUpdate();
 

--- a/src/components/app/data/hooks/useContentHighlightsConfiguration.test.jsx
+++ b/src/components/app/data/hooks/useContentHighlightsConfiguration.test.jsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '../../../../utils/tests';
 import { fetchEnterpriseCuration } from '../services';
-import useContentHighlightsConfiguration from './useContentHighlightsConfiguration';
+import useContentHighlightsConfiguration, { useCanOnlyViewHighlights } from './useContentHighlightsConfiguration';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 import { enterpriseCustomerFactory } from '../services/data/__factories__';
 
@@ -18,18 +18,20 @@ const mockEnterpriseCurations = {
   id: '123',
   name: 'Test Enterprise',
   canOnlyViewHighlightSets: false,
+  isHighlightFeatureActive: true,
 };
+const Wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+fetchEnterpriseCuration.mockResolvedValue(mockEnterpriseCurations);
 
 describe('useContentHighlightsConfiguration', () => {
-  const Wrapper = ({ children }) => (
-    <QueryClientProvider client={queryClient()}>
-      {children}
-    </QueryClientProvider>
-  );
   beforeEach(() => {
     jest.clearAllMocks();
-    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    fetchEnterpriseCuration.mockResolvedValue(mockEnterpriseCurations);
   });
   it('should handle resolved value correctly', async () => {
     const { result, waitForNextUpdate } = renderHook(() => useContentHighlightsConfiguration(), { wrapper: Wrapper });
@@ -38,6 +40,41 @@ describe('useContentHighlightsConfiguration', () => {
     expect(result.current).toEqual(
       expect.objectContaining({
         data: mockEnterpriseCurations,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});
+
+describe('useCanOnlyViewHighlights', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('should handle resolved value correctly when isHighlightFeatureActive is enabled', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCanOnlyViewHighlights(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockEnterpriseCurations.canOnlyViewHighlightSets,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+  it('should handle resolved value correctly when isHighlightFeatureActive is disabled', async () => {
+    const updatedMockEnterpriseCuration = {
+      ...mockEnterpriseCurations,
+      hasHighlightFeatureActive: false,
+    };
+    fetchEnterpriseCuration.mockResolvedValue(updatedMockEnterpriseCuration);
+    const { result, waitForNextUpdate } = renderHook(() => useCanOnlyViewHighlights(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: false,
         isLoading: false,
         isFetching: false,
       }),

--- a/src/components/app/data/hooks/useCouponCodes.test.jsx
+++ b/src/components/app/data/hooks/useCouponCodes.test.jsx
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { enterpriseCustomerFactory } from '../services/data/__factories__';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { queryClient } from '../../../../utils/tests';
+import { fetchCouponCodes } from '../services';
+import useCouponCodes from './useCouponCodes';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchCouponCodes: jest.fn().mockResolvedValue(null),
+}));
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockCouponCodes = {
+  couponsOverview: [{ id: 'test-coupon-code' }],
+  couponCodeAssignments: [{ id: 'test-coupon-code-assignment' }],
+};
+
+describe('useCouponCodes', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchCouponCodes.mockResolvedValue(mockCouponCodes);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCouponCodes(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockCouponCodes,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useCourseMetadata.test.jsx
+++ b/src/components/app/data/hooks/useCourseMetadata.test.jsx
@@ -30,7 +30,6 @@ const mockCourseMetadata = {
     isEnrollable: true,
   }],
 };
-const mockURL = new URL('https://example.com?course_run_key=edX DemoX');
 
 describe('useCourseMetadata', () => {
   const Wrapper = ({ children }) => (
@@ -43,7 +42,7 @@ describe('useCourseMetadata', () => {
     fetchCourseMetadata.mockResolvedValue(mockCourseMetadata);
     useParams.mockReturnValue({ courseKey: 'edX+DemoX' });
     useLateRedemptionBufferDays.mockReturnValue(undefined);
-    useSearchParams.mockReturnValue([new URLSearchParams(mockURL.search)]);
+    useSearchParams.mockReturnValue([new URLSearchParams({ course_run_key: 'course-v1:edX+DemoX+T2024' })]);
   });
   it('should handle resolved value correctly with no select function passed', async () => {
     const { result, waitForNextUpdate } = renderHook(() => useCourseMetadata(), { wrapper: Wrapper });
@@ -73,7 +72,7 @@ describe('useCourseMetadata', () => {
       }),
     );
   });
-  it('should handle resolved value correctly when no data is returned with a select function passed', async () => {
+  it('should handle resolved value correctly when data is returned with a select function passed', async () => {
     const { result, waitForNextUpdate } = renderHook(() => useCourseMetadata(
       { select: (data) => data },
     ), { wrapper: Wrapper });
@@ -88,6 +87,21 @@ describe('useCourseMetadata', () => {
             availableCourseRuns: [mockCourseMetadata.courseRuns[0]],
           },
         },
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+  it('should handle resolved value correctly when no data is returned with a select function passed', async () => {
+    fetchCourseMetadata.mockResolvedValue(null);
+    const { result, waitForNextUpdate } = renderHook(() => useCourseMetadata(
+      { select: (data) => data },
+    ), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: null,
         isLoading: false,
         isFetching: false,
       }),

--- a/src/components/app/data/hooks/useCourseMetadata.test.jsx
+++ b/src/components/app/data/hooks/useCourseMetadata.test.jsx
@@ -19,6 +19,7 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn(),
   useSearchParams: jest.fn(),
 }));
+
 const mockCourseMetadata = {
   key: 'edX+DemoX',
   courseRuns: [{

--- a/src/components/app/data/hooks/useCourseMetadata.test.jsx
+++ b/src/components/app/data/hooks/useCourseMetadata.test.jsx
@@ -1,0 +1,95 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { queryClient } from '../../../../utils/tests';
+import { fetchCourseMetadata } from '../services';
+import useLateRedemptionBufferDays from './useLateRedemptionBufferDays';
+import useCourseMetadata from './useCourseMetadata';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('./useLateRedemptionBufferDays');
+
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchCourseMetadata: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+const mockCourseMetadata = {
+  key: 'edX+DemoX',
+  courseRuns: [{
+    isMarketable: true,
+    availability: 'Current',
+    enrollmentStart: dayjs().add(10, 'day').toISOString(),
+    enrollmentEnd: dayjs().add(15, 'day').toISOString(),
+    isEnrollable: true,
+  }],
+};
+const mockURL = new URL('https://example.com?course_run_key=edX DemoX');
+
+describe('useCourseMetadata', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchCourseMetadata.mockResolvedValue(mockCourseMetadata);
+    useParams.mockReturnValue({ courseKey: 'edX+DemoX' });
+    useLateRedemptionBufferDays.mockReturnValue(undefined);
+    useSearchParams.mockReturnValue([new URLSearchParams(mockURL.search)]);
+  });
+  it('should handle resolved value correctly with no select function passed', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCourseMetadata(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: {
+          ...mockCourseMetadata,
+          availableCourseRuns: [mockCourseMetadata.courseRuns[0]],
+        },
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+  it('should handle resolved value correctly when no data is returned from course metadata', async () => {
+    fetchCourseMetadata.mockResolvedValue(null);
+    const { result, waitForNextUpdate } = renderHook(() => useCourseMetadata(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: null,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+  it('should handle resolved value correctly when no data is returned with a select function passed', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCourseMetadata(
+      { select: (data) => data },
+    ), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: {
+          original: mockCourseMetadata,
+          transformed: {
+            ...mockCourseMetadata,
+            availableCourseRuns: [mockCourseMetadata.courseRuns[0]],
+          },
+        },
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useCourseRecommendations.test.jsx
+++ b/src/components/app/data/hooks/useCourseRecommendations.test.jsx
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { AppContext } from '@edx/frontend-platform/react';
+import { authenticatedUserFactory, enterpriseCustomerFactory } from '../services/data/__factories__';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { queryClient } from '../../../../utils/tests';
+import { fetchCourseRecommendations } from '../services';
+import useCourseRecommendations from './useCourseRecommendations';
+import useSearchCatalogs from './useSearchCatalogs';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('./useSearchCatalogs');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchCourseRecommendations: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
+
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockAuthenticatedUser = authenticatedUserFactory();
+const mockCourseRecommendations = {
+  allRecommendations: ['test-course-recommendations'],
+  samePartnerRecommendations: ['test-same-partner-recommendations'],
+};
+
+describe('useCourseRecommendations', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+        {children}
+      </AppContext.Provider>
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchCourseRecommendations.mockResolvedValue(mockCourseRecommendations);
+    useSearchCatalogs.mockReturnValue(['sample-catalog-uuid']);
+    useParams.mockReturnValue({ courseKey: 'edX+DemoX' });
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCourseRecommendations(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockCourseRecommendations,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useCourseReviews.test.jsx
+++ b/src/components/app/data/hooks/useCourseReviews.test.jsx
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { queryClient } from '../../../../utils/tests';
+import { fetchCourseReviews } from '../services';
+import useCourseMetadata from './useCourseMetadata';
+import useCourseReviews from './useCourseReviews';
+
+jest.mock('./useCourseMetadata');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchCourseReviews: jest.fn().mockResolvedValue(null),
+}));
+const mockCourseReviews = {
+  course_key: 'test-course-run-key',
+  reviewsCount: 345,
+  avgCourseRating: 3,
+  confidentLearnersPercentage: 33,
+  mostCommonGoal: 'Job advancement',
+  mostCommonGoalLearnersPercentage: 34,
+  totalEnrollments: 4444,
+};
+const mockCourseMetadata = {
+  key: 'edX+DemoX',
+  courseRuns: [{
+    isMarketable: true,
+    availability: 'Current',
+    enrollmentStart: dayjs().add(10, 'day').toISOString(),
+    enrollmentEnd: dayjs().add(15, 'day').toISOString(),
+    isEnrollable: true,
+  }],
+};
+describe('useCourseReviews', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCourseMetadata.mockReturnValue({ data: mockCourseMetadata });
+    fetchCourseReviews.mockResolvedValue(mockCourseReviews);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useCourseReviews(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockCourseReviews,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useEnterpriseCustomer.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseCustomer.test.jsx
@@ -1,23 +1,19 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { AppContext } from '@edx/frontend-platform/react';
-import { render, screen, waitFor } from '@testing-library/react';
-import { authenticatedUserFactory } from '../services/data/__factories__';
+import { authenticatedUserFactory, enterpriseCustomerFactory } from '../services/data/__factories__';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 import { queryClient } from '../../../../utils/tests';
 import { fetchEnterpriseLearnerData } from '../services';
-import { useEnterpriseLearner } from './index';
 
 jest.mock('../services', () => ({
   ...jest.requireActual('../services'),
   fetchEnterpriseLearnerData: jest.fn().mockResolvedValue(null),
 }));
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
 const mockAuthenticatedUser = authenticatedUserFactory();
 const mockEnterpriseLearnerData = {
-  enterpriseCustomer: {
-    uuid: 'test-enterprise-customer',
-    slug: 'test-enterprise-slug',
-  },
+  enterpriseCustomer: mockEnterpriseCustomer,
   enterpriseCustomerUserRoleAssignments: [],
   activeEnterpriseCustomer: null,
   activeEnterpriseCustomerUserRoleAssignments: [],
@@ -38,58 +34,20 @@ describe('useEnterpriseCustomer', () => {
     jest.clearAllMocks();
     fetchEnterpriseLearnerData.mockResolvedValue(mockEnterpriseLearnerData);
   });
-  it('should return nested hook value correctly', async () => {
-    const {
-      result,
-      waitForNextUpdate,
-    } = renderHook(() => useEnterpriseLearner(), { wrapper: Wrapper });
+  it('should return enterprise customer metadata correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useEnterpriseCustomer(), { wrapper: Wrapper });
     await waitForNextUpdate();
-    expect(result.current).toEqual(
-      expect.objectContaining({
-        data: mockEnterpriseLearnerData,
-      }),
-    );
+    const actualEnterpriseCustomer = result.current.data;
+    expect(actualEnterpriseCustomer.uuid).toEqual(mockEnterpriseCustomer.uuid);
+    expect(actualEnterpriseCustomer.slug).toEqual(mockEnterpriseCustomer.slug);
   });
-  it('should handle parent hook return value correctly', async () => {
-    const EnterpriseCustomer = () => {
-      const { data: enterpriseCustomer } = useEnterpriseCustomer();
-      return (
-        <>
-          <div>{enterpriseCustomer?.uuid}</div>
-          <div>{enterpriseCustomer?.slug}</div>
-        </>
-      );
-    };
-
-    render(
-      <Wrapper>
-        <EnterpriseCustomer />
-      </Wrapper>,
-    );
-    await waitFor(() => {
-      expect(screen.getByText(mockEnterpriseLearnerData.enterpriseCustomer.uuid)).toBeTruthy();
-      expect(screen.getByText(mockEnterpriseLearnerData.enterpriseCustomer.slug)).toBeTruthy();
-    });
-  });
-  it('should handle parent hook return value correctly with select', async () => {
-    const EnterpriseCustomer = ({ queryOptions }) => {
-      const { data: enterpriseCustomer } = useEnterpriseCustomer(queryOptions);
-      return (
-        <>
-          <div>{JSON.stringify(enterpriseCustomer?.original)}</div>
-          <div>{JSON.stringify(enterpriseCustomer?.transformed)}</div>
-        </>
-      );
-    };
-
-    render(
-      <Wrapper>
-        <EnterpriseCustomer queryOptions={{ select: (data) => data }} />
-      </Wrapper>,
-    );
-    await waitFor(() => {
-      expect(screen.getByText(JSON.stringify(mockEnterpriseLearnerData))).toBeTruthy();
-      expect(screen.getByText(JSON.stringify(mockEnterpriseLearnerData.enterpriseCustomer))).toBeTruthy();
-    });
+  it('should return enterprise customer metadata correctly with select', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useEnterpriseCustomer({
+      select: (data) => data,
+    }), { wrapper: Wrapper });
+    await waitForNextUpdate();
+    const actualEnterpriseCustomerSelectArgs = result.current.data;
+    expect(actualEnterpriseCustomerSelectArgs.original).toEqual(mockEnterpriseLearnerData);
+    expect(actualEnterpriseCustomerSelectArgs.transformed).toEqual(mockEnterpriseCustomer);
   });
 });

--- a/src/components/app/data/hooks/useEnterpriseCustomer.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseCustomer.test.jsx
@@ -1,0 +1,101 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { AppContext } from '@edx/frontend-platform/react';
+import { useParams } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { authenticatedUserFactory } from '../services/data/__factories__';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { queryClient } from '../../../../utils/tests';
+import { fetchEnterpriseLearnerData } from '../services';
+import { useEnterpriseLearner } from './index';
+
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchEnterpriseLearnerData: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
+const mockAuthenticatedUser = authenticatedUserFactory();
+const mockEnterpriseLearnerData = {
+  enterpriseCustomer: {
+    uuid: 'test-enterprise-customer',
+    slug: 'test-enterprise-slug',
+  },
+  enterpriseCustomerUserRoleAssignments: [],
+  activeEnterpriseCustomer: null,
+  activeEnterpriseCustomerUserRoleAssignments: [],
+  allLinkedEnterpriseCustomerUsers: [],
+  enterpriseFeatures: {},
+  staffEnterpriseCustomer: null,
+};
+
+describe('useEnterpriseCustomer', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+        {children}
+      </AppContext.Provider>
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchEnterpriseLearnerData.mockResolvedValue(mockEnterpriseLearnerData);
+    useParams.mockReturnValue({ enterpriseSlug: 'test-enterprise-slug' });
+  });
+  it('should return nested hook value correctly', async () => {
+    const {
+      result,
+      waitForNextUpdate,
+    } = renderHook(() => useEnterpriseLearner(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockEnterpriseLearnerData,
+      }),
+    );
+  });
+  it('should handle parent hook return value correctly', async () => {
+    const EnterpriseCustomer = () => {
+      const { data: enterpriseCustomer } = useEnterpriseCustomer();
+      return (
+        <>
+          <div>{enterpriseCustomer?.uuid}</div>
+          <div>{enterpriseCustomer?.slug}</div>
+        </>
+      );
+    };
+
+    render(
+      <Wrapper>
+        <EnterpriseCustomer />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(mockEnterpriseLearnerData.enterpriseCustomer.uuid)).toBeTruthy();
+      expect(screen.getByText(mockEnterpriseLearnerData.enterpriseCustomer.slug)).toBeTruthy();
+    });
+  });
+  it('should handle parent hook return value correctly with select', async () => {
+    const EnterpriseCustomer = ({ queryOptions }) => {
+      const { data: enterpriseCustomer } = useEnterpriseCustomer(queryOptions);
+      return (
+        <>
+          <div>{JSON.stringify(enterpriseCustomer?.original)}</div>
+          <div>{JSON.stringify(enterpriseCustomer?.transformed)}</div>
+        </>
+      );
+    };
+
+    render(
+      <Wrapper>
+        <EnterpriseCustomer queryOptions={{ select: (data) => data }} />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(JSON.stringify(mockEnterpriseLearnerData))).toBeTruthy();
+      expect(screen.getByText(JSON.stringify(mockEnterpriseLearnerData.enterpriseCustomer))).toBeTruthy();
+    });
+  });
+});

--- a/src/components/app/data/hooks/useEnterpriseCustomerContainsContent.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseCustomerContainsContent.test.jsx
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { enterpriseCustomerFactory } from '../services/data/__factories__';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { queryClient } from '../../../../utils/tests';
+import { fetchEnterpriseCustomerContainsContent } from '../services';
+import useEnterpriseCustomerContainsContent from './useEnterpriseCustomerContainsContent';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchEnterpriseCustomerContainsContent: jest.fn().mockResolvedValue(null),
+}));
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockEnterpriseCustomerContainsContent = {
+  containsContentItems: false,
+  catalogList: [],
+};
+
+describe('useEnterpriseCustomerContainsContent', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchEnterpriseCustomerContainsContent.mockResolvedValue(mockEnterpriseCustomerContainsContent);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useEnterpriseCustomerContainsContent(),
+      { wrapper: Wrapper },
+    );
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockEnterpriseCustomerContainsContent,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useEnterpriseFeatures.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseFeatures.test.jsx
@@ -3,10 +3,9 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { AppContext } from '@edx/frontend-platform/react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { authenticatedUserFactory } from '../services/data/__factories__';
-import useEnterpriseCustomer from './useEnterpriseCustomer';
 import { queryClient } from '../../../../utils/tests';
 import { fetchEnterpriseLearnerData } from '../services';
-import { useEnterpriseLearner } from './index';
+import { useEnterpriseFeatures, useEnterpriseLearner } from './index';
 
 jest.mock('../services', () => ({
   ...jest.requireActual('../services'),
@@ -22,11 +21,13 @@ const mockEnterpriseLearnerData = {
   activeEnterpriseCustomer: null,
   activeEnterpriseCustomerUserRoleAssignments: [],
   allLinkedEnterpriseCustomerUsers: [],
-  enterpriseFeatures: {},
+  enterpriseFeatures: {
+    featurePrequerySearchSuggestions: true,
+  },
   staffEnterpriseCustomer: null,
 };
 
-describe('useEnterpriseCustomer', () => {
+describe('useEnterpriseFeatures', () => {
   const Wrapper = ({ children }) => (
     <QueryClientProvider client={queryClient()}>
       <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
@@ -50,46 +51,21 @@ describe('useEnterpriseCustomer', () => {
       }),
     );
   });
-  it('should handle parent hook return value correctly', async () => {
-    const EnterpriseCustomer = () => {
-      const { data: enterpriseCustomer } = useEnterpriseCustomer();
-      return (
-        <>
-          <div>{enterpriseCustomer?.uuid}</div>
-          <div>{enterpriseCustomer?.slug}</div>
-        </>
-      );
-    };
-
-    render(
-      <Wrapper>
-        <EnterpriseCustomer />
-      </Wrapper>,
-    );
-    await waitFor(() => {
-      expect(screen.getByText(mockEnterpriseLearnerData.enterpriseCustomer.uuid)).toBeTruthy();
-      expect(screen.getByText(mockEnterpriseLearnerData.enterpriseCustomer.slug)).toBeTruthy();
-    });
-  });
   it('should handle parent hook return value correctly with select', async () => {
-    const EnterpriseCustomer = ({ queryOptions }) => {
-      const { data: enterpriseCustomer } = useEnterpriseCustomer(queryOptions);
+    const EnterpriseFeatures = ({ queryOptions }) => {
+      const { data: enterpriseFeatures } = useEnterpriseFeatures(queryOptions);
       return (
-        <>
-          <div>{JSON.stringify(enterpriseCustomer?.original)}</div>
-          <div>{JSON.stringify(enterpriseCustomer?.transformed)}</div>
-        </>
+        <div>{JSON.stringify(enterpriseFeatures)}</div>
       );
     };
 
     render(
       <Wrapper>
-        <EnterpriseCustomer queryOptions={{ select: (data) => data }} />
+        <EnterpriseFeatures queryOptions={{ select: (data) => data }} />
       </Wrapper>,
     );
     await waitFor(() => {
-      expect(screen.getByText(JSON.stringify(mockEnterpriseLearnerData))).toBeTruthy();
-      expect(screen.getByText(JSON.stringify(mockEnterpriseLearnerData.enterpriseCustomer))).toBeTruthy();
+      expect(screen.getByText(JSON.stringify(mockEnterpriseLearnerData.enterpriseFeatures))).toBeTruthy();
     });
   });
 });

--- a/src/components/app/data/hooks/useEnterpriseLearner.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseLearner.test.jsx
@@ -1,18 +1,20 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { AppContext } from '@edx/frontend-platform/react';
-import { authenticatedUserFactory, enterpriseCustomerFactory } from '../services/data/__factories__';
-import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { useParams } from 'react-router-dom';
+import { authenticatedUserFactory } from '../services/data/__factories__';
 import { queryClient } from '../../../../utils/tests';
 import { fetchEnterpriseLearnerData } from '../services';
 import useEnterpriseLearner from './useEnterpriseLearner';
 
-jest.mock('./useEnterpriseCustomer');
 jest.mock('../services', () => ({
   ...jest.requireActual('../services'),
   fetchEnterpriseLearnerData: jest.fn().mockResolvedValue(null),
 }));
-const mockEnterpriseCustomer = enterpriseCustomerFactory();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
 const mockAuthenticatedUser = authenticatedUserFactory();
 const mockEnterpriseLearnerData = {
   enterpriseCustomer: {
@@ -37,8 +39,8 @@ describe('useEnterpriseLearner', () => {
   );
   beforeEach(() => {
     jest.clearAllMocks();
-    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     fetchEnterpriseLearnerData.mockResolvedValue(mockEnterpriseLearnerData);
+    useParams.mockReturnValue({ enterpriseSlug: 'test-slug' });
   });
   it('should handle resolved value correctly', async () => {
     const { result, waitForNextUpdate } = renderHook(() => useEnterpriseLearner(), { wrapper: Wrapper });

--- a/src/components/app/data/hooks/useEnterpriseLearner.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseLearner.test.jsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { AppContext } from '@edx/frontend-platform/react';
 import { useParams } from 'react-router-dom';
-import { authenticatedUserFactory } from '../services/data/__factories__';
+import { authenticatedUserFactory, enterpriseCustomerFactory } from '../services/data/__factories__';
 import { queryClient } from '../../../../utils/tests';
 import { fetchEnterpriseLearnerData } from '../services';
 import useEnterpriseLearner from './useEnterpriseLearner';
@@ -15,12 +15,10 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: jest.fn(),
 }));
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
 const mockAuthenticatedUser = authenticatedUserFactory();
 const mockEnterpriseLearnerData = {
-  enterpriseCustomer: {
-    uuid: 'test-enterprise-customer',
-    slug: 'test-enterprise-slug',
-  },
+  enterpriseCustomer: mockEnterpriseCustomer,
   enterpriseCustomerUserRoleAssignments: [],
   activeEnterpriseCustomer: null,
   activeEnterpriseCustomerUserRoleAssignments: [],
@@ -40,7 +38,7 @@ describe('useEnterpriseLearner', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     fetchEnterpriseLearnerData.mockResolvedValue(mockEnterpriseLearnerData);
-    useParams.mockReturnValue({ enterpriseSlug: 'test-slug' });
+    useParams.mockReturnValue({ enterpriseSlug: mockEnterpriseCustomer.slug });
   });
   it('should handle resolved value correctly', async () => {
     const { result, waitForNextUpdate } = renderHook(() => useEnterpriseLearner(), { wrapper: Wrapper });

--- a/src/components/app/data/hooks/useEnterpriseLearner.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseLearner.test.jsx
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { AppContext } from '@edx/frontend-platform/react';
+import { authenticatedUserFactory, enterpriseCustomerFactory } from '../services/data/__factories__';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { queryClient } from '../../../../utils/tests';
+import { fetchEnterpriseLearnerData } from '../services';
+import useEnterpriseLearner from './useEnterpriseLearner';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchEnterpriseLearnerData: jest.fn().mockResolvedValue(null),
+}));
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockAuthenticatedUser = authenticatedUserFactory();
+const mockEnterpriseLearnerData = {
+  enterpriseCustomer: {
+    uuid: 'test-enterprise-customer',
+    slug: 'test-enterprise-slug',
+  },
+  enterpriseCustomerUserRoleAssignments: [],
+  activeEnterpriseCustomer: null,
+  activeEnterpriseCustomerUserRoleAssignments: [],
+  allLinkedEnterpriseCustomerUsers: [],
+  enterpriseFeatures: {},
+  staffEnterpriseCustomer: null,
+};
+
+describe('useEnterpriseLearner', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+        {children}
+      </AppContext.Provider>
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchEnterpriseLearnerData.mockResolvedValue(mockEnterpriseLearnerData);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useEnterpriseLearner(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockEnterpriseLearnerData,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useEnterpriseOffers.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseOffers.test.jsx
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { enterpriseCustomerFactory } from '../services/data/__factories__';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { queryClient } from '../../../../utils/tests';
+import { fetchEnterpriseOffers } from '../services';
+import useEnterpriseOffers from './useEnterpriseOffers';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchEnterpriseOffers: jest.fn().mockResolvedValue(null),
+}));
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockEnterpriseOffers = [{
+  discount_value: 100,
+  end_datetime: '2023-01-06T00:00:00Z',
+  enterprise_catalog_uuid: 'uuid',
+  id: 1,
+  max_discount: 200,
+  remaining_balance: 200,
+  start_datetime: '2022-06-09T00:00:00Z',
+  usage_type: 'Percentage',
+  is_current: true,
+}];
+
+describe('useEnterpriseOffers', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchEnterpriseOffers.mockResolvedValue(mockEnterpriseOffers);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useEnterpriseOffers(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockEnterpriseOffers,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useEnterprisePathwaysList.test.jsx
+++ b/src/components/app/data/hooks/useEnterprisePathwaysList.test.jsx
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { enterpriseCustomerFactory } from '../services/data/__factories__';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { queryClient } from '../../../../utils/tests';
+import { fetchInProgressPathways } from '../services';
+import useEnterprisePathwaysList from './useEnterprisePathwaysList';
+import learnerPathwayData from '../../../pathway-progress/data/__mocks__/PathwayProgressListData.json';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchInProgressPathways: jest.fn().mockResolvedValue(null),
+}));
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const camelCasedLearnerPathwayData = camelCaseObject(learnerPathwayData);
+describe('useEnterprisePathwaysList', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchInProgressPathways.mockResolvedValue(camelCasedLearnerPathwayData);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useEnterprisePathwaysList(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: camelCasedLearnerPathwayData,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useEnterpriseProgramsList.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseProgramsList.test.jsx
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { enterpriseCustomerFactory } from '../services/data/__factories__';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { queryClient } from '../../../../utils/tests';
+import { fetchLearnerProgramsList } from '../services';
+import useEnterpriseProgramsList from './useEnterpriseProgramsList';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchLearnerProgramsList: jest.fn().mockResolvedValue(null),
+}));
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockProgramsListData = [
+  {
+    uuid: 'test-uuid',
+    title: 'Test Program Title',
+    type: 'MicroMasters',
+    bannerImage: {
+      large: {
+        url: 'www.example.com/large',
+        height: 123,
+        width: 455,
+      },
+      medium: {
+        url: 'www.example.com/medium',
+        height: 123,
+        width: 455,
+      },
+      small: {
+        url: 'www.example.com/small',
+        height: 123,
+        width: 455,
+      },
+      xSmall: {
+        url: 'www.example.com/xSmall',
+        height: 123,
+        width: 455,
+      },
+    },
+    authoringOrganizations: [
+      {
+        key: 'test-key',
+        logoImageUrl: '/media/organization/logos/shield.png',
+      },
+    ],
+    progress: {
+      inProgress: 1,
+      completed: 2,
+      notStarted: 3,
+    },
+  },
+];
+describe('useEnterpriseProgramsList', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchLearnerProgramsList.mockResolvedValue(mockProgramsListData);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useEnterpriseProgramsList(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockProgramsListData,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useLearnerPathwayProgressData.test.jsx
+++ b/src/components/app/data/hooks/useLearnerPathwayProgressData.test.jsx
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { queryClient } from '../../../../utils/tests';
+import { fetchPathwayProgressDetails } from '../services';
+import { useLearnerPathwayProgressData } from './index';
+import LearnerPathwayProgressData from '../../../pathway-progress/data/__mocks__/PathwayProgressListData.json';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchPathwayProgressDetails: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
+const mockLearnerPathwayProgressData = camelCaseObject(LearnerPathwayProgressData)[0].learnerPathwayProgress;
+describe('useEnterpriseProgramsList', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchPathwayProgressDetails.mockResolvedValue(mockLearnerPathwayProgressData);
+    useParams.mockReturnValue({ courseKey: 'edX+DemoX' });
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useLearnerPathwayProgressData(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockLearnerPathwayProgressData,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useLearnerProgramProgressData.test.jsx
+++ b/src/components/app/data/hooks/useLearnerProgramProgressData.test.jsx
@@ -1,22 +1,27 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
-import { camelCaseObject } from '@edx/frontend-platform';
 import { queryClient } from '../../../../utils/tests';
-import { fetchPathwayProgressDetails } from '../services';
-import { useLearnerPathwayProgressData } from './index';
-import LearnerPathwayProgressData from '../../../pathway-progress/data/__mocks__/PathwayProgressListData.json';
+import { fetchLearnerProgramProgressDetail } from '../services';
+import useLearnerProgramProgressData from './useLearnerProgramProgressData';
 
 jest.mock('../services', () => ({
   ...jest.requireActual('../services'),
-  fetchPathwayProgressDetails: jest.fn().mockResolvedValue(null),
+  fetchLearnerProgramProgressDetail: jest.fn().mockResolvedValue(null),
 }));
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: jest.fn(),
 }));
-const mockLearnerPathwayProgressData = camelCaseObject(LearnerPathwayProgressData)[0].learnerPathwayProgress;
-describe('useLearnerPathwayProgressData', () => {
+const mockLearnerProgramProgressData = {
+  certificateData: [],
+  courseData: null,
+  creditPathways: [],
+  industryPathways: [],
+  programData: null,
+  urls: null,
+};
+describe('useLearnerProgramProgressData', () => {
   const Wrapper = ({ children }) => (
     <QueryClientProvider client={queryClient()}>
       {children}
@@ -24,16 +29,16 @@ describe('useLearnerPathwayProgressData', () => {
   );
   beforeEach(() => {
     jest.clearAllMocks();
-    fetchPathwayProgressDetails.mockResolvedValue(mockLearnerPathwayProgressData);
-    useParams.mockReturnValue({ pathwayUUID: 'test-pathway-uuid' });
+    fetchLearnerProgramProgressDetail.mockResolvedValue(mockLearnerProgramProgressData);
+    useParams.mockReturnValue({ programUUID: 'test-program-uuid' });
   });
   it('should handle resolved value correctly', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useLearnerPathwayProgressData(), { wrapper: Wrapper });
+    const { result, waitForNextUpdate } = renderHook(() => useLearnerProgramProgressData(), { wrapper: Wrapper });
     await waitForNextUpdate();
 
     expect(result.current).toEqual(
       expect.objectContaining({
-        data: mockLearnerPathwayProgressData,
+        data: mockLearnerProgramProgressData,
         isLoading: false,
         isFetching: false,
       }),

--- a/src/components/app/data/hooks/useLearnerSkillLevels.test.jsx
+++ b/src/components/app/data/hooks/useLearnerSkillLevels.test.jsx
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '../../../../utils/tests';
+import { fetchLearnerSkillLevels } from '../services';
+import useLearnerSkillLevels from './useLearnerSkillLevels';
+
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchLearnerSkillLevels: jest.fn().mockResolvedValue(null),
+}));
+const mockLearnerSkillLevels = [
+  'introductory',
+];
+describe('useLearnerSkillLevels', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchLearnerSkillLevels.mockResolvedValue(mockLearnerSkillLevels);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useLearnerSkillLevels(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockLearnerSkillLevels,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useProgramDetails.test.jsx
+++ b/src/components/app/data/hooks/useProgramDetails.test.jsx
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { queryClient } from '../../../../utils/tests';
+import { fetchProgramDetails } from '../services';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { enterpriseCustomerFactory } from '../services/data/__factories__';
+import useProgramDetails from './useProgramDetails';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchProgramDetails: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockProgramDetails = {
+  title: 'Test Program Title',
+  courses: [
+    {
+      key: 'edX+DemoX',
+      title: 'Test Course 1 Title',
+      shortDescription: 'Test course 1 description',
+      courseRuns: [
+        {
+          title: 'Test Course Run 1 Title',
+          start: '2013-02-05T05:00:00Z',
+          shortDescription: 'Test course 1 description',
+        },
+      ],
+      enterpriseHasCourse: true,
+    },
+  ],
+  catalogContainsProgram: false,
+};
+describe('useProgramDetails', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchProgramDetails.mockResolvedValue(mockProgramDetails);
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    useParams.mockReturnValue({ programUUID: 'test-program-uuid' });
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useProgramDetails(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockProgramDetails,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useRedeemablePolicies.test.jsx
+++ b/src/components/app/data/hooks/useRedeemablePolicies.test.jsx
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { AppContext } from '@edx/frontend-platform/react';
+import dayjs from 'dayjs';
+import { authenticatedUserFactory, enterpriseCustomerFactory } from '../services/data/__factories__';
+import { queryClient } from '../../../../utils/tests';
+import { fetchRedeemablePolicies } from '../services';
+import useRedeemablePolicies from './useRedeemablePolicies';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchRedeemablePolicies: jest.fn().mockResolvedValue(null),
+}));
+
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockAuthenticatedUser = authenticatedUserFactory();
+const mockSubsidyExpirationDate = dayjs().add(1, 'year').toISOString();
+const mockContentAssignment = {
+  uuid: 'test-assignment-uuid',
+  state: 'allocated',
+};
+const redeemablePolicies = [
+  {
+    id: 123,
+    subsidyExpirationDate: mockSubsidyExpirationDate,
+  },
+  {
+    id: 456,
+    subsidyExpirationDate: mockSubsidyExpirationDate,
+    learnerContentAssignments: [mockContentAssignment],
+  },
+];
+const expectedTransformedPolicies = redeemablePolicies.map((policy) => ({
+  ...policy,
+  learnerContentAssignments: policy.learnerContentAssignments?.map((assignment) => ({
+    ...assignment,
+    subsidyExpirationDate: policy.subsidyExpirationDate,
+  })),
+}));
+const mockContentAssignmentWithSubsidyExpiration = {
+  ...mockContentAssignment,
+  subsidyExpirationDate: mockSubsidyExpirationDate,
+};
+const mockRedeemablePolicies = {
+  redeemablePolicies: expectedTransformedPolicies,
+  learnerContentAssignments: {
+    acceptedAssignments: [],
+    allocatedAssignments: [mockContentAssignmentWithSubsidyExpiration],
+    assignments: [mockContentAssignmentWithSubsidyExpiration],
+    assignmentsForDisplay: [mockContentAssignmentWithSubsidyExpiration],
+    canceledAssignments: [],
+    erroredAssignments: [],
+    expiredAssignments: [],
+    hasAcceptedAssignments: false,
+    hasAllocatedAssignments: true,
+    hasAssignments: true,
+    hasAssignmentsForDisplay: true,
+    hasCanceledAssignments: false,
+    hasErroredAssignments: false,
+    hasExpiredAssignments: false,
+  },
+};
+
+describe('useRedeemablePolicies', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+        {children}
+      </AppContext.Provider>
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchRedeemablePolicies.mockResolvedValue(mockRedeemablePolicies);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useRedeemablePolicies(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockRedeemablePolicies,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useSubscriptions.test.jsx
+++ b/src/components/app/data/hooks/useSubscriptions.test.jsx
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { enterpriseCustomerFactory } from '../services/data/__factories__';
+import { queryClient } from '../../../../utils/tests';
+import { fetchSubscriptions } from '../services';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import useSubscriptions from './useSubscriptions';
+import { LICENSE_STATUS } from '../../../enterprise-user-subsidy/data/constants';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchSubscriptions: jest.fn().mockResolvedValue(null),
+}));
+
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const licensesByStatus = {
+  [LICENSE_STATUS.ACTIVATED]: [],
+  [LICENSE_STATUS.ASSIGNED]: [],
+  [LICENSE_STATUS.REVOKED]: [],
+};
+const mockSubscriptionsData = {
+  subscriptionLicenses: [],
+  customerAgreement: null,
+  subscriptionLicense: null,
+  subscriptionPlan: null,
+  licensesByStatus,
+  showExpirationNotifications: false,
+  shouldShowActivationSuccessMessage: false,
+};
+
+describe('useSubscriptions', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchSubscriptions.mockResolvedValue(mockSubscriptionsData);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useSubscriptions(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockSubscriptionsData,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useUserEntitlements.test.jsx
+++ b/src/components/app/data/hooks/useUserEntitlements.test.jsx
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '../../../../utils/tests';
+import { fetchUserEntitlements } from '../services';
+import useUserEntitlements from './useUserEntitlements';
+
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchUserEntitlements: jest.fn().mockResolvedValue(null),
+}));
+const mockUserEntitlements = [
+  'test-entitlement',
+];
+describe('useUserEntitlements', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchUserEntitlements.mockResolvedValue(mockUserEntitlements);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useUserEntitlements(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockUserEntitlements,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Adds the following tests to improve code coverage, follow up to previous code coverage PR https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/1055:

useContentHighlightSets
useCouponCodes
useCourseMetadata
useCourseRecommendations
useCourseReviews
useEnterpriseCustomerContainsContent
useEnterpriseLearner
useEnterpriseCustomer
useEnterpriseFeatures
useEnterpriseOffers
useEnterprisePathwaysList
useEnterpriseProgramsList
useLearnerPathwayProgressData
useLearnerProgramProgressData
useProgramDetails
useLearnerSkillLevels
useRedeemablePolicies
useSubscriptions
useUserEntitlements
useCanOnlyViewHighlights

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
