### PR TITLE
feat: account for learner credit audit upgrade modal UI

### DIFF
--- a/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.js
+++ b/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.js
@@ -3,12 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { queryCanUpgradeWithLearnerCredit } from '../queries';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 
-export function isPolicyRedemptionEnabled({ canRedeemData }) {
-  const hasSuccessfulRedemption = canRedeemData?.hasSuccessfulRedemption;
-  const redeemableSubsidyAccessPolicy = canRedeemData?.redeemableSubsidyAccessPolicy;
-  return hasSuccessfulRedemption || !!redeemableSubsidyAccessPolicy;
-}
-
 /**
  * Determines whether the given courseRunKey is redeemable with their learner credit policies
  * Returns the first redeemableSubsidyAccessPolicy
@@ -21,18 +15,34 @@ export default function useCanUpgradeWithLearnerCredit(courseRunKey, queryOption
     ...queryCanUpgradeWithLearnerCredit(enterpriseCustomer.uuid, courseRunKey),
     ...queryOptionsRest,
     select: (data) => {
-      if (data.length === 0) {
-        return {
-          applicableSubsidyAccessPolicy: null,
-        };
-      }
-      return {
-        applicableSubsidyAccessPolicy: data.flatMap((canRedeemData) => ({
-          ...canRedeemData,
-          listPrice: canRedeemData?.listPrice?.usd,
-          isPolicyRedemptionEnabled: isPolicyRedemptionEnabled({ canRedeemData }),
-        }))[0],
+      // Base transformed data
+      const transformedData = {
+        applicableSubsidyAccessPolicy: null,
+        listPrice: null,
       };
+
+      // Determine whether the course run key is redeemable. If so, update the transformed data with the
+      // applicable subsidy access policy and list price.
+      const redeemableCourseRun = data.filter((canRedeemData) => (
+        canRedeemData.canRedeem && canRedeemData.redeemableSubsidyAccessPolicy
+      ))[0];
+      if (redeemableCourseRun) {
+        const applicableSubsidyAccessPolicy = redeemableCourseRun.redeemableSubsidyAccessPolicy;
+        applicableSubsidyAccessPolicy.isPolicyRedemptionEnabled = true;
+        transformedData.applicableSubsidyAccessPolicy = applicableSubsidyAccessPolicy;
+        transformedData.listPrice = redeemableCourseRun.listPrice.usd;
+      }
+
+      // When custom `select` function is provided in `queryOptions`, call it with original and transformed data.
+      if (select) {
+        return select({
+          original: data,
+          transformed: transformedData,
+        });
+      }
+
+      // Otherwise, return the transformed data.
+      return transformedData;
     },
   });
 }

--- a/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.test.jsx
+++ b/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.test.jsx
@@ -61,23 +61,37 @@ describe('useCanUpgradeWithLearnerCredit', () => {
     fetchCanRedeem.mockResolvedValue(mockCanRedeemData);
   });
 
-  it('should handle resolved value correctly', async () => {
+  it.each([
+    { hasCustomSelect: false },
+    { hasCustomSelect: true },
+  ])('should handle resolved value correctly (%s)', async ({ hasCustomSelect }) => {
+    const queryOptions = {};
+    if (hasCustomSelect) {
+      // mock the custom select transform function to simply return the same transformed data
+      queryOptions.select = jest.fn(data => data.transformed);
+    }
     const { result, waitForNextUpdate } = renderHook(
-      () => useCanUpgradeWithLearnerCredit(mockCourseRunKey),
+      () => useCanUpgradeWithLearnerCredit(mockCourseRunKey, queryOptions),
       { wrapper: Wrapper },
     );
     await waitForNextUpdate();
+    const expectedTransformedResult = {
+      applicableSubsidyAccessPolicy: {
+        ...mockCanRedeemData[0].redeemableSubsidyAccessPolicy,
+        isPolicyRedemptionEnabled: true,
+      },
+      listPrice: mockCanRedeemData[0].listPrice.usd,
+    };
+    if (hasCustomSelect) {
+      expect(queryOptions.select).toHaveBeenCalledWith({
+        original: mockCanRedeemData,
+        transformed: expectedTransformedResult,
+      });
+    }
     expect(result.current).toEqual(
       expect.objectContaining({
-        data: {
-          applicableSubsidyAccessPolicy: {
-            ...mockCanRedeemData[0].redeemableSubsidyAccessPolicy,
-            isPolicyRedemptionEnabled: true,
-          },
-          listPrice: mockCanRedeemData[0].listPrice.usd,
-        },
+        data: expectedTransformedResult,
         isLoading: false,
-        isFetching: false,
       }),
     );
   });

--- a/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.test.jsx
+++ b/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.test.jsx
@@ -48,32 +48,33 @@ const mockCanRedeemData = [{
   reasons: [],
 }];
 
+const Wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
 describe('useCanUpgradeWithLearnerCredit', () => {
-  const Wrapper = ({ children }) => (
-    <QueryClientProvider client={queryClient()}>
-      {children}
-    </QueryClientProvider>
-  );
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     fetchCanRedeem.mockResolvedValue(mockCanRedeemData);
   });
-  it('should handle resolved value correctly', async () => {
-    const {
-      result,
-      waitForNextUpdate,
-    } = renderHook(() => useCanUpgradeWithLearnerCredit(mockCourseRunKey), { wrapper: Wrapper });
-    await waitForNextUpdate();
 
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useCanUpgradeWithLearnerCredit(mockCourseRunKey),
+      { wrapper: Wrapper },
+    );
+    await waitForNextUpdate();
     expect(result.current).toEqual(
       expect.objectContaining({
         data: {
           applicableSubsidyAccessPolicy: {
-            ...mockCanRedeemData[0],
-            listPrice: mockCanRedeemData[0].listPrice.usd,
+            ...mockCanRedeemData[0].redeemableSubsidyAccessPolicy,
             isPolicyRedemptionEnabled: true,
           },
+          listPrice: mockCanRedeemData[0].listPrice.usd,
         },
         isLoading: false,
         isFetching: false,

--- a/src/components/app/data/queries/queries.js
+++ b/src/components/app/data/queries/queries.js
@@ -282,12 +282,12 @@ export function queryCanRedeem(enterpriseUuid, courseMetadata, isEnrollableBuffe
  * ._ctx.canRedeem(availableCourseRunKeys)
  * @returns {Types.QueryOptions}
  */
