### PR TITLE
feat: ExternalCourseEnrollment page - handle no applicable subsidies

### DIFF
--- a/src/components/course/routes/ExternalCourseEnrollment.jsx
+++ b/src/components/course/routes/ExternalCourseEnrollment.jsx
@@ -35,7 +35,7 @@ const ExternalCourseEnrollment = () => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const isCourseAssigned = useIsCourseAssigned();
   const { data: minimalCourseMetadata } = useMinimalCourseMetadata();
-  const { userSubsidyApplicableToCourse: { subsidyType } } = useUserSubsidyApplicableToCourse();
+  const { userSubsidyApplicableToCourse } = useUserSubsidyApplicableToCourse();
   const { data: { redeemabilityPerContentKey } } = useCourseRedemptionEligibility();
   const { courseRunKey } = useParams();
 
@@ -63,6 +63,11 @@ const ExternalCourseEnrollment = () => {
     }
   }, [externalCourseFormSubmissionError, containerRef]);
 
+  // If there are absolutely no subsidy types applicable for this course, then throw a 404.
+  if (!userSubsidyApplicableToCourse) {
+    return <NotFoundPage />;
+  }
+
   // If the course is to be redeemed via learner credit, but the specifically requested course run is not redeemable,
   // skip straight to the 404 page.
   //
@@ -70,7 +75,7 @@ const ExternalCourseEnrollment = () => {
   // * The requested course run key doesn't exist.
   // * The course run is not "available" according to rules baked into this frontend codebase, including cases where the
   //   current date is outside the enrollment window of the run.
-  if (subsidyType === LEARNER_CREDIT_SUBSIDY_TYPE) {
+  if (userSubsidyApplicableToCourse.subsidyType === LEARNER_CREDIT_SUBSIDY_TYPE) {
     const canRedeemDataCourseRun = redeemabilityPerContentKey.find(r => r.contentKey === courseRunKey);
     if (!canRedeemDataCourseRun?.canRedeem) {
       return <NotFoundPage />;

--- a/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
+++ b/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
@@ -191,7 +191,7 @@ describe('ExternalCourseEnrollment', () => {
         hasSuccessfulRedemption: false,
         canRedeem: false,
       },
-      LEARNER_CREDIT_SUBSIDY_TYPE,
+      { subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE },
     ],
     // The requested course run is not included in the can-redeem response, so it is "unavailable".
     [
@@ -200,11 +200,20 @@ describe('ExternalCourseEnrollment', () => {
         hasSuccessfulRedemption: false,
         canRedeem: true, // This one happens to be redeemable, but it's moot since it's the wrong course run.
       },
-      LEARNER_CREDIT_SUBSIDY_TYPE,
+      { subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE },
     ],
-  ])('renders 404 page when appropriate', (mockCanRedeemData, mockSubsidyTypeApplicable) => {
+    // There are absolutely no subsidy types applicable to the course.
+    [
+      {
+        contentKey: 'some+other+course', // A different run than what was requested in the URL.
+        hasSuccessfulRedemption: false,
+        canRedeem: false,
+      },
+      undefined,
+    ],
+  ])('renders 404 page when appropriate', (mockCanRedeemData, mockUserSubsidyApplicableToCourse) => {
     useUserSubsidyApplicableToCourse.mockReturnValue({
-      userSubsidyApplicableToCourse: { subsidyType: mockSubsidyTypeApplicable },
+      userSubsidyApplicableToCourse: mockUserSubsidyApplicableToCourse,
       missingUserSubsidyReason: undefined,
     });
     useCourseRedemptionEligibility.mockReturnValue({


### PR DESCRIPTION
Instead of throwing a JS error, return a 404 page when there are absolutely no applicable subsidies for a given course.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
