### PR TITLE
feat: add course section on video detail page

### DIFF
--- a/src/components/app/data/hooks/index.js
+++ b/src/components/app/data/hooks/index.js
@@ -44,3 +44,5 @@ export { default as usePassLearnerCsodParams } from './usePassLearnerCsodParams'
 export { default as useCanUpgradeWithLearnerCredit } from './useCanUpgradeWithLearnerCredit';
 export { default as useCourseRunMetadata } from './useCourseRunMetadata';
 export { default as useVideoDetails } from './useVideoDetails';
+export { default as useVideoCourseMetadata } from './useVideoCourseMetadata';
+export { default as useVideoCourseReviews } from './useVideoCourseReviews';

--- a/src/components/app/data/hooks/useVideoCourseMetadata.js
+++ b/src/components/app/data/hooks/useVideoCourseMetadata.js
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { queryCourseMetadata } from '../queries';
+import { getAvailableCourseRuns } from '../utils';
+import useLateEnrollmentBufferDays from './useLateEnrollmentBufferDays';
+
+/**
+ * Retrieves the course metadata for the given enterprise customer and course key.
+ * @returns {Types.UseQueryResult}} The query results for the course metadata.
+ */
+export default function useVideoCourseMetadata(courseKey, queryOptions = {}) {
+  const { select, ...queryOptionsRest } = queryOptions;
+  const isEnrollableBufferDays = useLateEnrollmentBufferDays({
+    enabled: !!courseKey,
+  });
+  return useQuery({
+    ...queryCourseMetadata(courseKey),
+    enabled: !!courseKey,
+    ...queryOptionsRest,
+    select: (data) => {
+      if (!data) {
+        return data;
+      }
+      const availableCourseRuns = getAvailableCourseRuns({ course: data, isEnrollableBufferDays });
+      const transformedData = {
+        ...data,
+        availableCourseRuns,
+      };
+      if (select) {
+        return select({
+          original: data,
+          transformed: transformedData,
+        });
+      }
+      return transformedData;
+    },
+  });
+}