-export function queryCanUpgradeWithLearnerCredit(enterpriseUuid, courseRunKeys) {
+export function queryCanUpgradeWithLearnerCredit(enterpriseUuid, courseRunKey) {
   return queries
     .enterprise
     .enterpriseCustomer(enterpriseUuid)
     ._ctx.course(null)
-    ._ctx.canRedeem(courseRunKeys);
+    ._ctx.canRedeem([courseRunKey]);
 }
 
 /**

--- a/src/components/app/data/services/course.js
+++ b/src/components/app/data/services/course.js
@@ -46,7 +46,7 @@ export async function fetchCourseMetadata(courseKey, courseRunKey) {
 }
 
 export async function fetchCourseRunMetadata(courseRunKey) {
-  const courseRunMetadataUrl = `${getConfig().DISCOVERY_API_BASE_URL}/api/v1/course_runs/${courseRunKey}`;
+  const courseRunMetadataUrl = `${getConfig().DISCOVERY_API_BASE_URL}/api/v1/course_runs/${courseRunKey}/`;
   try {
     const response = await getAuthenticatedHttpClient().get(courseRunMetadataUrl);
     return camelCaseObject(response.data);

--- a/src/components/app/data/services/course.test.js
+++ b/src/components/app/data/services/course.test.js
@@ -81,7 +81,7 @@ describe('fetchCourseMetadata', () => {
 });
 
 describe('fetchCourseRunMetadata', () => {
-  const COURSE_RUN_METADATA = `${APP_CONFIG.DISCOVERY_API_BASE_URL}/api/v1/course_runs/${mockCourseRunKey}`;
+  const COURSE_RUN_METADATA = `${APP_CONFIG.DISCOVERY_API_BASE_URL}/api/v1/course_runs/${mockCourseRunKey}/`;
   const courseRunMetadata = {
     key: mockCourseRunKey,
     title: 'edX Demonstration Course',

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -657,12 +657,6 @@ export const getSubsidyToApplyForCourse = ({
   applicableEnterpriseOffer = undefined,
   applicableSubsidyAccessPolicy = undefined,
 }) => {
-  console.log('getSubsidyToApplyForCourse!!!', {
-    applicableSubscriptionLicense,
-    applicableCouponCode,
-    applicableEnterpriseOffer,
-  });
-
   if (applicableSubscriptionLicense) {
     return {
       subsidyType: LICENSE_SUBSIDY_TYPE,

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -657,6 +657,12 @@ export const getSubsidyToApplyForCourse = ({
   applicableEnterpriseOffer = undefined,
   applicableSubsidyAccessPolicy = undefined,
 }) => {
+  console.log('getSubsidyToApplyForCourse!!!', {
+    applicableSubscriptionLicense,
+    applicableCouponCode,
+    applicableEnterpriseOffer,
+  });
+
   if (applicableSubscriptionLicense) {
     return {
       subsidyType: LICENSE_SUBSIDY_TYPE,

--- a/src/components/course/EnrollModal.jsx
+++ b/src/components/course/EnrollModal.jsx
@@ -4,17 +4,95 @@ import {
   ActionRow, AlertModal, Button, Icon, Spinner, Stack,
 } from '@openedx/paragon';
 import { Check } from '@openedx/paragon/icons';
+import { FormattedMessage, defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+import { v4 as uuidv4 } from 'uuid';
 
 import { ENTERPRISE_OFFER_TYPE } from '../enterprise-user-subsidy/enterprise-offers/data/constants';
 import { COUPON_CODE_SUBSIDY_TYPE, ENTERPRISE_OFFER_SUBSIDY_TYPE, LEARNER_CREDIT_SUBSIDY_TYPE } from '../app/data';
 
-export const createUseCouponCodeText = couponCodesCount => `You are about to redeem 1 enrollment code from your ${couponCodesCount} remaining codes.`;
+const messages = defineMessages({
+  enrollModalConfirmCta: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.buttons.enroll.text',
+    defaultMessage: 'Enroll',
+    description: 'Text for the enroll button in the confirmation modal',
+  },
+  upgradeModalConfirmCta: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.buttons.upgrade.text',
+    defaultMessage: 'Confirm upgrade',
+    description: 'Text for the upgrade button in the confirmation modal',
+  },
+  modalCancelCta: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.buttons.cancel.text',
+    defaultMessage: 'Cancel',
+    description: 'Text for the cancel button in the confirmation modal',
+  },
+  couponCodeModalTitle: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.titles.coupon-code',
+    defaultMessage: 'Use enrollment code for this course?',
+    description: 'Title for the confirmation modal when using a coupon code',
+  },
+  enterpriseOfferModalTitle: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.titles.enterprise-offer',
+    defaultMessage: 'Use learner credit for this course?', // refers to *legacy* learner credit
+    description: 'Title for the confirmation modal when using an enterprise offer',
+  },
+  learnerCreditModalTitle: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.titles.learner-credit',
+    defaultMessage: 'Upgrade for free',
+    description: 'Title for the confirmation modal when using a learner credit',
+  },
+  couponCodesUsage: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.text.coupon-codes-usage',
+    defaultMessage: 'You are about to redeem an enrollment code from your {couponCodesCount} remaining codes.',
+    description: 'Text for the confirmation modal when using a coupon code',
+  },
+  enterpriseOfferUsageWithPrice: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.text.enterprise-offer-usage.with-price',
+    defaultMessage: 'You are about to redeem {courseRunPrice} from your learner credit. This action cannot be reversed.',
+    description: 'Text for the confirmation modal when using an enterprise offer with a price',
+  },
+  enterpriseOfferUsageWithoutPrice: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.text.enterprise-offer-usage.without-price',
+    defaultMessage: 'You are about to redeem 1 learner credit. This action cannot be reversed.',
+    description: 'Text for the confirmation modal when using an enterprise offer with a limit',
+  },
+  upgradeCoveredByOrg: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.text.upgrade-covered-by-org',
+    defaultMessage: 'This course is covered by your organization, which allows you to upgrade for free.',
+    description: 'Text for the confirmation modal when upgrading is covered by the organization',
+  },
+  upgradeBenefitsPrefix: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.list-items.prefix',
+    defaultMessage: 'By upgrading, you will get:',
+    description: 'Prefix for the list of benefits of upgrading',
+  },
+  upgradeBenefitsUnlimitedAccess: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.list-items.unlimited-access',
+    defaultMessage: 'Unlimited access to course materials',
+    description: 'List item for the benefits of upgrading, including unlimited access.',
+  },
+  upgradeBenefitsFeedbackAndGradedAssignments: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.list-items.feedback-graded-assignments',
+    defaultMessage: 'Feedback and graded assignments',
+    description: 'List item for the benefits of upgrading, including feedback.',
+  },
+  upgradeBenefitsShareableCertificate: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.list-items.shareable-certificate',
+    defaultMessage: 'Shareable certificate upon completion',
+    description: 'List item for the benefits of upgrading, including a shareable certificate.',
+  },
+  confirmationCtaLoading: {
+    id: 'enterprise.learner_portal.enroll-upgrade-modal.buttons.loading',
+    defaultMessage: 'Loading...',
+    description: 'Text for the confirmation button in the modal when loading',
+  },
+});
 
-export const createUseEnterpriseOfferText = (offer, courseRunPrice) => {
-  if (offer.offerType === ENTERPRISE_OFFER_TYPE.ENROLLMENTS_LIMIT) {
-    return 'You are about to redeem 1 learner credit. This action cannot be reversed.';
+export const createUseEnterpriseOfferText = (offerType, courseRunPrice) => {
+  if (offerType !== ENTERPRISE_OFFER_TYPE.ENROLLMENTS_LIMIT && courseRunPrice) {
+    return messages.enterpriseOfferUsageWithPrice;
   }
-  return `You are about to redeem $${courseRunPrice} from your learner credit. This action cannot be reversed.`;
+  return messages.enterpriseOfferUsageWithoutPrice;
 };
 
 const UpgradeConfirmationModalListItem = ({
@@ -39,75 +117,90 @@ UpgradeConfirmationModalListItem.defaultProps = {
 
 export const MODAL_TEXTS = {
   HAS_COUPON_CODE: {
-    body: (couponCodesCount) => createUseCouponCodeText(couponCodesCount),
-    button: 'Enroll',
-    title: 'Use 1 enrollment code for this course?',
+    body: messages.couponCodesUsage,
+    button: messages.enrollModalConfirmCta,
+    title: messages.couponCodeModalTitle,
   },
   HAS_ENTERPRISE_OFFER: {
-    body: (offer, courseRunPrice) => createUseEnterpriseOfferText(offer, courseRunPrice),
-    button: 'Enroll',
-    title: 'Use learner credit for this course?', // refers to *legacy* learner credit
+    body: createUseEnterpriseOfferText,
+    button: messages.enrollModalConfirmCta,
+    title: messages.enterpriseOfferModalTitle,
   },
   HAS_LEARNER_CREDIT: {
-    Body: () => (
-      <>
-        {/* TODO: i18n */}
-        <p>This course is covered by your organization, which allows you to upgrade for free.</p>
-        <p>By upgrading, you will get:</p>
-        <ul className="list-unstyled">
-          <Stack gap={1}>
-            <UpgradeConfirmationModalListItem>
-              Unlimited access to course materials
-            </UpgradeConfirmationModalListItem>
-            <UpgradeConfirmationModalListItem>
-              Feedback and graded assignments
-            </UpgradeConfirmationModalListItem>
-            <UpgradeConfirmationModalListItem>
-              Shareable certifcate upon completion
-            </UpgradeConfirmationModalListItem>
-          </Stack>
-        </ul>
-      </>
-    ),
+    Body: () => {
+      const listItems = [
+        <FormattedMessage {...messages.upgradeBenefitsUnlimitedAccess} />,
+        <FormattedMessage {...messages.upgradeBenefitsFeedbackAndGradedAssignments} />,
+        <FormattedMessage {...messages.upgradeBenefitsShareableCertificate} />,
+      ];
+      return (
+        <>
+          <p><FormattedMessage {...messages.upgradeCoveredByOrg} /></p>
+          <p><FormattedMessage {...messages.upgradeBenefitsPrefix} /></p>
+          <ul className="list-unstyled">
+            <Stack gap={1}>
+              {listItems.map((listItem) => (
+                <UpgradeConfirmationModalListItem key={uuidv4()}>
+                  {listItem}
+                </UpgradeConfirmationModalListItem>
+              ))}
+            </Stack>
+          </ul>
+        </>
+      );
+    },
     // TODO: button text should be stateful to account for async loading
