### PR TITLE
fix: fix auto-applied license flow

### DIFF
--- a/src/components/app/data/services/subsidies/subscriptions.js
+++ b/src/components/app/data/services/subsidies/subscriptions.js
@@ -139,9 +139,11 @@ export async function activateOrAutoApplySubscriptionLicense({
   const {
     customerAgreement,
     licensesByStatus,
-    subscriptionLicense,
   } = subscriptionsData;
-  if (!customerAgreement || !subscriptionLicense?.subscriptionPlan?.isCurrent) {
+  // If there is no available customer agreement for the current customer,
+  // or if there is no *current* plan available within such a customer agreement,
+  // exit early and redirect to the dashboard.
+  if (!customerAgreement || customerAgreement.netDaysUntilExpiration <= 0) {
     return checkLicenseActivationRouteAndRedirectToDashboard();
   }
 

--- a/src/components/app/data/services/subsidies/subscriptions.test.js
+++ b/src/components/app/data/services/subsidies/subscriptions.test.js
@@ -34,6 +34,7 @@ const mockLicenseActivationKey = 'test-license-activation-key';
 const mockSubscriptionPlanUUID = 'test-subscription-plan-uuid';
 const mockCustomerAgreement = {
   uuid: 'test-customer-agreement-uuid',
+  netDaysUntilExpiration: 35,
 };
 const APP_CONFIG = {
   LICENSE_MANAGER_URL: 'http://localhost:18170',
@@ -197,7 +198,13 @@ describe('activateOrAutoApplySubscriptionLicense', () => {
 
   it('returns null with already activated license', async () => {
     const mockLicensesByStatus = {
-      [LICENSE_STATUS.ACTIVATED]: [{ uuid: 'test-license-uuid' }],
+      [LICENSE_STATUS.ACTIVATED]: [
+        {
+          uuid: 'test-license-uuid',
+          status: LICENSE_STATUS.ACTIVATED,
+          subscriptionPlan: { isCurrent: true },
+        },
+      ],
       [LICENSE_STATUS.ASSIGNED]: [],
       [LICENSE_STATUS.REVOKED]: [],
     };
@@ -222,7 +229,13 @@ describe('activateOrAutoApplySubscriptionLicense', () => {
     const mockLicensesByStatus = {
       [LICENSE_STATUS.ACTIVATED]: [],
       [LICENSE_STATUS.ASSIGNED]: [],
-      [LICENSE_STATUS.REVOKED]: [{ uuid: 'test-license-uuid' }],
+      [LICENSE_STATUS.REVOKED]: [
+        {
+          uuid: 'test-license-uuid',
+          status: LICENSE_STATUS.REVOKED,
+          subscriptionPlan: { isCurrent: true },
+        },
+      ],
     };
     const mockSubscriptionsData = {
       customerAgreement: mockCustomerAgreement,
@@ -253,6 +266,7 @@ describe('activateOrAutoApplySubscriptionLicense', () => {
       uuid: mockLicenseUUID,
       status: LICENSE_STATUS.ASSIGNED,
       activationKey: mockLicenseActivationKey,
+      subscriptionPlan: { isCurrent: true },
     };
     const mockLicensesByStatus = {
       [LICENSE_STATUS.ACTIVATED]: [],


### PR DESCRIPTION
Fix the `activateOrAutoApplySubscriptionLicense()` function so that it doesn't early-return when there is no subscription license present (which is actually the *expected* case during the auto-apply flow), but *does* early return if there is no current subscription plan associated with the present customer agreement record.
ENT-9221

Local success (after fixing devstack CSRF_TRUSTED_ORIGINS in license-manager):
https://github.com/user-attachments/assets/5b4885b8-6ccf-4d4e-9aac-59df077d0df9

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
