### PR TITLE
[ENT-8680]: style and text changes on the academy detail page

### DIFF
--- a/src/components/academies/AcademyContentCard.jsx
+++ b/src/components/academies/AcademyContentCard.jsx
@@ -109,6 +109,22 @@ const AcademyContentCard = ({
     }
     return showAllOcmCourses;
   };
+
+  const toggleButtonText = (showMoreBtnEnabled, contentType, title, contentLength) => {
+    if (showMoreBtnEnabled) {
+      return intl.formatMessage({
+        id: 'academy.detail.page.show.less.button.text',
+        defaultMessage: '< Show less {title} courses',
+        description: 'Text for the show less button on academy detail page.',
+      }, { title });
+    }
+    return intl.formatMessage({
+      id: 'academy.detail.page.show.more.button.text',
+      defaultMessage: 'Show more {title} courses ({contentLength}) >',
+      description: 'Text for the show more button on academy detail page.',
+    }, { title, contentLength });
+  };
+
   const renderableContent = ({
     content,
     contentLength,
@@ -125,8 +141,8 @@ const AcademyContentCard = ({
 
     return (
       <div className={additionalClass}>
-        <div className="d-flex flex-row align-items-center justify-content-between">
-          <h3 data-testid={titleTestId}>{title}</h3>
+        <div className="d-flex flex-row align-items-center justify-content-between mt-5">
+          <h3 data-testid={titleTestId} className="font-weight-normal">{title}</h3>
           {contentType !== LEARNING_TYPE_PATHWAY && contentLength > 4 && (
             <Button
               className=""
@@ -134,7 +150,7 @@ const AcademyContentCard = ({
               size="xl"
               onClick={toggleShowMore(contentType)}
             >
-              {showMoreButton(contentType) ? '< Show Less' : `Show More (${contentLength}) >`}
+              { toggleButtonText(showMoreButton(contentType), contentType, title, contentLength) }
             </Button>
           )}
         </div>

--- a/src/components/academies/AcademyDetailPage.jsx
+++ b/src/components/academies/AcademyDetailPage.jsx
@@ -5,9 +5,10 @@ import {
 import {
   useParams, Link,
 } from 'react-router-dom';
-import { useIntl } from '@edx/frontend-platform/i18n';
+import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 import algoliasearch from 'algoliasearch/lite';
 import { getConfig } from '@edx/frontend-platform/config';
+import { ArrowDownward } from '@openedx/paragon/icons';
 import NotFoundPage from '../NotFoundPage';
 import './styles/Academy.scss';
 import AcademyContentCard from './AcademyContentCard';
@@ -64,12 +65,53 @@ const AcademyDetailPage = () => {
           />
         </div>
         <div>
-          <h2 data-testid="academy-title" className="mb-3 mt-3">{academy?.title}</h2>
-          <p data-testid="academy-description">{academy?.longDescription}</p>
+          <h1 data-testid="academy-title" className="mb-4 mt-3 font-italic text-left academy-title">
+            <FormattedMessage
+              id="academy.detail.page.academy.title"
+              defaultMessage="{academyTitle} Academy"
+              description="Title for the academy on the academy detail page"
+              values={{ academyTitle: academy?.title || 'Academy' }}
+            />
+          </h1>
+          <div>
+            <h3 data-testid="academy-instruction-header">
+              <FormattedMessage
+                id="academy.detail.page.instruction.header"
+                defaultMessage="Follow a recommended pathway - or select individual courses"
+                description="Header for pathways and course selection instructions in a specific academy on the academy detail page"
+              />
+            </h3>
+            <p data-testid="academy-instruction-description">
+              <FormattedMessage
+                id="academy.detail.page.instruction.description"
+                defaultMessage="Pathways are curated roadmaps through the academy’s content designed specifically for your learning goals. Or select a specific course from Executive Education or Self-paced courses in this Academy."
+                description="Description for pathways and course selection in a specific academy on the academy detail page"
+              />
+            </p>
+          </div>
+          <div data-testid="academies-jump-link" className="mt-3 mb-4 text-right mr-5">
+            <Link to="#academy-all-courses">
+              <FormattedMessage
+                id="academy.detail.page.view.all.courses.link"
+                defaultMessage="View all {academyTitle} Academy Courses"
+                description="Link text to view all courses for a specific academy on the academy detail page"
+                values={{ academyTitle: academy?.title || '' }}
+              />
+              <ArrowDownward />
+            </Link>
+          </div>
         </div>
       </Container>
       {/* new pathway sectoin will come here */}
-      <Container size="lg" className="pb-4">
+      <Container size="lg" className="pb-4 mt-4">
+        <h3 id="academy-all-courses" data-testid="academy-all-courses-title">
+          <FormattedMessage
+            id="academy.detail.page.all.courses.title"
+            defaultMessage="All {academyTitle} Academy Courses"
+            description="Title for the all courses section of a specific academy on the academy detail page"
+            values={{ academyTitle: academy?.title }}
+          />
+        </h3>
         <AcademyContentCard
           courseIndex={courseIndex}
           academyUUID={academyUUID}

--- a/src/components/academies/PathwaysSection.jsx
+++ b/src/components/academies/PathwaysSection.jsx
@@ -2,7 +2,7 @@ import { Container } from '@openedx/paragon';
 import React from 'react';
 
 const PathwaysSection = () => (
-  <Container className="pathway-section">
+  <Container className="pathway-section mb-4">
     <Container size="lg" className="inner-container pr-0">
       <div className="row">
         <div className="col">

--- a/src/components/academies/styles/Academy.scss
+++ b/src/components/academies/styles/Academy.scss
@@ -78,3 +78,9 @@
     }
   }
 }
+
+.academy-title {
+  font-size: 55px;
+  line-height: 60px;
+  letter-spacing: -0.02em;
+}

--- a/src/components/academies/tests/AcademyDetailPage.test.jsx
+++ b/src/components/academies/tests/AcademyDetailPage.test.jsx
@@ -123,9 +123,9 @@ describe('<AcademyDetailPage />', () => {
   it('renders academy detail page', async () => {
     renderWithRouter(<AcademyDetailPageWrapper />);
 
-    const headingElement = await screen.findByRole('heading', { level: 2 });
-    expect(headingElement.textContent).toBe(ACADEMY_MOCK_DATA.title);
-    expect(screen.getByTestId('academy-description')).toHaveTextContent(ACADEMY_MOCK_DATA.longDescription);
+    const headingElement = await screen.getByTestId('academy-all-courses-title');
+    const expectedHeadingElement = `All ${ACADEMY_MOCK_DATA.title} Academy Courses`;
+    expect(headingElement.textContent).toBe(expectedHeadingElement);
     const academyTags = screen.getAllByTestId('academy-tag').map((tag) => tag.textContent);
     expect(academyTags).toEqual(['wowwww', 'boooo']);
     expect(screen.getByTestId('academy-exec-ed-courses-title')).toHaveTextContent('Executive Education');


### PR DESCRIPTION
### Ticket
https://2u-internal.atlassian.net/browse/ENT-8680

### Description
Style and text changes on the academy detail page as per [figma](https://www.figma.com/file/Ht9ykk12r2ZcvXjZk69pcr/Pathways-for-Academies?type=design&node-id=383-67713&mode=design&t=I6cQuEpd34GOvfH7-0)

The new pathway section hasn't been integrated yet because it will be integrated as part of [ENT-8678](https://2u-internal.atlassian.net/browse/ENT-8678)

### UI Screenshots


https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/113524403/3ed90871-83c0-48bb-95fa-3fe6dc144046



<img width="1440" alt="Screenshot 2024-04-17 at 5 45 35 PM" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/113524403/f77d1da9-9673-4a3d-b495-722e01647e4d">



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
