### PR TITLE
fix: resolve reading properties of null flatMap JS error

### DIFF
--- a/src/components/app/data/services/enterpriseGroupMemberships.js
+++ b/src/components/app/data/services/enterpriseGroupMemberships.js
@@ -11,7 +11,7 @@ export async function fetchEnterpriseAccessPolicies(enterpriseUuid) {
     return results;
   } catch (error) {
     logError(error);
-    return null;
+    return [];
   }
 }
 


### PR DESCRIPTION
When running into the recurring issue of having the Request header size too large to access some backend services (e.g., due to known issue of being linked to too many enterprise customers), a JS error occurs in the Learner Portal preventing the UI from rendering:

![image](https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/7ea8db88-c30d-4d98-b075-71995456f683)

Because an API error is being caught and returned as `null` and then trying to access `.flatMap` on the `null`, results in the JS error.

Instead of returning `null` in the catch block, returning an empty array `[]` resolves the JS error even when the API throws an error due to the request header size.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