-    button: 'Confirm upgrade',
-    title: 'Upgrade for free',
+    button: messages.upgradeModalConfirmCta,
+    title: messages.learnerCreditModalTitle,
   },
 };
 
-const getModalTexts = ({ userSubsidyApplicableToCourse, couponCodesCount, courseRunPrice }) => {
-  const { HAS_COUPON_CODE, HAS_ENTERPRISE_OFFER, HAS_LEARNER_CREDIT } = MODAL_TEXTS;
+const useModalTexts = ({ userSubsidyApplicableToCourse, couponCodesCount, courseRunPrice }) => {
+  const intl = useIntl();
+  const {
+    HAS_COUPON_CODE,
+    HAS_ENTERPRISE_OFFER,
+    HAS_LEARNER_CREDIT,
+  } = MODAL_TEXTS;
   const { subsidyType } = userSubsidyApplicableToCourse || {};
 
   if (subsidyType === COUPON_CODE_SUBSIDY_TYPE) {
     return {
       paymentRequiredForCourse: false,
-      buttonText: HAS_COUPON_CODE.button,
-      enrollText: HAS_COUPON_CODE.body(couponCodesCount),
-      titleText: HAS_COUPON_CODE.title,
+      buttonText: intl.formatMessage(HAS_COUPON_CODE.button),
+      enrollText: intl.formatMessage(HAS_COUPON_CODE.body, { couponCodesCount }),
+      titleText: intl.formatMessage(HAS_COUPON_CODE.title),
     };
   }
 
   if (subsidyType === ENTERPRISE_OFFER_SUBSIDY_TYPE) {
     return {
       paymentRequiredForCourse: false,
-      buttonText: HAS_ENTERPRISE_OFFER.button,
-      enrollText: HAS_ENTERPRISE_OFFER.body(userSubsidyApplicableToCourse, courseRunPrice),
-      titleText: HAS_ENTERPRISE_OFFER.title,
+      buttonText: intl.formatMessage(HAS_ENTERPRISE_OFFER.button),
+      enrollText: intl.formatMessage(
+        HAS_ENTERPRISE_OFFER.body(userSubsidyApplicableToCourse.offerType, courseRunPrice),
+        { courseRunPrice: `$${courseRunPrice}` },
+      ),
+      titleText: intl.formatMessage(HAS_ENTERPRISE_OFFER.title),
     };
   }
 
   if (subsidyType === LEARNER_CREDIT_SUBSIDY_TYPE) {
     return {
       paymentRequiredForCourse: false,
-      buttonText: HAS_LEARNER_CREDIT.button,
-      enrollText: <HAS_LEARNER_CREDIT.Body />, // TODO: determine whether this pattern/convention still makes sense
-      titleText: HAS_LEARNER_CREDIT.title,
+      buttonText: intl.formatMessage(HAS_LEARNER_CREDIT.button),
+      enrollText: <HAS_LEARNER_CREDIT.Body />,
+      titleText: intl.formatMessage(HAS_LEARNER_CREDIT.title),
     };
   }
 
   // Otherwise, given subsidy type is not supported for the enroll/upgrade modal
-  return { paymentRequiredForCourse: true };
+  return {
+    paymentRequiredForCourse: true,
+    buttonText: null,
+    enrollText: null,
+    titleText: null,
+  };
 };
 
 const EnrollModal = ({
@@ -119,14 +212,15 @@ const EnrollModal = ({
   couponCodesCount,
   onEnroll,
 }) => {
+  const intl = useIntl();
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleEnroll = async (e) => {
+  const handleEnroll = async () => {
     if (!onEnroll) {
       return;
     }
     setIsLoading(true);
-    await onEnroll(e);
+    onEnroll();
     setIsLoading(false);
   };
 
@@ -140,7 +234,7 @@ const EnrollModal = ({
     titleText,
     enrollText,
     buttonText,
-  } = getModalTexts({
+  } = useModalTexts({
     userSubsidyApplicableToCourse,
     couponCodesCount,
     courseRunPrice,
@@ -155,7 +249,7 @@ const EnrollModal = ({
   return (
     <AlertModal
       isOpen={isModalOpen}
-      closeLabel="Cancel"
+      closeLabel={intl.formatMessage(messages.modalCancelCta)}
       title={titleText}
       footerNode={(
         <ActionRow>
@@ -163,7 +257,7 @@ const EnrollModal = ({
             variant="tertiary"
             onClick={dismissModal}
           >
-            Cancel
+            <FormattedMessage {...messages.modalCancelCta} />
           </Button>
           {/* FIXME: the following Button should be using StatefulButton from @openedx/paragon */}
           <Button
@@ -171,7 +265,15 @@ const EnrollModal = ({
             href={userSubsidyApplicableToCourse.subsidyType === LEARNER_CREDIT_SUBSIDY_TYPE ? undefined : enrollmentUrl}
             onClick={handleEnroll}
           >
-            {isLoading && <Spinner animation="border" className="mr-2" variant="light" size="sm" screenReaderText="Loading" />}
+            {isLoading && (
+              <Spinner
+                animation="border"
+                className="mr-2"
+                variant="light"
+                size="sm"
+                screenReaderText={intl.formatMessage(messages.confirmationCtaLoading)}
+              />
+            )}
             {buttonText}
           </Button>
         </ActionRow>

--- a/src/components/course/EnrollModal.jsx
+++ b/src/components/course/EnrollModal.jsx
@@ -53,7 +53,7 @@ const messages = defineMessages({
   },
   enterpriseOfferUsageWithoutPrice: {
     id: 'enterprise.learner_portal.enroll-upgrade-modal.text.enterprise-offer-usage.without-price',
-    defaultMessage: 'You are about to redeem 1 learner credit. This action cannot be reversed.',
+    defaultMessage: 'You are about to redeem your learner credit for this course. This action cannot be reversed.',
     description: 'Text for the confirmation modal when using an enterprise offer with a limit',
   },
   upgradeCoveredByOrg: {

--- a/src/components/course/EnrollModal.jsx
+++ b/src/components/course/EnrollModal.jsx
@@ -1,9 +1,12 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Modal, Spinner } from '@openedx/paragon';
+import {
+  ActionRow, AlertModal, Button, Icon, Spinner, Stack,
+} from '@openedx/paragon';
+import { Check } from '@openedx/paragon/icons';
 
 import { ENTERPRISE_OFFER_TYPE } from '../enterprise-user-subsidy/enterprise-offers/data/constants';
-import { COUPON_CODE_SUBSIDY_TYPE, ENTERPRISE_OFFER_SUBSIDY_TYPE } from '../app/data';
+import { COUPON_CODE_SUBSIDY_TYPE, ENTERPRISE_OFFER_SUBSIDY_TYPE, LEARNER_CREDIT_SUBSIDY_TYPE } from '../app/data';
 
 export const createUseCouponCodeText = couponCodesCount => `You are about to redeem 1 enrollment code from your ${couponCodesCount} remaining codes.`;
 
@@ -12,6 +15,26 @@ export const createUseEnterpriseOfferText = (offer, courseRunPrice) => {
     return 'You are about to redeem 1 learner credit. This action cannot be reversed.';
   }
   return `You are about to redeem $${courseRunPrice} from your learner credit. This action cannot be reversed.`;
+};
+
+const UpgradeConfirmationModalListItem = ({
+  icon,
+  children,
+}) => (
+  <li>
+    <Stack direction="horizontal" gap={2}>
+      <Icon src={icon} />
+      {children}
+    </Stack>
+  </li>
+);
+
+UpgradeConfirmationModalListItem.propTypes = {
+  icon: PropTypes.elementType,
+  children: PropTypes.node.isRequired,
+};
+UpgradeConfirmationModalListItem.defaultProps = {
+  icon: Check,
 };
 
 export const MODAL_TEXTS = {
@@ -23,12 +46,36 @@ export const MODAL_TEXTS = {
   HAS_ENTERPRISE_OFFER: {
     body: (offer, courseRunPrice) => createUseEnterpriseOfferText(offer, courseRunPrice),
     button: 'Enroll',
-    title: 'Use learner credit for this course?',
+    title: 'Use learner credit for this course?', // refers to *legacy* learner credit
+  },
+  HAS_LEARNER_CREDIT: {
+    Body: () => (
+      <>
+        <p>This course is covered by your organization, which allows you to upgrade for free.</p>
+        <p>By upgrading, you will get:</p>
+        <ul className="list-unstyled">
+          <Stack gap={1}>
+            <UpgradeConfirmationModalListItem>
+              Unlimited access to course materials
+            </UpgradeConfirmationModalListItem>
+            <UpgradeConfirmationModalListItem>
+              Feedback and graded assignments
+            </UpgradeConfirmationModalListItem>
+            <UpgradeConfirmationModalListItem>
+              Shareable certifcate upon completion
+            </UpgradeConfirmationModalListItem>
+          </Stack>
+        </ul>
+      </>
+    ),
+    // TODO: button text should be stateful to account for async loading
+    button: 'Confirm upgrade',
+    title: 'Upgrade for free',
   },
 };
 
 const getModalTexts = ({ userSubsidyApplicableToCourse, couponCodesCount, courseRunPrice }) => {
-  const { HAS_COUPON_CODE, HAS_ENTERPRISE_OFFER } = MODAL_TEXTS;
+  const { HAS_COUPON_CODE, HAS_ENTERPRISE_OFFER, HAS_LEARNER_CREDIT } = MODAL_TEXTS;
   const { subsidyType } = userSubsidyApplicableToCourse || {};
 
   if (subsidyType === COUPON_CODE_SUBSIDY_TYPE) {
@@ -49,6 +96,16 @@ const getModalTexts = ({ userSubsidyApplicableToCourse, couponCodesCount, course
     };
   }
 
+  if (subsidyType === LEARNER_CREDIT_SUBSIDY_TYPE) {
+    return {
+      paymentRequiredForCourse: false,
+      buttonText: HAS_LEARNER_CREDIT.button,
+      enrollText: <HAS_LEARNER_CREDIT.Body />, // TODO: determine whether this pattern/convention still makes sense
+      titleText: HAS_LEARNER_CREDIT.title,
+    };
+  }
+
+  // Otherwise, given subsidy type is not supported for the enroll/upgrade modal
   return { paymentRequiredForCourse: true };
 };
 
@@ -63,16 +120,30 @@ const EnrollModal = ({
 }) => {
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleEnroll = (e) => {
-    setIsLoading(true);
-    if (onEnroll) {
-      onEnroll(e);
+  const handleEnroll = async (e) => {
+    if (!onEnroll) {
+      return;
     }
+    setIsLoading(true);
+    await onEnroll(e);
+    setIsLoading(false);
+  };
+
+  const dismissModal = () => {
+    setIsModalOpen(false);
+    setIsLoading(false);
   };
 
   const {
-    paymentRequiredForCourse, titleText, enrollText, buttonText,
-  } = getModalTexts({ userSubsidyApplicableToCourse, couponCodesCount, courseRunPrice });
+    paymentRequiredForCourse,
+    titleText,
+    enrollText,
+    buttonText,
+  } = getModalTexts({
+    userSubsidyApplicableToCourse,
+    couponCodesCount,
+    courseRunPrice,
+  });
 
   // Check whether the modal should be rendered (i.e., do not show modal if user has no applicable subsidy)
   // as payment would be required for the learner to enroll in the course.
@@ -81,22 +152,33 @@ const EnrollModal = ({
   }
 
   return (
-    <Modal
-      open={isModalOpen}
-      closeText="Cancel"
+    <AlertModal
+      isOpen={isModalOpen}
+      closeLabel="Cancel"
       title={titleText}
-      body={<div><p>{enrollText}</p></div>}
-      buttons={[
-        <Button
-          href={enrollmentUrl}
-          onClick={handleEnroll}
-        >
-          {isLoading && <Spinner animation="border" className="mr-2" variant="light" size="sm" screenReaderText="Loading" />}
-          {buttonText}
-        </Button>,
-      ]}
-      onClose={() => setIsModalOpen(false)}
-    />
+      footerNode={(
+        <ActionRow>
+          <Button
+            variant="tertiary"
+            onClick={dismissModal}
+          >
+            Cancel
+          </Button>
+          {/* FIXME: the following Button should be using StatefulButton from @openedx/paragon */}
+          <Button
+            // TODO: remove no-op behavior for learner credit
+            href={userSubsidyApplicableToCourse.subsidyType === LEARNER_CREDIT_SUBSIDY_TYPE ? undefined : enrollmentUrl}
+            onClick={handleEnroll}
+          >
+            {isLoading && <Spinner animation="border" className="mr-2" variant="light" size="sm" screenReaderText="Loading" />}
+            {buttonText}
+          </Button>
+        </ActionRow>
+      )}
+      onClose={dismissModal}
+    >
+      {enrollText}
+    </AlertModal>
   );
 };
 
@@ -106,7 +188,7 @@ EnrollModal.propTypes = {
   enrollmentUrl: PropTypes.string.isRequired,
   userSubsidyApplicableToCourse: PropTypes.shape({
     subsidyType: PropTypes.oneOf(
-      [COUPON_CODE_SUBSIDY_TYPE, ENTERPRISE_OFFER_SUBSIDY_TYPE],
+      [COUPON_CODE_SUBSIDY_TYPE, ENTERPRISE_OFFER_SUBSIDY_TYPE, LEARNER_CREDIT_SUBSIDY_TYPE],
     ),
     offerType: PropTypes.oneOf(
       Object.values(ENTERPRISE_OFFER_TYPE),

--- a/src/components/course/EnrollModal.jsx
+++ b/src/components/course/EnrollModal.jsx
@@ -10,7 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { ENTERPRISE_OFFER_TYPE } from '../enterprise-user-subsidy/enterprise-offers/data/constants';
 import { COUPON_CODE_SUBSIDY_TYPE, ENTERPRISE_OFFER_SUBSIDY_TYPE, LEARNER_CREDIT_SUBSIDY_TYPE } from '../app/data';
 
-const messages = defineMessages({
+export const messages = defineMessages({
   enrollModalConfirmCta: {
     id: 'enterprise.learner_portal.enroll-upgrade-modal.buttons.enroll.text',
     defaultMessage: 'Enroll',

--- a/src/components/course/EnrollModal.jsx
+++ b/src/components/course/EnrollModal.jsx
@@ -51,6 +51,7 @@ export const MODAL_TEXTS = {
   HAS_LEARNER_CREDIT: {
     Body: () => (
       <>
+        {/* TODO: i18n */}
         <p>This course is covered by your organization, which allows you to upgrade for free.</p>
         <p>By upgrading, you will get:</p>
         <ul className="list-unstyled">

--- a/src/components/course/tests/EnrollModal.test.jsx
+++ b/src/components/course/tests/EnrollModal.test.jsx
@@ -1,15 +1,23 @@
 import React from 'react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import '@testing-library/jest-dom/extend-expect';
 import { screen, render } from '@testing-library/react';
-
 import userEvent from '@testing-library/user-event';
+
 import EnrollModal, { MODAL_TEXTS } from '../EnrollModal';
 import { COUPON_CODE_SUBSIDY_TYPE, ENTERPRISE_OFFER_SUBSIDY_TYPE } from '../../app/data';
+import { ENTERPRISE_OFFER_TYPE } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
 
 jest.mock('../data/hooks', () => ({
   useTrackSearchConversionClickHandler: jest.fn(),
   useOptimizelyEnrollmentClickHandler: jest.fn(),
 }));
+
+const EnrollModalWrapper = (props) => (
+  <IntlProvider locale="en">
+    <EnrollModal {...props} />
+  </IntlProvider>
+);
 
 describe('<EnrollModal />', () => {
   const basicProps = {
@@ -22,7 +30,7 @@ describe('<EnrollModal />', () => {
   };
 
   it('does not render when user has no applicable subsidy', () => {
-    const { container } = render(<EnrollModal {...basicProps} />);
+    const { container } = render(<EnrollModalWrapper {...basicProps} />);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -34,12 +42,10 @@ describe('<EnrollModal />', () => {
       },
       couponCodesCount: 5,
     };
-    render(
-      <EnrollModal {...props} />,
-    );
-    expect(screen.getByText(MODAL_TEXTS.HAS_COUPON_CODE.title)).toBeInTheDocument();
-    expect(screen.getByText(MODAL_TEXTS.HAS_COUPON_CODE.body(props.couponCodesCount))).toBeInTheDocument();
-    expect(screen.getByText(MODAL_TEXTS.HAS_COUPON_CODE.button)).toBeInTheDocument();
+    render(<EnrollModalWrapper {...props} />);
+    expect(screen.getByText(MODAL_TEXTS.HAS_COUPON_CODE.title.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(MODAL_TEXTS.HAS_COUPON_CODE.body.defaultMessage.replace('{couponCodesCount}', props.couponCodesCount))).toBeInTheDocument();
+    expect(screen.getByText(MODAL_TEXTS.HAS_COUPON_CODE.button.defaultMessage)).toBeInTheDocument();
   });
 
   it('displays the correct texts when there is an enterprise offer', () => {
@@ -47,26 +53,22 @@ describe('<EnrollModal />', () => {
       ...basicProps,
       userSubsidyApplicableToCourse: {
         subsidyType: ENTERPRISE_OFFER_SUBSIDY_TYPE,
+        offerType: ENTERPRISE_OFFER_TYPE.ENROLLMENTS_LIMIT,
       },
     };
-    render(
-      <EnrollModal {...props} />,
-    );
-    expect(screen.getByText(MODAL_TEXTS.HAS_ENTERPRISE_OFFER.title)).toBeInTheDocument();
+    render(<EnrollModalWrapper {...props} />);
+    expect(screen.getByText(MODAL_TEXTS.HAS_ENTERPRISE_OFFER.title.defaultMessage)).toBeInTheDocument();
     expect(
-      screen.getByText(MODAL_TEXTS.HAS_ENTERPRISE_OFFER.body(
-        props.userSubsidyApplicableToCourse,
-        props.courseRunPrice,
-      )),
+      screen.getByText(MODAL_TEXTS.HAS_ENTERPRISE_OFFER.body(ENTERPRISE_OFFER_TYPE.ENROLLMENTS_LIMIT).defaultMessage),
     ).toBeInTheDocument();
-    expect(screen.getByText(MODAL_TEXTS.HAS_ENTERPRISE_OFFER.button)).toBeInTheDocument();
+    expect(screen.getByText(MODAL_TEXTS.HAS_ENTERPRISE_OFFER.button.defaultMessage)).toBeInTheDocument();
   });
 
   it('calls onEnroll when enrollmentUrl is clicked', () => {
     const mockHandleEnroll = jest.fn();
 
     render(
-      <EnrollModal
+      <EnrollModalWrapper
         {...basicProps}
         onEnroll={mockHandleEnroll}
         userSubsidyApplicableToCourse={{
@@ -75,7 +77,7 @@ describe('<EnrollModal />', () => {
         couponCodesCount={5}
       />,
     );
-    const enrollButton = screen.getByText(MODAL_TEXTS.HAS_COUPON_CODE.button);
+    const enrollButton = screen.getByText(MODAL_TEXTS.HAS_COUPON_CODE.button.defaultMessage);
     userEvent.click(enrollButton);
 
     expect(mockHandleEnroll).toHaveBeenCalled();

--- a/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
@@ -106,19 +106,16 @@ const CourseSection = ({
     const isAuditOrHonorEnrollment = [COURSE_MODES_MAP.AUDIT, COURSE_MODES_MAP.HONOR].includes(courseRun.mode);
     if (isAuditOrHonorEnrollment && courseRun.courseRunStatus === COURSE_STATUSES.inProgress) {
       return (
-        <Suspense fallback={(
-          <DelayedFallbackContainer>
-            <>
+        <Suspense
+          key={courseRun.courseRunId}
+          fallback={(
+            <DelayedFallbackContainer className="dashboard-course-card border-bottom py-3 mb-2">
               <div className="sr-only">Loading...</div>
-              <Skeleton key={uuidv4()} height={200} className="dashboard-course-card py-3 mb-2" />
-            </>
-          </DelayedFallbackContainer>
-        )}
+              <Skeleton key={uuidv4()} height={200} />
+            </DelayedFallbackContainer>
+          )}
         >
-          <Component
-            {...getCourseRunProps(courseRun)}
-            key={courseRun.courseRunId}
-          />
+          <Component {...getCourseRunProps(courseRun)} />
         </Suspense>
       );
     }

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/ContinueLearningButton.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/ContinueLearningButton.jsx
@@ -16,6 +16,7 @@ import { EXECUTIVE_EDUCATION_COURSE_MODES, useEnterpriseCustomer } from '../../.
  * @returns {Function} A functional React component for the continue learning button.
  */
 const ContinueLearningButton = ({
+  variant,
   className,
   linkToCourse,
   title,
@@ -39,7 +40,7 @@ const ContinueLearningButton = ({
   const isCourseStarted = () => dayjs(startDate) <= dayjs();
   const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
   const disabled = !isCourseStarted() ? 'disabled' : undefined;
-  const variant = isExecutiveEducation2UCourse ? 'inverse-primary' : 'outline-primary';
+  const defaultVariant = isExecutiveEducation2UCourse ? 'inverse-primary' : 'outline-primary';
 
   const renderContent = () => {
     // resumeCourseRunUrl indicates that learner has made progress, available only if the learner has started learning.
@@ -57,7 +58,7 @@ const ContinueLearningButton = ({
       destination={linkToCourse}
       className={classNames('btn-xs-block', disabled, className)}
       onClick={onClickHandler}
-      variant={variant}
+      variant={variant || defaultVariant}
     >
       {renderContent()}
       <span className="sr-only">for {title}</span>
@@ -66,7 +67,8 @@ const ContinueLearningButton = ({
 };
 
 ContinueLearningButton.defaultProps = {
-  className: null,
+  className: undefined,
+  variant: null,
   startDate: null,
   mode: null,
   resumeCourseRunUrl: null,
@@ -74,6 +76,7 @@ ContinueLearningButton.defaultProps = {
 
 ContinueLearningButton.propTypes = {
   className: PropTypes.string,
+  variant: PropTypes.string,
   linkToCourse: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   courseRunId: PropTypes.string.isRequired,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
@@ -31,6 +31,9 @@ function useLinkToCourse({
   subsidyForCourse,
 }) {
   let url = linkToCourse;
+  // For subscription upgrades, there is no upgrade confirmation required by the user
+  // so we can directly redirect the user to the upgrade path when the `subsidyForCourse`
+  // is a subscription license.
   if (subsidyForCourse?.subsidyType === LICENSE_SUBSIDY_TYPE) {
     url = subsidyForCourse.redemptionUrl;
   }

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
@@ -1,9 +1,10 @@
 import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
-import { AppContext } from '@edx/frontend-platform/react';
 import { useNavigate } from 'react-router-dom';
+import { AppContext } from '@edx/frontend-platform/react';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { FormattedMessage, defineMessages } from '@edx/frontend-platform/i18n';
+import { Stack } from '@openedx/paragon';
 
 import dayjs from '../../../../../utils/dayjs';
 import BaseCourseCard, { getScreenReaderText } from './BaseCourseCard';
@@ -13,7 +14,7 @@ import ContinueLearningButton from './ContinueLearningButton';
 import Notification from './Notification';
 
 import UpgradeCourseButton from './UpgradeCourseButton';
-import { useEnterpriseCustomer } from '../../../../app/data';
+import { LICENSE_SUBSIDY_TYPE, useEnterpriseCustomer } from '../../../../app/data';
 import { useCourseUpgradeData, useUpdateCourseEnrollmentStatus } from '../data';
 import { COURSE_STATUSES } from '../../../../../constants';
 
@@ -24,6 +25,17 @@ const messages = defineMessages({
     description: 'Text for the save course for later button in the course card dropdown menu',
   },
 });
+
+function useLinkToCourse({
+  linkToCourse,
+  subsidyForCourse,
+}) {
+  let url = linkToCourse;
+  if (subsidyForCourse?.subsidyType === LICENSE_SUBSIDY_TYPE) {
+    url = subsidyForCourse.redemptionUrl;
+  }
+  return url;
+}
 
 export const InProgressCourseCard = ({
   linkToCourse,
@@ -36,33 +48,40 @@ export const InProgressCourseCard = ({
   mode,
   ...rest
 }) => {
-  // TODO: Destructure learnerCreditUpgradeUrl field here
-  const {
-    licenseUpgradeUrl,
-    couponUpgradeUrl,
-  } = useCourseUpgradeData({ courseRunKey: courseRunId, mode });
   const navigate = useNavigate();
-  // The upgrade button is only for upgrading via coupon, upgrades via license are automatic through the course link.
-  const shouldShowUpgradeButton = !!couponUpgradeUrl;
+  const {
+    subsidyForCourse,
+    hasUpgradeAndConfirm,
+  } = useCourseUpgradeData({ courseRunKey: courseRunId, mode });
 
   const [isMarkCompleteModalOpen, setIsMarkCompleteModalOpen] = useState(false);
   const { courseCards } = useContext(AppContext);
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const updateCourseEnrollmentStatus = useUpdateCourseEnrollmentStatus({ enterpriseCustomer });
+  const coursewareOrUpgradeLink = useLinkToCourse({
+    linkToCourse,
+    subsidyForCourse,
+  });
 
   const renderButtons = () => (
-    <>
+    <Stack direction="horizontal" gap={1}>
       <ContinueLearningButton
-        className={shouldShowUpgradeButton ? 'btn-primary' : undefined}
-        linkToCourse={licenseUpgradeUrl ?? linkToCourse}
+        variant={hasUpgradeAndConfirm ? 'primary' : undefined}
+        linkToCourse={coursewareOrUpgradeLink}
         title={title}
         courseRunId={courseRunId}
         mode={mode}
         startDate={startDate}
         resumeCourseRunUrl={resumeCourseRunUrl}
       />
-      {shouldShowUpgradeButton && <UpgradeCourseButton className="ml-1" title={title} courseRunKey={courseRunId} mode={mode} />}
-    </>
+      {hasUpgradeAndConfirm && (
+        <UpgradeCourseButton
+          title={title}
+          courseRunKey={courseRunId}
+          mode={mode}
+        />
+      )}
+    </Stack>
   );
 
   const filteredNotifications = notifications.filter((notification) => {
@@ -166,7 +185,7 @@ export const InProgressCourseCard = ({
       buttons={renderButtons()}
       dropdownMenuItems={getDropdownMenuItems()}
       title={title}
-      linkToCourse={licenseUpgradeUrl ?? linkToCourse}
+      linkToCourse={coursewareOrUpgradeLink}
       courseRunId={courseRunId}
       mode={mode}
       startDate={startDate}

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/UpgradeCourseButton.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/UpgradeCourseButton.jsx
@@ -23,7 +23,6 @@ const UpgradeCourseButton = ({
   const { data: { couponCodeRedemptionCount } } = useCouponCodes();
   const {
     subsidyForCourse,
-    couponUpgradeUrl,
     courseRunPrice,
   } = useCourseUpgradeData({ courseRunKey, mode });
 
@@ -56,7 +55,7 @@ const UpgradeCourseButton = ({
       <EnrollModal
         isModalOpen={isModalOpen}
         setIsModalOpen={setIsModalOpen}
-        enrollmentUrl={couponUpgradeUrl}
+        enrollmentUrl={subsidyForCourse.redemptionUrl}
         courseRunPrice={courseRunPrice}
         userSubsidyApplicableToCourse={subsidyForCourse}
         couponCodesCount={couponCodeRedemptionCount}

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/InProgressCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/InProgressCourseCard.test.jsx
@@ -10,6 +10,8 @@ import { InProgressCourseCard } from '../InProgressCourseCard';
 import {
   COUPON_CODE_SUBSIDY_TYPE,
   COURSE_MODES_MAP,
+  LEARNER_CREDIT_SUBSIDY_TYPE,
+  LICENSE_SUBSIDY_TYPE,
   useCouponCodes,
   useEnterpriseCustomer,
 } from '../../../../../app/data';
@@ -66,12 +68,6 @@ describe('<InProgressCourseCard />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    useCouponCodes.mockReturnValue({
-      data: {
-        couponCodeAssignments: [],
-        couponCodeRedemptionCount: 0,
-      },
-    });
     useCourseUpgradeData.mockReturnValue({
       subsidyForCourse: null,
       courseRunPrice: null,
@@ -79,12 +75,25 @@ describe('<InProgressCourseCard />', () => {
     });
   });
 
-  it('should not render upgrade course button when hasUpgradeAndConfirm=false', () => {
+  it('should not render upgrade course button when hasUpgradeAndConfirm=false (no subsidy returned)', () => {
     renderWithRouter(<InProgressCourseCardWrapper {...baseProps} />);
     expect(screen.queryByTestId('upgrade-course-button')).not.toBeInTheDocument();
   });
 
-  it('should render upgrade course button when hasUpgradeAndConfirm=true', () => {
+  it('should not render upgrade course button when hasUpgradeAndConfirm=false (subscription license)', () => {
+    useCourseUpgradeData.mockReturnValue({
+      courseRunPrice: null,
+      subsidyForCourse: {
+        subsidyType: LICENSE_SUBSIDY_TYPE,
+        redemptionUrl: 'https://redemption.url',
+      },
+      hasUpgradeAndConfirm: false,
+    });
+    renderWithRouter(<InProgressCourseCardWrapper {...baseProps} />);
+    expect(screen.queryByTestId('upgrade-course-button')).not.toBeInTheDocument();
+  });
+
+  it('should render upgrade course button when hasUpgradeAndConfirm=true (coupon codes)', () => {
     useCouponCodes.mockReturnValue({
       data: {
         couponCodeAssignments: [{
@@ -97,7 +106,20 @@ describe('<InProgressCourseCard />', () => {
       courseRunPrice: 100,
       subsidyForCourse: {
         subsidyType: COUPON_CODE_SUBSIDY_TYPE,
-        redemptionUrl: 'coupon-upgrade-url',
+        redemptionUrl: 'https://redemption.url',
+      },
+      hasUpgradeAndConfirm: true,
+    });
+    renderWithRouter(<InProgressCourseCardWrapper {...baseProps} />);
+    expect(screen.getByTestId('upgrade-course-button')).toBeInTheDocument();
+  });
+
+  it('should render upgrade course button when hasUpgradeAndConfirm=true (learner credit)', () => {
+    useCourseUpgradeData.mockReturnValue({
+      courseRunPrice: 100,
+      subsidyForCourse: {
+        subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE,
+        redemptionUrl: 'https://redemption.url',
       },
       hasUpgradeAndConfirm: true,
     });

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/InProgressCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/InProgressCourseCard.test.jsx
@@ -7,7 +7,12 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { QueryClientProvider } from '@tanstack/react-query';
 
 import { InProgressCourseCard } from '../InProgressCourseCard';
-import { COURSE_MODES_MAP, useCouponCodes, useEnterpriseCustomer } from '../../../../../app/data';
+import {
+  COUPON_CODE_SUBSIDY_TYPE,
+  COURSE_MODES_MAP,
+  useCouponCodes,
+  useEnterpriseCustomer,
+} from '../../../../../app/data';
 import { queryClient } from '../../../../../../utils/tests';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../../../../app/data/services/data/__factories__';
 import { useCourseUpgradeData } from '../../data';
@@ -64,40 +69,39 @@ describe('<InProgressCourseCard />', () => {
     useCouponCodes.mockReturnValue({
       data: {
         couponCodeAssignments: [],
+        couponCodeRedemptionCount: 0,
       },
     });
     useCourseUpgradeData.mockReturnValue({
-      licenseUpgradeUrl: undefined,
-      couponUpgradeUrl: undefined,
-      learnerCreditUpgradeUrl: undefined,
-      subsidyForCourse: undefined,
-      courseRunPrice: undefined,
+      subsidyForCourse: null,
+      courseRunPrice: null,
+      hasUpgradeAndConfirm: false,
     });
   });
 
-  it('should not render upgrade course button if there is no couponUpgradeUrl', () => {
+  it('should not render upgrade course button when hasUpgradeAndConfirm=false', () => {
     renderWithRouter(<InProgressCourseCardWrapper {...baseProps} />);
     expect(screen.queryByTestId('upgrade-course-button')).not.toBeInTheDocument();
   });
 
-  it('should render upgrade course button if there is a couponUpgradeUrl', () => {
-    useCourseUpgradeData.mockReturnValue({
-      licenseUpgradeUrl: undefined,
-      couponUpgradeUrl: 'coupon-upgrade-url',
-      courseRunPrice: 100,
-      learnerCreditUpgradeUrl: undefined,
-      subsidyForCourse: undefined,
+  it('should render upgrade course button when hasUpgradeAndConfirm=true', () => {
+    useCouponCodes.mockReturnValue({
+      data: {
+        couponCodeAssignments: [{
+          code: 'abc123',
+        }],
+        couponCodeRedemptionCount: 1,
+      },
     });
-    renderWithRouter(<InProgressCourseCardWrapper
-      {...baseProps}
-      upgradeableCourseEnrollmentContextValue={
-        {
-          couponUpgradeUrl: 'coupon-upgrade-url',
-          courseRunPrice: 100,
-        }
-      }
-    />);
-
+    useCourseUpgradeData.mockReturnValue({
+      courseRunPrice: 100,
+      subsidyForCourse: {
+        subsidyType: COUPON_CODE_SUBSIDY_TYPE,
+        redemptionUrl: 'coupon-upgrade-url',
+      },
+      hasUpgradeAndConfirm: true,
+    });
+    renderWithRouter(<InProgressCourseCardWrapper {...baseProps} />);
     expect(screen.getByTestId('upgrade-course-button')).toBeInTheDocument();
   });
 });

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AppContext } from '@edx/frontend-platform/react';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { logError } from '@edx/frontend-platform/logging';
+import { hasFeatureFlagEnabled } from '@edx/frontend-enterprise-utils';
 import _camelCase from 'lodash.camelcase';
 import _cloneDeep from 'lodash.clonedeep';
 
@@ -20,7 +21,10 @@ import {
 import { getExpiringAssignmentsAcknowledgementState, getHasUnacknowledgedAssignments } from '../../../data/utils';
 import { ASSIGNMENT_TYPES } from '../../../../enterprise-user-subsidy/enterprise-offers/data/constants';
 import {
+  COUPON_CODE_SUBSIDY_TYPE,
   COURSE_MODES_MAP,
+  LEARNER_CREDIT_SUBSIDY_TYPE,
+  LICENSE_SUBSIDY_TYPE,
   getSubsidyToApplyForCourse,
   groupCourseEnrollmentsByStatus,
   queryEnterpriseCourseEnrollments,
@@ -125,112 +129,123 @@ export const useCourseEnrollments = ({
  * @param {String} args.mode The mode of the course. Used as a gating mechanism for upgradability
  * default: false
  * @returns {Object} {
- *     licenseUpgradeUrl: undefined,
- *     couponUpgradeUrl: undefined,
- *     learnerCreditUpgradeUrl: undefined,
  *     subsidyForCourse: undefined,
  *     courseRunPrice: undefined,
- *     }
+ *     hasUpgradeAndConfirm: false,
+ * }
  */
 export const useCourseUpgradeData = ({
   courseRunKey,
   mode,
 }) => {
   const location = useLocation();
-  // We determine whether the course mode is such that it can be upgraded
+  // Determine whether the course mode is such that it can be upgraded
   const canUpgradeToVerifiedEnrollment = [COURSE_MODES_MAP.AUDIT, COURSE_MODES_MAP.HONOR].includes(mode);
   const { authenticatedUser } = useContext(AppContext);
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const { data: customerContainsContent } = useEnterpriseCustomerContainsContent([courseRunKey]);
+  const { data: customerContainsContent } = useEnterpriseCustomerContainsContent([courseRunKey], {
+    enabled: canUpgradeToVerifiedEnrollment,
+  });
 
-  // TODO: Remove authenticatedUser?.administrator flag when rolling out ENT-9135
+  // TODO: Remove `isLearnerCreditUpgradeEnabled` flag when rolling out ENT-9135
   // Metadata required to allow upgrade via applicable learner credit
-  const { data: learnerCreditMetadata } = useCanUpgradeWithLearnerCredit(
-    [courseRunKey],
-    { enabled: authenticatedUser?.administrator && canUpgradeToVerifiedEnrollment },
-  );
+  const isLearnerCreditUpgradeEnabled = authenticatedUser.administrator || hasFeatureFlagEnabled('LEARNER_CREDIT_AUDIT_UPGRADE');
+  const { data: learnerCreditMetadata } = useCanUpgradeWithLearnerCredit(courseRunKey, {
+    enabled: isLearnerCreditUpgradeEnabled && canUpgradeToVerifiedEnrollment,
+  });
 
   // Metadata required to allow upgrade via applicable subscription license
-  const { data: { subscriptionLicense: applicableSubscriptionLicense } } = useSubscriptions(
-    { enabled: customerContainsContent?.containsContentItems && canUpgradeToVerifiedEnrollment },
-  );
+  const { data: subscriptions } = useSubscriptions({
+    enabled: !!customerContainsContent?.containsContentItems && canUpgradeToVerifiedEnrollment,
+  });
 
-  // Metadata required to allow upgrade via applicable coupon codes
+  // Metadata required to allow upgrade via applicable coupon code
   const { data: couponCodesMetadata } = useCouponCodes({
     select: (data) => ({
       applicableCouponCode: findCouponCodeForCourse(data.couponCodeAssignments, customerContainsContent?.catalogList),
     }),
-    enabled: canUpgradeToVerifiedEnrollment,
+    enabled: !!customerContainsContent?.containsContentItems && canUpgradeToVerifiedEnrollment,
   });
-  // If coupon codes are not eligible, there is no need to make this call
+
+  // If coupon codes are not eligible, there is no need to make an API call to get the course run product SKU
   const { data: courseRunDetails } = useCourseRunMetadata(courseRunKey, {
     select: (data) => ({
       ...data,
       sku: findHighestLevelSeatSku(data.seats),
-      code: data.code,
     }),
-    enabled: !couponCodesMetadata.applicableCouponCode && canUpgradeToVerifiedEnrollment,
+    enabled: !couponCodesMetadata?.applicableCouponCode && canUpgradeToVerifiedEnrollment,
   });
 
   return useMemo(() => {
     const defaultReturn = {
-      licenseUpgradeUrl: undefined,
-      couponUpgradeUrl: undefined,
-      learnerCreditUpgradeUrl: undefined,
-      subsidyForCourse: undefined,
-      courseRunPrice: undefined,
+      subsidyForCourse: null,
+      courseRunPrice: null,
+      hasUpgradeAndConfirm: false,
     };
 
-    // Exit early if the content to upgrade is not contained in the customers content or
-    // if they are unable to upgrade due to their course mode
-    if (!customerContainsContent?.containsContentItems || !canUpgradeToVerifiedEnrollment) {
+    // Return early if the user is unable to upgrade to their course mode OR the content
+    // to upgrade is not contained in the customer's content catalog(s).
+    if (!(canUpgradeToVerifiedEnrollment || customerContainsContent?.containsContentItems)) {
+      return defaultReturn;
+    }
+
+    // Determine applicable subsidy, if any, based on priority order of subsidy types.
+    const applicableSubsidy = getSubsidyToApplyForCourse({
+      applicableSubscriptionLicense: subscriptions?.subscriptionLicense,
+      applicableCouponCode: couponCodesMetadata?.applicableCouponCode,
+      applicableSubsidyAccessPolicy: learnerCreditMetadata?.applicableSubsidyAccessPolicy,
+    });
+
+    // No applicable subsidy found, return early.
+    if (!applicableSubsidy) {
       return defaultReturn;
     }
 
     // Construct and return subscription based upgrade url
-    if (applicableSubscriptionLicense) {
+    if (applicableSubsidy.subsidyType === LICENSE_SUBSIDY_TYPE) {
+      applicableSubsidy.redemptionUrl = createEnrollWithLicenseUrl({
+        courseRunKey,
+        enterpriseId: enterpriseCustomer.uuid,
+        licenseUUID: subscriptions.subscriptionLicense.uuid,
+        location,
+      });
       return {
         ...defaultReturn,
-        subsidyForCourse: getSubsidyToApplyForCourse({ applicableSubscriptionLicense }),
-        licenseUpgradeUrl: createEnrollWithLicenseUrl({
-          courseRunKey,
-          enterpriseId: enterpriseCustomer.uuid,
-          licenseUUID: applicableSubscriptionLicense.uuid,
-          location,
-        }),
+        subsidyForCourse: applicableSubsidy,
       };
     }
 
     // Construct and return coupon code based upgrade url
-    if (couponCodesMetadata?.applicableCouponCode) {
-      const { applicableCouponCode } = couponCodesMetadata;
+    if (applicableSubsidy.subsidyType === COUPON_CODE_SUBSIDY_TYPE) {
+      applicableSubsidy.redemptionUrl = createEnrollWithCouponCodeUrl({
+        courseRunKey,
+        sku: courseRunDetails.sku,
+        code: applicableSubsidy.code,
+        location,
+      });
       return {
         ...defaultReturn,
-        subsidyForCourse: getSubsidyToApplyForCourse({ applicableCouponCode }),
-        couponUpgradeUrl: createEnrollWithCouponCodeUrl({
-          courseRunKey,
-          sku: courseRunDetails.sku,
-          code: applicableCouponCode.code,
-          location,
-        }),
+        subsidyForCourse: applicableSubsidy,
         courseRunPrice: courseRunDetails.firstEnrollablePaidSeatPrice,
+        hasUpgradeAndConfirm: true,
       };
     }
 
     // Construct and return learner credit based upgrade url
-    if (learnerCreditMetadata?.applicableSubsidyAccessPolicy?.canRedeem) {
-      const { applicableSubsidyAccessPolicy } = learnerCreditMetadata;
+    if (applicableSubsidy.subsidyType === LEARNER_CREDIT_SUBSIDY_TYPE) {
+      applicableSubsidy.redemptionUrl = learnerCreditMetadata.applicableSubsidyAccessPolicy.policyRedemptionUrl;
       return {
         ...defaultReturn,
-        subsidyForCourse: getSubsidyToApplyForCourse({ applicableSubsidyAccessPolicy }),
-        learnerCreditUpgradeUrl: applicableSubsidyAccessPolicy.redeemableSubsidyAccessPolicy?.policyRedemptionUrl,
+        subsidyForCourse: applicableSubsidy,
+        courseRunPrice: learnerCreditMetadata.listPrice,
+        hasUpgradeAndConfirm: true,
       };
     }
 
-    // If none is applicable, return with defaultReturn values
+    // If no subsidy type is applicable, return with default values
     return defaultReturn;
   }, [
-    applicableSubscriptionLicense,
+    subscriptions?.subscriptionLicense,
     canUpgradeToVerifiedEnrollment,
     couponCodesMetadata,
     courseRunDetails?.firstEnrollablePaidSeatPrice,

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -154,6 +154,7 @@ export const useCourseUpgradeData = ({
   const { data: learnerCreditMetadata } = useCanUpgradeWithLearnerCredit(courseRunKey, {
     enabled: isLearnerCreditUpgradeEnabled && canUpgradeToVerifiedEnrollment,
   });
+  console.log('learnerCreditMetadata!!!', learnerCreditMetadata);
 
   // Metadata required to allow upgrade via applicable subscription license
   const { data: subscriptionLicense } = useSubscriptions({

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -154,13 +154,12 @@ export const useCourseUpgradeData = ({
   const { data: learnerCreditMetadata } = useCanUpgradeWithLearnerCredit(courseRunKey, {
     enabled: isLearnerCreditUpgradeEnabled && canUpgradeToVerifiedEnrollment,
   });
-  console.log('learnerCreditMetadata!!!', learnerCreditMetadata);
 
   // Metadata required to allow upgrade via applicable subscription license
   const { data: subscriptionLicense } = useSubscriptions({
     select: (data) => {
       const license = data?.subscriptionLicense;
-      const isLicenseActivated = !!license?.status === LICENSE_STATUS.ACTIVATED;
+      const isLicenseActivated = !!(license?.status === LICENSE_STATUS.ACTIVATED);
       const isSubscriptionPlanCurrent = !!license?.subscriptionPlan.isCurrent;
       if (!isLicenseActivated || !isSubscriptionPlanCurrent) {
         return null;


### PR DESCRIPTION
# Description

Ticket: [ENT-9066](https://2u-internal.atlassian.net/browse/ENT-9066) (part 1)

[Figma](https://www.figma.com/design/gbMBXoSZRXKk6ExOPGqjOH/Audit-to-Verified-LC?node-id=81-5145&m=dev)

## Changelog

tl;dr; Some clean up on existing logic; display "Upgrade" CTA when audit enrollment is upgradeable via Learner Credit; update `EnrollModal` with Learner Credit audit upgrade confirmation messaging.

* Updates to `useCanUpgradeWithLearnerCredit`
  * No longer relies on `isPolicyRedemptionEnabled` util function as it returns true when the course enrollment is associated with a prior successful redemption, whereby the `redeemableSubsidyAccessPolicy` is not returned when `hasSuccessfulRedemption: true` (i.e., no access to `redeemableSubsidyAccessPolicy.policyRedemptionUrl` to use during upgrade).
    * TODO: file ticket for backlog/icebox.
  * Refactors to ensure any custom `select` function passed in the query options will be applied.
  * Updates the returned data structure to separate list price and the subsidy access policy into separate properties (i.e., `applicableSubsidyAccessPolicy` + `listPrice` versus having `listPrice` as an attribute on `applicableSubsidyAccessPolicy`).
* Updates to `useCourseUpgradeData`
  * Ensures the `contains_content_items` API is only called if the course enrollment is upgradeable based on its `mode`.
  * Extends the LC feature flag (based on staff users) to also allow enablement via query parameter when not using a staff user (i.e., `?feature= LEARNER_CREDIT_AUDIT_UPGRADE`).
  * Simplifies the returned data structure to include `redemptionUrl` property on the returned `subsidyForCourse` such that callers of the hook don't need to rely on distinct variable names for `redemptionUrl` that vary across subsidies. Instead, prefers to use `subsidyForCourse.subsidyType` checks alongside the consolidated `redemptionUrl`.
  * Returns `hasUpgradeAndConfirm` as a helper property for callers of the hook to determine whether the upgradeable course enrollment card should display upgrade CTA and confirmation modal.
* Updates to `InProgressCourseCard`
  * Introduces `useLinkToCourse` to abstract some business logic from the UI component
  * Slight refactor to rely on `Stack`.
* Updates to `EnrollModal`
  * Migrates off deprecated Paragon `Modal` in favor of `AlertModal` instead.
  * Currently opts to re-use existing `EnrollModal` as the consolidated enroll/upgrade confirmation modal across all subsidy types, whereby the messaging varies by subsidy type.

## Screenshots

### Audit course enrollment card, upgradeable with Learner Credit

<img width="791" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/406bc87a-4fa6-4ad7-b2b8-ed1c6369f744">

Note: the "Confirm upgrade" CTA is currently a no-op. This is acceptable as the Learner Credit variant of `EnrollModal` is feature flagged for staff users only or with the explicit opt-in with `?feature` URL query parameter.

<img width="875" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/4d7d02b5-dd40-4e81-a8e5-c59b82bf9051">

### Audit course enrollment card, upgradeable with coupon code

<img width="873" alt="image" src="https://github.com/openedx/frontend-app-learner-portal-enterprise/assets/2828721/595fb54c-2e10-4e47-97fe-3400624d5562">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
