### PR TITLE
fix: bug fix to allow for only one highlight call

### DIFF
--- a/src/components/app/data/constants.js
+++ b/src/components/app/data/constants.js
@@ -52,5 +52,4 @@ export const ENTERPRISE_OFFER_SUBSIDY_TYPE = 'enterpriseOffer';
 export const LEARNER_CREDIT_SUBSIDY_TYPE = 'learnerCredit';
 
 export const ENROLL_BY_DATE_WARNING_THRESHOLD_DAYS = 10;
-
 export const MAX_HIGHLIGHT_SETS = 12;

--- a/src/components/app/data/constants.js
+++ b/src/components/app/data/constants.js
@@ -52,3 +52,5 @@ export const ENTERPRISE_OFFER_SUBSIDY_TYPE = 'enterpriseOffer';
 export const LEARNER_CREDIT_SUBSIDY_TYPE = 'learnerCredit';
 
 export const ENROLL_BY_DATE_WARNING_THRESHOLD_DAYS = 10;
+
+export const MAX_HIGHLIGHT_SETS = 12;

--- a/src/components/app/data/services/contentHighlights.js
+++ b/src/components/app/data/services/contentHighlights.js
@@ -37,6 +37,7 @@ export async function fetchEnterpriseCuration(enterpriseUUID, options = {}) {
 export async function fetchContentHighlights(enterpriseUUID, options = {}) {
   const queryParams = new URLSearchParams({
     enterprise_customer: enterpriseUUID,
+    page_size: 12,
     ...options,
   });
   const url = `${getConfig().ENTERPRISE_CATALOG_API_BASE_URL}/api/v1/highlight-sets/?${queryParams.toString()}`;

--- a/src/components/app/data/services/contentHighlights.js
+++ b/src/components/app/data/services/contentHighlights.js
@@ -2,7 +2,7 @@ import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { logError } from '@edx/frontend-platform/logging';
 
-import MAX_HIGHLIGHT_SETS from '../constants';
+import { MAX_HIGHLIGHT_SETS } from '../constants';
 import { fetchPaginatedData } from './utils';
 
 /**

--- a/src/components/app/data/services/contentHighlights.js
+++ b/src/components/app/data/services/contentHighlights.js
@@ -2,6 +2,7 @@ import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { logError } from '@edx/frontend-platform/logging';
 
+import MAX_HIGHLIGHT_SETS from '../constants';
 import { fetchPaginatedData } from './utils';
 
 /**
@@ -37,7 +38,7 @@ export async function fetchEnterpriseCuration(enterpriseUUID, options = {}) {
 export async function fetchContentHighlights(enterpriseUUID, options = {}) {
   const queryParams = new URLSearchParams({
     enterprise_customer: enterpriseUUID,
-    page_size: 12,
+    page_size: MAX_HIGHLIGHT_SETS,
     ...options,
   });
   const url = `${getConfig().ENTERPRISE_CATALOG_API_BASE_URL}/api/v1/highlight-sets/?${queryParams.toString()}`;

--- a/src/components/app/data/services/contentHighlights.test.js
+++ b/src/components/app/data/services/contentHighlights.test.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 import { fetchContentHighlights, fetchEnterpriseCuration } from './contentHighlights';
+import { MAX_HIGHLIGHT_SETS } from '../constants';
 
 const axiosMock = new MockAdapter(axios);
 getAuthenticatedHttpClient.mockReturnValue(axios);
@@ -60,6 +61,7 @@ describe('fetchEnterpriseCuration', () => {
 describe('fetchContentHighlights', () => {
   const queryParams = new URLSearchParams({
     enterprise_customer: mockEnterpriseId,
+    page_size: MAX_HIGHLIGHT_SETS,
   });
   const HIGHLIGHT_SETS_URL = `${APP_CONFIG.ENTERPRISE_CATALOG_API_BASE_URL}/api/v1/highlight-sets/?${queryParams.toString()}`;
 
@@ -75,6 +77,7 @@ describe('fetchContentHighlights', () => {
         { uuid: 'test-highlight-set-uuid-2' },
       ],
     };
+    console.log('mockUrl ', HIGHLIGHT_SETS_URL);
     axiosMock.onGet(HIGHLIGHT_SETS_URL).reply(200, mockResponse);
     const result = await fetchContentHighlights(mockEnterpriseId);
     expect(result).toEqual(mockResponse.results);


### PR DESCRIPTION
Now that I've made the change allowing for a specified page size to be passed in, we are now only making one call to enterprise catalog. There is a limit on highlights to be 12 in admin portal, so it won't be more than that anyway. 

Testing: I created 12 highlights on `https://localhost.stage.edx.org:8734/hooli/search`

[Jira ticket 
](https://2u-internal.atlassian.net/browse/ENT-9210)
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
