### PR TITLE
[ENT-8962] fix: removed feature flag check from video detail page

### DIFF
--- a/src/components/microlearning/VideoDetailPage.jsx
+++ b/src/components/microlearning/VideoDetailPage.jsx
@@ -10,7 +10,6 @@ import { Sidebar } from '../layout';
 import './styles/VideoDetailPage.scss';
 import DelayedFallbackContainer from '../DelayedFallback/DelayedFallbackContainer';
 import NotFoundPage from '../NotFoundPage';
-import { features } from '../../config';
 
 const VideoPlayer = loadable(() => import(/* webpackChunkName: "videojs" */ '../video/VideoPlayer'), {
   fallback: (
@@ -51,7 +50,7 @@ const VideoDetailPage = () => {
 
   // Comprehensive error handling will be implemented upon receiving specific error use cases from the UX team
   // and corresponding Figma designs.
-  if (!videoData || !features.FEATURE_ENABLE_VIDEO_CATALOG) {
+  if (!videoData) {
     return (
       <NotFoundPage
         errorHeading={intl.formatMessage({

--- a/src/components/microlearning/tests/VideoDetailPage.test.jsx
+++ b/src/components/microlearning/tests/VideoDetailPage.test.jsx
@@ -7,7 +7,6 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
 import { renderWithRouter } from '../../../utils/tests';
 import VideoDetailPage from '../VideoDetailPage';
-import { features } from '../../../config';
 import { useVideoDetails, useEnterpriseCustomer } from '../../app/data';
 
 const APP_CONFIG = {
@@ -49,10 +48,6 @@ jest.mock('@edx/frontend-platform/config', () => ({
 jest.mock('@edx/frontend-platform/auth');
 getAuthenticatedHttpClient.mockReturnValue(axios);
 
-jest.mock('../../../config', () => ({
-  features: { FEATURE_ENABLE_VIDEO_CATALOG: true },
-}));
-
 const VideoDetailPageWrapper = () => (
   <IntlProvider locale="en">
     <VideoDetailPage />
@@ -79,12 +74,6 @@ describe('VideoDetailPage Tests', () => {
 
   it('renders a not found page when video data is not found', () => {
     useVideoDetails.mockReturnValue({ data: null });
-    renderWithRouter(<VideoDetailPageWrapper />);
-    expect(screen.getByTestId('not-found-page')).toBeInTheDocument();
-  });
-
-  it('renders a not found page when feature flag is turned off', () => {
-    features.FEATURE_ENABLE_VIDEO_CATALOG = false;
     renderWithRouter(<VideoDetailPageWrapper />);
     expect(screen.getByTestId('not-found-page')).toBeInTheDocument();
   });


### PR DESCRIPTION
**Description**
Removed the feature flag check from the video detail page, as it has already been applied on the video card that redirects to this page.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
