### PR TITLE
fix: use correct late redemption enablement key

### DIFF
--- a/src/components/app/data/hooks/useLateEnrollmentBufferDays.test.jsx
+++ b/src/components/app/data/hooks/useLateEnrollmentBufferDays.test.jsx
@@ -23,12 +23,13 @@ const redeemablePolicies = [
   {
     id: 123,
     subsidyExpirationDate: mockSubsidyExpirationDate,
+    isLateRedemptionAllowed: false,
   },
   {
     id: 456,
     subsidyExpirationDate: mockSubsidyExpirationDate,
     learnerContentAssignments: [mockContentAssignment],
-    isLateRedemptionEnabled: true,
+    isLateRedemptionAllowed: true, // all it takes is one redeemable policy to turn on the late redemption feature.
   },
 ];
 const expectedTransformedPolicies = redeemablePolicies.map((policy) => ({
@@ -82,15 +83,18 @@ describe('useLateEnrollmentBufferDays', () => {
     expect(result.current).toEqual(LATE_ENROLLMENTS_BUFFER_DAYS);
   });
   it('should return undefined if no late redemption is enabled', async () => {
+    // Copy of redeemablePolicies but no policies have late redemption allowed.
     const updatedRedeemablePolicies = [
       {
         id: 123,
         subsidyExpirationDate: mockSubsidyExpirationDate,
+        isLateRedemptionAllowed: false,
       },
       {
         id: 456,
         subsidyExpirationDate: mockSubsidyExpirationDate,
         learnerContentAssignments: [mockContentAssignment],
+        isLateRedemptionAllowed: false,
       },
     ];
     const updatedExpectedTransformedPolicies = updatedRedeemablePolicies.map((policy) => ({

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -438,10 +438,10 @@ export function getLateEnrollmentBufferDays(redeemablePolicies) {
     return undefined;
   }
   const anyPolicyHasLateRedemptionEnabled = redeemablePolicies.some((policy) => (
-    // is_late_redemption_enabled=True on the serialized policy represents the fact that late
+    // is_late_redemption_allowed=True on the serialized policy represents the fact that late
     // redemption has been temporarily enabled by an operator for the policy. It will toggle
     // itself back to False after a finite period of time.
-    policy.isLateRedemptionEnabled
+    policy.isLateRedemptionAllowed
   ));
   return anyPolicyHasLateRedemptionEnabled ? LATE_ENROLLMENTS_BUFFER_DAYS : undefined;
 }


### PR DESCRIPTION
Renames:

`isLateRedemptionEnabled` -> `isLateRedemptionAllowed`

I can't quite fathom how this was wrong, but it's [abundantly clear in the API serializer](https://github.com/openedx/enterprise-access/blob/5461be33217cfe873c4db705b271e97edea5b41c/enterprise_access/apps/api/serializers/subsidy_access_policy.py#L192) that the correct value should be `isLateRedemptionAllowed`.

ENT-9259