### PR TITLE
build: set fail_ci_if_error to true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,5 @@ jobs:
     - name: Upload Coverage
       uses: codecov/codecov-action@v4
       with:
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
In an effort to standardize codecov across the org, flip fail_ci_if_error to true as per https://openedx.atlassian.net/wiki/spaces/COMM/pages/3438280709/Adding+Codecov.

See https://github.com/openedx/wg-frontend/issues/179
