### PR TITLE
fix: use the selected course run to determine start date

### DIFF
--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -687,7 +687,7 @@ export function useMinimalCourseMetadata() {
           marketingUrl: organizationDetails.organizationMarketingUrl,
         },
         title: transformed.title,
-        startDate: getCourseStartDate({ contentMetadata: transformed, courseRun: activeCourseRun }),
+        startDate: getCourseStartDate({ contentMetadata: transformed, courseRun }),
         duration: getDuration(),
         priceDetails: {
           price: coursePrice.list,


### PR DESCRIPTION
This typo was missed in part due to not being able to unit test query select callback functions.