### PR TITLE
fix: remove retake course prompt on completed course cards for EE cou…

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/course-cards/CompletedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/CompletedCourseCard.jsx
@@ -8,6 +8,7 @@ import ContinueLearningButton from './ContinueLearningButton';
 
 import { isCourseEnded } from '../../../../../utils/common';
 import CertificateImg from './images/edx-verified-mini-cert.png';
+import { EXECUTIVE_EDUCATION_COURSE_MODES } from '../../../../app/data';
 
 const CompletedCourseCard = (props) => {
   const { authenticatedUser: { username } } = useContext(AppContext);
@@ -38,7 +39,7 @@ const CompletedCourseCard = (props) => {
       />
     );
   };
-
+  const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
   const renderCertificateInfo = () => (
     props.linkToCertificate ? (
       <div className="d-flex mb-3">
@@ -55,12 +56,14 @@ const CompletedCourseCard = (props) => {
         </div>
       </div>
     ) : (
-      <p className="mb-3 mt-2 small">
-        To earn a certificate,{' '}
-        <a href={props.linkToCourse}>
-          retake this course →
-        </a>
-      </p>
+      !isExecutiveEducation2UCourse && (
+        <p className="mb-3 mt-2 small">
+          To earn a certificate,{' '}
+          <a href={props.linkToCourse}>
+            retake this course →
+          </a>
+        </p>
+      )
     )
   );
 


### PR DESCRIPTION
**Description**

**Context**:
For courses taken on GetSmarter, no certificates are generated on course completion within the edX LMS as our LMS does not track the user's progress via GetSmarter. Therefore, learners should not see the prompt "To earn a certificate, you need to retake the course" on completed course cards.

**Solution**:
If the course is taken on GetSmarter, do not display the prompt "To earn a certificate, you need to retake the course" on completed course cards.

Jira -> [ENT-9103](https://2u-internal.atlassian.net/browse/ENT-9103)

![image](https://github.com/user-attachments/assets/2f92a614-b82a-4c78-8c60-0f3de4657b79)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
