### PR TITLE
build: add new coverage.yml workflow github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: node_js CI
 
-on: [pull_request, workflow_dispatch]
+on: [pull_request]
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,32 @@
+name: Upload coverage for default branch
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Nodejs Env
+      run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
+    - name: Setup Nodejs
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ env.NODE_VER }}
+    - name: Install dependencies
+      run: npm ci
+    - name: Test
+      run: npm run test
+    - name: Upload Coverage
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
 
-concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Based on #1069, we were able to manually run the `ci.yml` workflow on `master` and successfully saw a coverage report generated and uploaded for most recent merged commit in CodeCov (rather than the previous stale 11 month old commit).

We then attempted to merge another commit to see if the new commit appears in CodeCov via #1070, without luck.

The next step will be to always upload coverage reports to CodeCov on commits to `master` similar to the previous manual run of the `ci.yml` file.

Instead of running `ci.yml` for commits to `master`, I've opted to create a new GitHub Action workflow file (`coverage.yml`) solely responsible for the running of CodeCov on `master`. It does NOT do the `npm run lint` or `npm run build` steps in `ci.yml` since they are not relevant to generating coverage reports (saving time for the workflow to execute).

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
