### PR TITLE
fix: useMinimalCourseMetadata - search for run among ALL runs

### DIFF
--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -667,8 +667,8 @@ export function useMinimalCourseMetadata() {
   const { coursePrice, currency } = useCoursePrice();
   return useCourseMetadata({
     select: ({ transformed }) => {
-      const { activeCourseRun, availableCourseRuns } = transformed;
-      const courseRun = availableCourseRuns.find(run => run.key === courseRunKey) || activeCourseRun;
+      const { activeCourseRun, courseRuns } = transformed;
+      const courseRun = courseRuns.find(run => run.key === courseRunKey) || activeCourseRun;
       const organizationDetails = getCourseOrganizationDetails(transformed);
       const getDuration = () => {
         if (!courseRun) {


### PR DESCRIPTION
The only consumer of this hook is currently external enrollment pages, and those actually need the metadata from the requested course run without hiding "unavailable" ones, due to the nature of this particular route being used for late enrollment.

ENT-8780