### PR TITLE
fix: remove all remaining usages of additional_metadata

### DIFF
--- a/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
+++ b/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
@@ -26,20 +26,18 @@ const messages = defineMessages({
  * Determines the heading to display on the course run card.
  * @param {object} args
  * @param {boolean} args.isCourseRunCurrent Whether the course run is current.
- * @param {object} args.course Data about the course for the course run card.
  * @param {object} args.courseRun Data about the course run for the course run card.
  * @param {boolean} args.isUserEnrolled Whether the user is already enrolled in the course run.
  * @returns {string} The heading to display on the course run card.
  */
 const useCourseRunCardHeading = ({
   isCourseRunCurrent,
-  course,
   courseRun,
   isUserEnrolled,
 }) => {
   const intl = useIntl();
 
-  const courseStartDate = getCourseStartDate({ contentMetadata: course, courseRun });
+  const courseStartDate = getCourseStartDate({ courseRun });
 
   // check whether the course run is current based on its `availability` or whether
   // the start date is indeed in the past. As of this implementation, the `availability`

--- a/src/components/course/course-header/deprecated/CourseRunCard.jsx
+++ b/src/components/course/course-header/deprecated/CourseRunCard.jsx
@@ -28,7 +28,6 @@ import { determineEnrollmentType } from '../../enrollment/utils';
 import {
   COURSE_AVAILABILITY_MAP,
   isArchived,
-  useCourseMetadata,
   useEnterpriseCustomer,
   useSubscriptions,
 } from '../../../app/data';
@@ -61,10 +60,9 @@ const CourseRunCard = ({
   });
   const location = useLocation();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const { data: courseMetadata } = useCourseMetadata();
   const userCanRequestSubsidyForCourse = useCanUserRequestSubsidyForCourse();
 
-  const courseStartDate = getCourseStartDate({ contentMetadata: courseMetadata, courseRun });
+  const courseStartDate = getCourseStartDate({ courseRun });
 
   const isCourseStarted = useMemo(
     () => hasCourseStarted(courseStartDate),

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -687,7 +687,7 @@ export function useMinimalCourseMetadata() {
           marketingUrl: organizationDetails.organizationMarketingUrl,
         },
         title: transformed.title,
-        startDate: getCourseStartDate({ contentMetadata: transformed, courseRun }),
+        startDate: getCourseStartDate({ courseRun }),
         duration: getDuration(),
         priceDetails: {
           price: coursePrice.list,

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -257,7 +257,6 @@ describe('useCourseEnrollmentUrl', () => {
           'executive-education-2u': {
             pathSlug: 'executive-education-2u',
             usesEntitlementListPrice: true,
-            useAdditionalMetadata: true,
           },
         },
       });

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -39,7 +39,6 @@ jest.mock('@edx/frontend-platform', () => ({
       'executive-education-2u': {
         pathSlug: 'executive-education-2u',
         usesEntitlementListPrice: true,
-        usesAdditionalMetadata: true,
       },
     },
   }),
@@ -434,39 +433,9 @@ describe('getLinkToCourse', () => {
 });
 
 describe('getCourseStartDate tests', () => {
-  it('Validate additionalMetadata gets priority in course start date calculation', async () => {
-    const mockAdditionalMetadataStartDate = '2023-06-10T12:00:00Z';
-    const startDate = getCourseStartDate({
-      contentMetadata: {
-        additionalMetadata: {
-          startDate: mockAdditionalMetadataStartDate,
-        },
-        courseType: 'executive-education-2u',
-      },
-      courseRun: {
-        start: '2022-03-08T12:00:00Z',
-      },
-    });
-    expect(startDate).toMatch(mockAdditionalMetadataStartDate);
-  });
-
-  it('Validate active course run\'s start date is used when additionalMetadata is null.', async () => {
-    const mockCourseRuStartDate = '2022-03-08T12:00:00Z';
-    const startDate = getCourseStartDate({
-      contentMetadata: {
-        additionalMetadata: null,
-        courseType: 'executive-education-2u',
-      },
-      courseRun: {
-        start: mockCourseRuStartDate,
-      },
-    });
-    expect(startDate).toMatch(mockCourseRuStartDate);
-  });
-
   it('Validate getCourseDate handles empty data for course run and course metadata.', async () => {
     const startDate = getCourseStartDate(
-      { contentMetadata: null, courseRun: null },
+      { courseRun: null },
     );
     expect(startDate).toBe(undefined);
   });

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -877,28 +877,17 @@ export const getCourseOrganizationDetails = (courseData) => {
 };
 
 /**
- * Determines the start date for the the course run, pulling the appropriate date
- * from either `contentMetadata.additionalMetadata.startDate` or `courseRun.start`
- * based on the course type configuration.
+ * Determines the start date for the the course run, pulling ONLY from the metadata of the run.
+ *
+ * Historically, for some course types we would derive certain fields from `contentMetadata.additionalMetadata`, but now
+ * that additionalMetadata is being phased out we only read from course run metadata.
  *
  * @param {Object} args
- * @param {Object} args.contentMetadata
  * @param {Object} args.courseRun
  *
  * @returns {string|undefined} Formatted date if a start date was found; otherwise, undefined.
  */
-export const getCourseStartDate = ({ contentMetadata, courseRun }) => {
-  let startDate;
-  const courseTypeConfig = contentMetadata && getCourseTypeConfig(contentMetadata);
-
-  if (courseTypeConfig?.usesAdditionalMetadata && contentMetadata?.additionalMetadata) {
-    startDate = contentMetadata.additionalMetadata.startDate;
-  } else {
-    startDate = courseRun?.start;
-  }
-
-  return startDate;
-};
+export const getCourseStartDate = ({ courseRun }) => courseRun?.start;
 
 export function processCourseSubjects(course) {
   const config = getConfig();


### PR DESCRIPTION
This results in reading course start dates from the run metadata instead of `additional_metadata` when evaluating Exec Ed runs.

In prod, this should be a no-op because the `start_date` key inside `additional_metadata` is exactly the same as the value of `start` for all 220 Exec Ed runs.

ENT-8780

Companion PR: https://github.com/edx/edx-internal/pull/10640

Testing performed
===
I was able to at least confirm that when I hooked up my local MFE to stage data, the one Exec Ed course still works:

```
https://localhost.stage.edx.org:8734/troy-test-5/executive-education-2u/course/OxfordX+LSC/enroll/course-v1:OxfordX+LSC+1T2024
```

<img width="1221" alt="Screenshot 2024-04-16 at 14 33 50" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/85151/cbcd2480-d48f-4a3f-b096-ff228957150a">
