### PR TITLE
ENT-8994: feat: Enabled i18n for search header component.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,10 @@ pull_translations:
 	  && atlas pull $(ATLAS_OPTIONS) \
 		translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
 		translations/paragon/src/i18n/messages:paragon \
-		translations/frontend-app-learner-portal-enterprise/src/i18n/messages:frontend-app-learner-portal-enterprise
+		translations/frontend-app-learner-portal-enterprise/src/i18n/messages:frontend-app-learner-portal-enterprise \
+		translations/frontend-enterprise/i18n/messages:frontend-enterprise
 
-	$(intl_imports) frontend-component-footer paragon frontend-app-learner-portal-enterprise
+	$(intl_imports) frontend-component-footer paragon frontend-enterprise frontend-app-learner-portal-enterprise
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
__Jira Ticket:__ [ENT-8994](https://2u-internal.atlassian.net/browse/ENT-8994)

__Description:__
This PR enabled translations for the search header component in enterprise learner portal.

**Screenshot:**
<img width="1507" alt="Screenshot 2024-05-31 at 4 12 08 PM" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/7114956/229d033d-e0e1-47b8-8f6d-ecb9dfc21540">



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
