### PR TITLE
[ENT-9016] Added data sharing consent link on exec-ed course enrollment page

### DIFF
--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -355,8 +355,19 @@ const UserEnrollmentForm = ({ className }) => {
                           <span aria-hidden>
                             <FormattedMessage
                               id="executive.education.external.course.enrollment.page.data.sharing.consent.label"
-                              defaultMessage="I have read and accepted GetSmarter's data sharing consent."
+                              defaultMessage="I have read and accepted GetSmarter's <a>data sharing consent.</a>"
                               description="Data sharing consent label for the executive education course enrollment page. And here GetSmarter is brand name"
+                              values={{
+                                // eslint-disable-next-line react/no-unstable-nested-components
+                                a: (chunks) => (
+                                  <Hyperlink
+                                    destination={config.GETSMARTER_PRIVACY_POLICY_URL}
+                                    target="_blank"
+                                  >
+                                    {chunks}
+                                  </Hyperlink>
+                                ),
+                              }}
                             />
                           </span>
                         </div>


### PR DESCRIPTION
Ticket
https://2u-internal.atlassian.net/browse/ENT-9016

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
