### PR TITLE
fix: block learners from accessing ExternalCourseEnrollment outside enrollment window

### DIFF
--- a/src/components/course/routes/ExternalCourseEnrollment.jsx
+++ b/src/components/course/routes/ExternalCourseEnrollment.jsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useRef } from 'react';
+import { useParams } from 'react-router-dom';
 import {
   Alert, Button, Col, Container, Hyperlink, Row,
 } from '@openedx/paragon';
@@ -15,10 +16,16 @@ import {
   useExternalEnrollmentFailureReason,
   useIsCourseAssigned,
   useMinimalCourseMetadata,
+  useUserSubsidyApplicableToCourse,
 } from '../data/hooks';
+import { LEARNER_CREDIT_SUBSIDY_TYPE } from '../data/constants';
 import ErrorPageContent from '../../executive-education-2u/components/ErrorPageContent';
 import { features } from '../../../config';
-import { useEnterpriseCustomer } from '../../app/data';
+import {
+  useCourseRedemptionEligibility,
+  useEnterpriseCustomer,
+} from '../../app/data';
+import NotFoundPage from '../../NotFoundPage';
 
 export { default as makeExternalCourseEnrollmentLoader } from './externalCourseEnrollmentLoader';
 
@@ -28,6 +35,9 @@ const ExternalCourseEnrollment = () => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const isCourseAssigned = useIsCourseAssigned();
   const { data: minimalCourseMetadata } = useMinimalCourseMetadata();
+  const { userSubsidyApplicableToCourse: { subsidyType } } = useUserSubsidyApplicableToCourse();
+  const { data: { redeemabilityPerContentKey } } = useCourseRedemptionEligibility();
+  const { courseRunKey } = useParams();
 
   const externalDashboardQueryParams = new URLSearchParams();
   if (enterpriseCustomer.authOrgId) {
@@ -52,6 +62,20 @@ const ExternalCourseEnrollment = () => {
       containerRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [externalCourseFormSubmissionError, containerRef]);
+
+  // If the course is to be redeemed via learner credit, but the specifically requested course run is not redeemable,
+  // skip straight to the 404 page.
+  //
+  // A run is not redeemable if can_redeem=False, but other situations may lead to canRedeemDataCourseRun === undefined:
+  // * The requested course run key doesn't exist.
+  // * The course run is not "available" according to rules baked into this frontend codebase, including cases where the
+  //   current date is outside the enrollment window of the run.
+  if (subsidyType === LEARNER_CREDIT_SUBSIDY_TYPE) {
+    const canRedeemDataCourseRun = redeemabilityPerContentKey.find(r => r.contentKey === courseRunKey);
+    if (!canRedeemDataCourseRun?.canRedeem) {
+      return <NotFoundPage />;
+    }
+  }
 
   return (
     <div className="fill-vertical-space page-light-bg">


### PR DESCRIPTION
BEFORE this commit: It's possible (and easy) in some cases for a learner to enroll in a course even if late enrollment feature is disabled on the policy.

The exact conditions which allow this bug to manifest:

* The current date is within 30 days after the enrollment deadline of a course run.
* The learner has been given a link to a ExternalCourseEnrollment page (i.e. T's&C's page) for that course run.
* The policy late enrollment is disabled (including cases where late enrollment was enabled, then self-expired).

AFTER this commit: The ExternalCourseEnrollment page (i.e. T's&C's page) will render a 404 page in the above case.

Side effects:
* Now, this view also returns 404 *ANY* time the requested course run is non-redeemable according to can-redeem, or the course run is "unavailable" due to the current date being outside the enrollment window.

ENT-8856

Screenshots
===

Attempting to load a page with "foo+bar" as the course run key in the URL results in 404:
![Screenshot 2024-05-02 at 14 13 59](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/85151/1418b243-1567-4d55-a062-0495d6686108)

Attempting to load a page with an archived (unavailable) run in the URL results in a 404:
![Screenshot 2024-05-02 at 14 13 04](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/85151/fce3a33c-d933-4541-8fdb-11834765b62f)

Finally, only loading a redeemable run will render the normal page:
![Screenshot 2024-05-02 at 14 12 47](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/85151/ee0e135a-1258-40c9-9ef0-4a5d3c12a98a)