--- a/src/components/app/data/hooks/useVideoCourseMetadata.test.jsx
+++ b/src/components/app/data/hooks/useVideoCourseMetadata.test.jsx
@@ -1,0 +1,105 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { queryClient } from '../../../../utils/tests';
+import { fetchCourseMetadata } from '../services';
+import useLateEnrollmentBufferDays from './useLateEnrollmentBufferDays';
+import useVideoCourseMetadata from './useVideoCourseMetadata';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('./useLateEnrollmentBufferDays');
+
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchCourseMetadata: jest.fn().mockResolvedValue(null),
+}));
+
+const mockCourseMetadata = {
+  key: 'edX+DemoX',
+  courseRuns: [{
+    isMarketable: true,
+    availability: 'Current',
+    enrollmentStart: dayjs().add(10, 'day').toISOString(),
+    enrollmentEnd: dayjs().add(15, 'day').toISOString(),
+    isEnrollable: true,
+  }],
+};
+const courseKey = 'edX+DemoX';
+
+describe('useVideoCourseMetadata', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchCourseMetadata.mockResolvedValue(mockCourseMetadata);
+    useLateEnrollmentBufferDays.mockReturnValue(undefined);
+  });
+  it('should handle resolved value correctly with no select function passed', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useVideoCourseMetadata(courseKey), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: {
+          ...mockCourseMetadata,
+          availableCourseRuns: [mockCourseMetadata.courseRuns[0]],
+        },
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+  it('should handle resolved value correctly when no data is returned from video course metadata', async () => {
+    fetchCourseMetadata.mockResolvedValue(null);
+    const { result, waitForNextUpdate } = renderHook(() => useVideoCourseMetadata(courseKey), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: null,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+  it('should handle resolved value correctly when data is returned with a select function passed', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useVideoCourseMetadata(
+      courseKey,
+      { select: (data) => data },
+    ), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: {
+          original: mockCourseMetadata,
+          transformed: {
+            ...mockCourseMetadata,
+            availableCourseRuns: [mockCourseMetadata.courseRuns[0]],
+          },
+        },
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+  it('should handle resolved value correctly when no data is returned with a select function passed', async () => {
+    fetchCourseMetadata.mockResolvedValue(null);
+    const { result, waitForNextUpdate } = renderHook(() => useVideoCourseMetadata(
+      courseKey,
+      { select: (data) => data },
+    ), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: null,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/hooks/useVideoCourseReviews.js
+++ b/src/components/app/data/hooks/useVideoCourseReviews.js
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryCourseReviews } from '../queries';
+import useVideoCourseMetadata from './useVideoCourseMetadata';
+
+export default function useVideoCourseReviews(courseKey, queryOptions = {}) {
+  const { data: courseMetadata } = useVideoCourseMetadata(courseKey);
+  return useQuery({
+    ...queryCourseReviews(courseMetadata.key),
+    ...queryOptions,
+  });
+}

--- a/src/components/app/data/hooks/useVideoCourseReviews.test.jsx
+++ b/src/components/app/data/hooks/useVideoCourseReviews.test.jsx
@@ -1,0 +1,58 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { queryClient } from '../../../../utils/tests';
+import { fetchCourseReviews } from '../services';
+import useVideoCourseMetadata from './useVideoCourseMetadata';
+import useVideoCourseReviews from './useVideoCourseReviews';
+
+jest.mock('./useVideoCourseMetadata');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchCourseReviews: jest.fn().mockResolvedValue(null),
+}));
+const mockCourseReviews = {
+  course_key: 'test-course-run-key',
+  reviewsCount: 345,
+  avgCourseRating: 3,
+  confidentLearnersPercentage: 33,
+  mostCommonGoal: 'Job advancement',
+  mostCommonGoalLearnersPercentage: 34,
+  totalEnrollments: 4444,
+};
+const mockCourseMetadata = {
+  key: 'edX+DemoX',
+  courseRuns: [{
+    isMarketable: true,
+    availability: 'Current',
+    enrollmentStart: dayjs().add(10, 'day').toISOString(),
+    enrollmentEnd: dayjs().add(15, 'day').toISOString(),
+    isEnrollable: true,
+  }],
+};
+const courseKey = 'edX+DemoX';
+
+describe('useVideoCourseReviews', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useVideoCourseMetadata.mockReturnValue({ data: mockCourseMetadata });
+    fetchCourseReviews.mockResolvedValue(mockCourseReviews);
+  });
+  it('should handle resolved value correctly', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useVideoCourseReviews(courseKey), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockCourseReviews,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/services/videos.test.js
+++ b/src/components/app/data/services/videos.test.js
@@ -38,8 +38,9 @@ const mockVideoDetailResponse = {
       },
       duration: 135.98,
     },
+    title: 'Needs-Driven Innovation',
     parent_content_metadata: {
-      title: 'Needs-Driven Innovation ',
+      title: 'Demo Course Run Title',
     },
     summary_transcripts: {
       listItem: 'Needs-Driven Innovation focuses on identifying...',

--- a/src/components/microlearning/VideoCourseReview.jsx
+++ b/src/components/microlearning/VideoCourseReview.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Icon, OverlayTrigger, Tooltip } from '@openedx/paragon';
+import { StarFilled, StarOutline } from '@openedx/paragon/icons';
+import PropTypes from 'prop-types';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
+import { useVideoCourseReviews } from '../app/data';
+import { fixDecimalNumber } from '../course/data';
+
+const VideoCourseReview = ({ courseKey }) => {
+  const { data: courseReviews } = useVideoCourseReviews(courseKey);
+  const intl = useIntl();
+  if (!courseReviews) {
+    return null;
+  }
+  const rating = Math.round(fixDecimalNumber(courseReviews?.avgCourseRating ?? 0)); // Round to the nearest whole number
+  const totalStars = 5; // Total number of stars
+
+  return (
+    <div className="d-flex flex-row justify-content-center align-items-center mt-2 x-small">
+      {courseReviews?.avgCourseRating
+      && (
+        <span>{fixDecimalNumber(courseReviews.avgCourseRating ?? 0)}
+        </span>
+      )}
+      {courseReviews?.reviewsCount > 0
+      && (
+        <OverlayTrigger
+          placement="top"
+          overlay={(
+            <Tooltip variant="light" id="video-course-rating">
+              {intl.formatMessage({
+                id: 'enterprise.videoDetailPage.courseReviews.averageRating',
+                defaultMessage: '{reviewsCount} learners have rated this course in a post completion survey.',
+                description: 'The average rating of the course on a 5-star scale',
+              }, {
+                reviewsCount: courseReviews.reviewsCount,
+              })}
+            </Tooltip>
+          )}
+        >
+          <span className="d-flex flex-row mx-1 p-0">
+            {Array.from({ length: totalStars }, (_, index) => (
+              <Icon
+                key={index}
+                className="star-color"
+                size="xs"
+                src={index < rating ? StarFilled : StarOutline}
+              />
+            ))}
+          </span>
+        </OverlayTrigger>
+      )}
+      {courseReviews?.reviewsCount > 0 && <span>({courseReviews.reviewsCount})</span>}
+      <span className="mx-2">|</span>
+      {courseReviews?.totalEnrollments > 0 && (
+        <span>
+          <FormattedMessage
+            id="enterprise.courseAbout.learnersReviews.demand.and.growth.in.last.year"
+            defaultMessage="{totalEnrollments} recently enrolled!"
+            description="The number of learners who took the course in the last 12 months"
+            values={{
+              totalEnrollments: courseReviews.totalEnrollments,
+            }}
+          />
+        </span>
+      )}
+    </div>
+  );
+};
+
+VideoCourseReview.propTypes = {
+  courseKey: PropTypes.string.isRequired,
+};
+
+export default VideoCourseReview;

--- a/src/components/microlearning/VideoDetailPage.jsx
+++ b/src/components/microlearning/VideoDetailPage.jsx
@@ -1,15 +1,27 @@
+/* eslint-disable max-len */
 import React, { useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
-  Container, Breadcrumb, Row, MediaQuery, breakpoints, Badge, Skeleton,
+  Container, Breadcrumb, Row, Badge, Skeleton,
+  Hyperlink,
+  Icon,
+  Button,
 } from '@openedx/paragon';
 import loadable from '@loadable/component';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
-import { useVideoDetails, useEnterpriseCustomer } from '../app/data';
-import { Sidebar } from '../layout';
+import {
+  Person, Speed, Timelapse,
+} from '@openedx/paragon/icons';
+import {
+  useVideoDetails, useEnterpriseCustomer, useVideoCourseMetadata,
+} from '../app/data';
 import './styles/VideoDetailPage.scss';
 import DelayedFallbackContainer from '../DelayedFallback/DelayedFallbackContainer';
 import NotFoundPage from '../NotFoundPage';
+import { getCoursePrice, useCoursePacingType } from '../course/data';
+import VideoCourseReview from './VideoCourseReview';
+import { hasTruthyValue, isDefinedAndNotNull } from '../../utils/common';
+import { getLevelType } from './data/utils';
 
 const VideoPlayer = loadable(() => import(/* webpackChunkName: "videojs" */ '../video/VideoPlayer'), {
   fallback: (
@@ -23,7 +35,8 @@ const VideoDetailPage = () => {
   const location = useLocation();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { data: videoData } = useVideoDetails();
-
+  const { data: courseMetadata } = useVideoCourseMetadata(videoData?.courseKey);
+  const [pacingType, pacingTypeContent] = useCoursePacingType(courseMetadata?.activeCourseRun);
   const intl = useIntl();
 
   const customOptions = {
@@ -61,7 +74,7 @@ const VideoDetailPage = () => {
       />
     );
   }
-
+  const levelType = courseMetadata?.activeCourseRun?.levelType ? getLevelType(intl, courseMetadata.activeCourseRun.levelType) : null;
   return (
     <Container size="lg" className="pt-3 video-detail-page-wrapper">
       <div className="small">
@@ -82,24 +95,24 @@ const VideoDetailPage = () => {
                 {videoData?.videoDuration && `(${videoData?.videoDuration} minutes)`}
               </span>
             </div>
-            <p className="small align-self-stretch text-justify mb-2">
+            <p className="small align-self-stretch text-justify p-0 mb-0">
               {videoData?.videoSummary}
             </p>
-            { videoData?.videoSkills?.length > 0 && (
+            {videoData?.videoSkills?.length > 0 && (
               <div className="d-flex flex-row align-items-center">
-                <h4>
+                <h4 className="mb-0">
                   <FormattedMessage
                     id="videoDetailPage.skills.label"
                     defaultMessage="Skills:"
                     description="Label for skills on video detail page"
                   />
                 </h4>
-                <div className="ml-2 mb-2.5">
+                <div className="ml-2 mb-1">
                   {(
-                    videoData?.videoSkills.map((skill) => (
+                    videoData.videoSkills.map((skill) => (
                       <Badge
                         key={skill.skill_id}
-                        className="p-2 mr-1 mt-2 mr-2 font-weight-normal"
+                        className="p-2 mr-3 font-weight-normal"
                         variant="light"
                       >
                         {skill.name}
@@ -110,17 +123,143 @@ const VideoDetailPage = () => {
               </div>
             )}
           </div>
-          <div className="video-player-wrapper position-relative mw-100 overflow-hidden my-4 mt-2">
+          <div className="video-player-wrapper position-relative mw-100 overflow-hidden my-4 mt-0">
             <VideoPlayer videoURL={videoData?.videoUrl} customOptions={customOptions} />
           </div>
         </article>
-        <MediaQuery minWidth={breakpoints.large.minWidth}>
-          {matches => matches && (
-            <Sidebar>
-              {/* Course Sidebar will be inserted here */}
-            </Sidebar>
-          )}
-        </MediaQuery>
+        {isDefinedAndNotNull(courseMetadata.activeCourseRun) && (
+          <article className="col-12 col-lg-3 pr-0">
+            <div className="d-flex flex-column align-items-start">
+              <h3 className="m-0">
+                <FormattedMessage
+                  id="enterprise.videoDetail.courseSidebar.explore.course"
+                  defaultMessage="Explore this course"
+                  description="Heading for the section that lists the course details."
+                />
+              </h3>
+              <div className="d-flex align-items-center mt-2.5">
+                <img
+                  src={videoData?.institutionLogo}
+                  alt="institution logo"
+                  className="mr-2 logo-cutom-style rounded-sm p-1"
+                />
+                <div className="x-small">
+                  <Hyperlink
+                    destination={`/${enterpriseCustomer.slug}/course/${courseMetadata?.key}`}
+                    target="_blank"
+                  >
+                    {courseMetadata?.title}
+                  </Hyperlink>
+                </div>
+              </div>
+              <VideoCourseReview courseKey={courseMetadata.key} />
+              <div className="d-flex flex-column mt-2.5">
+                <div className="d-flex flex-row align-items-center">
+                  <strong className="mr-1">
+                    <FormattedMessage
+                      id="enterprise.courseAbout.courseSidebar.price.original"
+                      defaultMessage="Original price:"
+                      description="Label for the original price of the course."
+                    />
+                  </strong>
+                  <s>${getCoursePrice(courseMetadata)} USD</s>
+                  <h4 className="text-danger ml-2 m-0">
+                    <FormattedMessage
+                      id="enterprise.courseAbout.courseSidebar.price.free"
+                      defaultMessage="FREE"
+                      description="Label for the price of the course. FREE"
+                    />
+                  </h4>
+                </div>
+                <span className="text-muted small">
+                  <FormattedMessage
+                    id="enterprise.courseAbout.courseSidebar.price.coveredBy.your.organization"
+                    defaultMessage="Covered by your organization"
+                    description="Label for the price of the course. Covered by your organization"
+                  />
+                </span>
+              </div>
+            </div>
+            <div className="my-4.5">
+              {hasTruthyValue(courseMetadata.activeCourseRun.weeksToComplete) && (
+                <div className="d-flex flex-row align-items-center mb-3">
+                  <Icon className="mr-2" size="lg" src={Timelapse} style={{ height: '40px', width: '40px' }} />
+                  <div className="d-flex flex-column p-0 m-0">
+                    <h5 className="m-0 x-small">{courseMetadata.activeCourseRun.weeksToComplete} weeks</h5>
+                    {hasTruthyValue([courseMetadata.activeCourseRun.minEffort, courseMetadata.activeCourseRun.maxEffort]) && (
+                      <span className="text-muted x-small">
+                        {`${courseMetadata.activeCourseRun.minEffort}-${courseMetadata.activeCourseRun.maxEffort} hours per week`}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+              <div className="d-flex flex-row align-items-center mb-3">
+                <Icon className="mr-2" size="lg" src={Person} style={{ height: '40px', width: '40px' }} />
+                <div className="d-flex flex-column p-0 m-0">
+                  <h5 className="m-0 x-small">{pacingType}</h5>
+                  <span className="text-muted x-small">{pacingTypeContent}</span>
+                </div>
+              </div>
+              {courseMetadata.activeCourseRun.levelType && (
+                <div className="d-flex flex-row align-items-center mb-3">
+                  <Icon className="mr-2" size="lg" src={Speed} style={{ height: '40px', width: '40px' }} />
+                  <div className="d-flex flex-column p-0 m-0">
+                    <h5 className="m-0 x-small">{levelType.level}</h5>
+                    <span className="text-muted x-small">{levelType.description}</span>
+                  </div>
+                </div>
+              )}
+            </div>
+            <div>
+              <h3>
+                {intl.formatMessage({
+                  id: 'enterprise.videoDetail.courseSidebar.outcomeHeading',
+                  defaultMessage: "What you'll learn",
+                  description: 'Heading for the section that lists what you will learn in the course.',
+                })}
+              </h3>
+              <div
+                className="preview-enroll-expand-body x-small overflow-hidden position-relative"
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: courseMetadata?.outcome }}
+              />
+              <div className="x-small">
+                <FormattedMessage
+                  id="enterprise.videoDetailPage.sidebar.view.moreOn.coursePage"
+                  defaultMessage="<a>View more on course page</a>"
+                  description="Data sharing consent label for the executive education course enrollment page. And here GetSmarter is brand name"
+                  values={{
+                    // eslint-disable-next-line react/no-unstable-nested-components
+                    a: (chunks) => (
+                      <Hyperlink
+                        destination={`/${enterpriseCustomer.slug}/course/${courseMetadata?.key}`}
+                        target="_blank"
+                      >
+                        {chunks}
+                      </Hyperlink>
+                    ),
+                  }}
+                />
+              </div>
+              <div>
+                <Button
+                  variant="primary"
+                  as={Hyperlink}
+                  destination={`/${enterpriseCustomer.slug}/course/${courseMetadata?.key}`}
+                  target="_blank"
+                  className="mt-4.5 w-100"
+                >
+                  <FormattedMessage
+                    id="enterprise.videoDetailPage.sidebar.view.course.details"
+                    defaultMessage="View course details"
+                    description="Button to view course details"
+                  />
+                </Button>
+              </div>
+            </div>
+          </article>
+        )}
       </Row>
     </Container>
   );

--- a/src/components/microlearning/data/utils.js
+++ b/src/components/microlearning/data/utils.js
@@ -19,9 +19,60 @@ export const formatSkills = (skills) => skills?.map(skill => ({
 
 export const transformVideoData = (data) => ({
   videoUrl: data?.json_metadata?.download_link,
-  courseTitle: data?.parent_content_metadata?.title,
+  courseTitle: data?.title || data?.parent_content_metadata?.title,
   videoSummary: data?.summary_transcripts?.[0],
   transcriptUrls: data?.json_metadata?.transcript_urls,
   videoSkills: formatSkills(data?.skills),
   videoDuration: formatDuration(data?.json_metadata?.duration),
+  institutionLogo: data?.parent_content_metadata?.logo_image_urls[0],
+  courseKey: data?.parent_content_metadata?.parent_content_key,
 });
+
+export const getLevelType = (intl, level) => {
+  switch (level) {
+    case 'Introductory':
+      return {
+        level: intl.formatMessage({
+          id: 'enterprise.courseAbout.sidebarLevel.Introductory',
+          defaultMessage: 'Introductory',
+          description: 'Level of the course',
+        }),
+        description: intl.formatMessage({
+          id: 'enterprise.courseAbout.sidebarLevel.introductory.description',
+          defaultMessage: 'No prior experience required',
+          description: 'Introductory level of the course',
+        }),
+      };
+    case 'Intermediate':
+      return {
+        level: intl.formatMessage({
+          id: 'enterprise.courseAbout.sidebarLevel.intermediate',
+          defaultMessage: 'Intermediate',
+          description: 'Level of the course',
+        }),
+        description: intl.formatMessage({
+          id: 'enterprise.courseAbout.sidebarLevel.intermediate.description',
+          defaultMessage: 'Some prior experience recommended',
+          description: 'Intermediate level of the course',
+        }),
+      };
+    case 'Advanced':
+      return {
+        level: intl.formatMessage({
+          id: 'enterprise.courseAbout.sidebarLevel.Advanced',
+          defaultMessage: 'Advanced',
+          description: 'Level of the course',
+        }),
+        description: intl.formatMessage({
+          id: 'enterprise.courseAbout.sidebarLevel.advanced.description',
+          defaultMessage: 'Extensive prior experience recommended',
+          description: 'Advanced level of the course',
+        }),
+      };
+    default:
+      return {
+        level,
+        description: '',
+      };
+  }
+};

--- a/src/components/microlearning/data/utils.test.js
+++ b/src/components/microlearning/data/utils.test.js
@@ -24,6 +24,8 @@ describe('Microlearning utils tests', () => {
     },
     parent_content_metadata: {
       title: 'Course Title',
+      logo_image_urls: ['http://example.com/logo.png'],
+      parent_content_key: 'course-key',
     },
     summary_transcripts: [
       'Transcript 1', 'Transcript 2',
@@ -78,6 +80,8 @@ describe('Microlearning utils tests', () => {
         },
       ],
       videoDuration: '2:03',
+      institutionLogo: 'http://example.com/logo.png',
+      courseKey: 'course-key',
     });
   });
 

--- a/src/components/microlearning/styles/VideoDetailPage.scss
+++ b/src/components/microlearning/styles/VideoDetailPage.scss
@@ -81,4 +81,28 @@
   .vjs-transcribe-cueline {
     color: #00688d;
   }
+  .logo-cutom-style {
+    max-width: 59px;
+    max-height: 30px;
+    box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.15), 0px 0px 4px 0px rgba(0, 0, 0, 0.15);
+  }
+}
+.preview-enroll-expand-body {
+  max-height: 120px;
+  -webkit-transition: max-height .5s ease;
+  transition: max-height .5s ease;
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 24px;
+    background-image: -webkit-gradient(linear,left top,left bottom,from(hsla(0,0%,100%,0)),to(white));
+    background-image: linear-gradient(180deg,hsla(0,0%,100%,0),white);
+  }
+  ul {
+    padding-left: 1.5rem;
+  }
 }

--- a/src/components/microlearning/tests/VideoDetailPage.test.jsx
+++ b/src/components/microlearning/tests/VideoDetailPage.test.jsx
@@ -7,7 +7,11 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
 import { renderWithRouter } from '../../../utils/tests';
 import VideoDetailPage from '../VideoDetailPage';
-import { useVideoDetails, useEnterpriseCustomer } from '../../app/data';
+import {
+  useVideoDetails, useEnterpriseCustomer, useVideoCourseMetadata,
+  useVideoCourseReviews,
+} from '../../app/data';
+import { COURSE_PACING_MAP } from '../../course/data';
 
 const APP_CONFIG = {
   USE_API_CACHE: true,
@@ -25,14 +29,21 @@ const VIDEO_MOCK_DATA = {
     en: 'https://prod-edx-video-transcripts.edx-video.net/video-transcripts/4149c8bc684d4c01a0d82bca3acd8047.sjson',
   },
   videoUrl: 'test-video-url.mp4',
+  institutionLogo: 'test-institution-logo.png',
+  courseKey: 'test-course-key',
 };
 
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
 
+jest.mock('@edx/frontend-platform/auth');
+getAuthenticatedHttpClient.mockReturnValue(axios);
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
   useEnterpriseCustomer: jest.fn(),
   useVideoDetails: jest.fn(),
+  useRedeemablePolicies: jest.fn(() => ({ data: { redeemablePolicies: [] } })),
+  useVideoCourseMetadata: jest.fn(() => ({ data: { courseKey: 'test-course-key' } })),
+  useVideoCourseReviews: jest.fn(() => ({ data: { courseKey: 'test-course-key' } })),
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -45,8 +56,34 @@ jest.mock('@edx/frontend-platform/config', () => ({
   getConfig: jest.fn(() => APP_CONFIG),
 }));
 
-jest.mock('@edx/frontend-platform/auth');
-getAuthenticatedHttpClient.mockReturnValue(axios);
+const mockCourseRun = {
+  isEnrollable: true,
+  key: 'test-course-run-key',
+  pacingType: COURSE_PACING_MAP.SELF_PACED,
+  start: '2020-09-09T04:00:00Z',
+  availability: 'Current',
+  courseUuid: 'Foo',
+  weeksToComplete: 4,
+  minEffort: 2,
+  maxEffort: 4,
+  levelType: 'Introductory',
+};
+const mockCourseMetadata = {
+  key: 'test-course-key',
+  outcome: '<ul><li>hello i am descritpion</li></ul>',
+  title: 'Test Course Title',
+  activeCourseRun: mockCourseRun,
+  courseRuns: [mockCourseRun],
+};
+const mockCourseReviews = {
+  course_key: 'course-test-key',
+  reviewsCount: 345,
+  avgCourseRating: 3,
+  confidentLearnersPercentage: 33,
+  mostCommonGoal: 'Job advancement',
+  mostCommonGoalLearnersPercentage: 34,
+  totalEnrollments: 4444,
+};
 
 const VideoDetailPageWrapper = () => (
   <IntlProvider locale="en">
@@ -59,9 +96,11 @@ describe('VideoDetailPage Tests', () => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     useVideoDetails.mockReturnValue({ data: VIDEO_MOCK_DATA });
+    useVideoCourseReviews.mockReturnValue({ data: mockCourseReviews });
   });
 
   it('Renders video details when data is available', () => {
+    useVideoCourseMetadata.mockReturnValue({ data: mockCourseMetadata });
     const { container } = renderWithRouter(<VideoDetailPageWrapper />);
 
     expect(screen.getByTestId('video-title')).toHaveTextContent('Test Video');
@@ -70,6 +109,23 @@ describe('VideoDetailPage Tests', () => {
     expect(screen.getByText('Skill 1')).toBeInTheDocument();
     expect(screen.getByText('Skill 2')).toBeInTheDocument();
     expect(container.querySelector('.video-player-wrapper')).toBeTruthy();
+  });
+  it('renders a video detail page when course level type is Intermediate', () => {
+    useVideoCourseMetadata.mockReturnValue({ data: { ...mockCourseMetadata, activeCourseRun: { ...mockCourseRun, levelType: 'Intermediate' } } });
+    renderWithRouter(<VideoDetailPageWrapper />);
+    expect(screen.getByText('Intermediate')).toBeInTheDocument();
+  });
+
+  it('renders a video detail page when course level type is Advanced', () => {
+    useVideoCourseMetadata.mockReturnValue({ data: { ...mockCourseMetadata, activeCourseRun: { ...mockCourseRun, levelType: 'Advanced' } } });
+    renderWithRouter(<VideoDetailPageWrapper />);
+    expect(screen.getByText('Advanced')).toBeInTheDocument();
+  });
+
+  it('renders a video detail page when course level is not from listed ones', () => {
+    useVideoCourseMetadata.mockReturnValue({ data: { ...mockCourseMetadata, activeCourseRun: { ...mockCourseRun, levelType: 'Unknown' } } });
+    renderWithRouter(<VideoDetailPageWrapper />);
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
   });
 
   it('renders a not found page when video data is not found', () => {


### PR DESCRIPTION
**Description**
I added a course detail section to the video detail page.

![screencapture-localhost-stage-edx-org-8734-pied-piper-videos-e86f3685-2e68-499a-baaa-1e537a8dd728-2024-07-26-19_01_43](https://github.com/user-attachments/assets/e89fcf83-2ed8-40c7-9dbf-80d6f63997f5)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
