### PR TITLE
fix: ensure transcript button appears in video player

### DIFF
--- a/src/components/microlearning/VideoDetailPage.jsx
+++ b/src/components/microlearning/VideoDetailPage.jsx
@@ -91,11 +91,11 @@ const VideoDetailPage = () => {
               <h2 data-testid="video-title" className="mb-0">
                 {videoData?.courseTitle}
               </h2>
-              <span className="small ml-2 mt-2">
+              <span className="small ml-2 mt-2 text-nowrap">
                 {videoData?.videoDuration && `(${videoData?.videoDuration} minutes)`}
               </span>
             </div>
-            <p className="small align-self-stretch text-justify p-0 mb-0">
+            <p className="small align-self-stretch p-0 mb-0">
               {videoData?.videoSummary}
             </p>
             {videoData?.videoSkills?.length > 0 && (
@@ -123,9 +123,11 @@ const VideoDetailPage = () => {
               </div>
             )}
           </div>
-          <div className="video-player-wrapper position-relative mw-100 overflow-hidden my-4 mt-0">
-            <VideoPlayer videoURL={videoData?.videoUrl} customOptions={customOptions} />
-          </div>
+          { videoData?.videoUrl && (
+            <div className="video-player-wrapper position-relative mw-100 overflow-hidden my-4 mt-2">
+              <VideoPlayer videoURL={videoData?.videoUrl} customOptions={customOptions} />
+            </div>
+          )}
         </article>
         {isDefinedAndNotNull(courseMetadata.activeCourseRun) && (
           <article className="col-12 col-lg-3 pr-0">

--- a/src/components/video/VideoJS.jsx
+++ b/src/components/video/VideoJS.jsx
@@ -81,7 +81,6 @@ const VideoJS = ({ options, onReady, customOptions }) => {
       playerRef.current = videojs(videoElement, transformedPlayerOptions, () => {
         const textTracks = Object.entries(transcriptsData.textTracks);
         textTracks.forEach(([lang, webVttFileUrl]) => {
-          console.log('Adding remote text track', lang, webVttFileUrl);
           playerRef.current.addRemoteTextTrack({
             kind: 'subtitles',
             src: webVttFileUrl,

--- a/src/components/video/VideoJS.jsx
+++ b/src/components/video/VideoJS.jsx
@@ -13,7 +13,7 @@ window.videojs = videojs;
 require('videojs-vjstranscribe');
 
 function useTranscripts({ player, customOptions }) {
-  const shouldUseTranscripts = customOptions?.showTranscripts && customOptions?.transcriptUrls
+  const shouldUseTranscripts = customOptions?.showTranscripts && customOptions?.transcriptUrls;
   const [isLoading, setIsLoading] = useState(shouldUseTranscripts);
   const [textTracks, setTextTracks] = useState([]);
   const [transcriptUrl, setTranscriptUrl] = useState(null);

--- a/src/components/video/VideoPlayer.jsx
+++ b/src/components/video/VideoPlayer.jsx
@@ -8,6 +8,7 @@ const defaultOptions = {
   controls: true,
   responsive: true,
   fluid: true,
+  muted: true,
 };
 
 const VideoPlayer = ({ videoURL, onReady, customOptions }) => {

--- a/src/components/video/VideoPlayer.jsx
+++ b/src/components/video/VideoPlayer.jsx
@@ -8,7 +8,6 @@ const defaultOptions = {
   controls: true,
   responsive: true,
   fluid: true,
-  muted: true,
 };
 
 const VideoPlayer = ({ videoURL, onReady, customOptions }) => {

--- a/src/components/video/data/hooks.js
+++ b/src/components/video/data/hooks.js
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { logError } from '@edx/frontend-platform/logging';
+
+import { fetchAndAddTranscripts } from './service';
+
+export function useTranscripts({ player, customOptions }) {
+  const shouldUseTranscripts = !!(customOptions?.showTranscripts && customOptions?.transcriptUrls);
+  const [isLoading, setIsLoading] = useState(shouldUseTranscripts);
+  const [textTracks, setTextTracks] = useState([]);
+  const [transcriptUrl, setTranscriptUrl] = useState(null);
+
+  useEffect(() => {
+    const fetchFn = async () => {
+      setIsLoading(true);
+      if (shouldUseTranscripts) {
+        try {
+          const result = await fetchAndAddTranscripts(customOptions.transcriptUrls, player);
+          setTextTracks(result);
+          // We are only catering to English transcripts for now as we don't have the option to change
+          // the transcript language yet.
+          if (result.en) {
+            setTranscriptUrl(result.en);
+          }
+        } catch (error) {
+          logError(`Error fetching transcripts for player: ${error}`);
+        } finally {
+          setIsLoading(false);
+        }
+      }
+    };
+    fetchFn();
+  }, [customOptions.transcriptUrls, player, shouldUseTranscripts]);
+
+  return {
+    textTracks,
+    transcriptUrl,
+    isLoading,
+  };
+}
+
+export function usePlayerOptions({
+  transcripts,
+  options,
+  customOptions,
+}) {
+  const plugins = { ...options.plugins };
+  if (customOptions?.showTranscripts && transcripts.transcriptUrl) {
+    const existingTranscribeUrls = plugins.vjstranscribe?.urls || [];
+    plugins.vjstranscribe = {
+      ...plugins.vjstranscribe,
+      urls: [transcripts.transcriptUrl, ...existingTranscribeUrls],
+    };
+  }
+  return {
+    ...options,
+    plugins,
+  };
+}

--- a/src/components/video/data/hooks.js
+++ b/src/components/video/data/hooks.js
@@ -29,7 +29,7 @@ export function useTranscripts({ player, customOptions }) {
       }
     };
     fetchFn();
-  }, [customOptions.transcriptUrls, player, shouldUseTranscripts]);
+  }, [customOptions?.transcriptUrls, player, shouldUseTranscripts]);
 
   return {
     textTracks,

--- a/src/components/video/data/index.js
+++ b/src/components/video/data/index.js
@@ -1,0 +1,4 @@
+export * from './constants';
+export * from './hooks';
+export * from './service';
+export * from './utils';

--- a/src/components/video/data/service.js
+++ b/src/components/video/data/service.js
@@ -4,13 +4,8 @@ import { convertToWebVtt, createWebVttFile } from './utils';
 const fetchAndAddTranscripts = async (transcriptUrls) => {
   const data = {};
   const transcriptPromises = Object.entries(transcriptUrls).map(([lang, url]) => fetch(url)
-    .then(response => {
-      if (!response.ok) {
-        logError(`Failed to fetch transcript for ${lang}`);
-      }
-      return response.json();
-    })
-    .then(transcriptData => {
+    .then(response => response.json())
+    .then((transcriptData) => {
       const webVttData = convertToWebVtt(transcriptData);
       const webVttFileUrl = createWebVttFile(webVttData);
       data[lang] = webVttFileUrl;

--- a/src/components/video/data/service.js
+++ b/src/components/video/data/service.js
@@ -1,7 +1,7 @@
 import { logError } from '@edx/frontend-platform/logging';
 import { convertToWebVtt, createWebVttFile } from './utils';
 
-const fetchAndAddTranscripts = async (transcriptUrls, player) => {
+const fetchAndAddTranscripts = async (transcriptUrls) => {
   const data = {};
   const transcriptPromises = Object.entries(transcriptUrls).map(([lang, url]) => fetch(url)
     .then(response => {
@@ -24,6 +24,7 @@ const fetchAndAddTranscripts = async (transcriptUrls, player) => {
     return data;
   } catch (error) {
     logError(`Error fetching or processing transcripts: ${error}`);
+    return data;
   }
 };
 

--- a/src/components/video/data/tests/hooks.test.js
+++ b/src/components/video/data/tests/hooks.test.js
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { logError } from '@edx/frontend-platform/logging';
+import { useTranscripts } from '../hooks';
+import { fetchAndAddTranscripts } from '../service';
+
+// Mocking dependencies
+jest.mock('../service', () => ({
+  fetchAndAddTranscripts: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+describe('useTranscripts', () => {
+  const customOptions = {
+    showTranscripts: true,
+    transcriptUrls: {
+      en: 'https://example.com/transcript-en.txt',
+    },
+  };
+  const mockPlayer = {};
+
+  it('should set isLoading to true initially if showTranscripts is true', () => {
+    const { result } = renderHook(() => useTranscripts({ player: mockPlayer, customOptions }));
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('should fetch and set textTracks and transcriptUrl correctly', async () => {
+    const textTracks = { en: 'https://example.com/transcript-en.txt' };
+    fetchAndAddTranscripts.mockResolvedValueOnce(textTracks);
+
+    const { result, waitForNextUpdate } = renderHook(() => useTranscripts({ player: mockPlayer, customOptions }));
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.textTracks).toEqual(textTracks);
+    expect(result.current.transcriptUrl).toBe(textTracks.en);
+  });
+
+  it('should log error and set isLoading to false if fetching transcripts fails', async () => {
+    const errorMessage = 'Error fetching transcripts';
+    fetchAndAddTranscripts.mockRejectedValueOnce(new Error(errorMessage));
+
+    const { result, waitForNextUpdate } = renderHook(() => useTranscripts({ player: mockPlayer, customOptions }));
+
+    await waitForNextUpdate();
+
+    expect(logError).toHaveBeenCalledWith(`Error fetching transcripts for player: Error: ${errorMessage}`);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.textTracks).toEqual([]);
+    expect(result.current.transcriptUrl).toBeNull();
+  });
+
+  it('should not fetch transcripts if showTranscripts is false', async () => {
+    const customOptionsWithoutTranscripts = {
+      showTranscripts: false,
+      transcriptUrls: undefined,
+    };
+
+    const { result } = renderHook(() => useTranscripts({
+      player: mockPlayer,
+      customOptions: customOptionsWithoutTranscripts,
+    }));
+
+    expect(result.current.textTracks).toEqual([]);
+    expect(result.current.transcriptUrl).toBeNull();
+  });
+});

--- a/src/components/video/tests/VideoJS.test.jsx
+++ b/src/components/video/tests/VideoJS.test.jsx
@@ -25,8 +25,8 @@ const YoutubeVideoOptions = {
   sources: [{ src: ytUrl, type: 'video/youtube' }],
 };
 
-describe('Videon JS component', () => {
-  it('Renders VideoJS components correctly.', () => {
+describe('VideoJS', () => {
+  it('Renders VideoJS components correctly for HLS videos.', () => {
     const { container } = renderWithRouter(<VideoJS options={HLSVideoOptions} />);
     expect(container.querySelector('.video-js-wrapper')).toBeTruthy();
     expect(container.querySelector('.vjs-big-play-centered')).toBeTruthy();

--- a/src/components/video/tests/VideoJS.test.jsx
+++ b/src/components/video/tests/VideoJS.test.jsx
@@ -1,8 +1,15 @@
 import React from 'react';
-import { VideoJS } from '..';
+import { waitFor } from '@testing-library/react';
 import { renderWithRouter } from '../../../utils/tests';
+import VideoJS from '../VideoJS';
+import { useTranscripts } from '../data';
 
+// Mocking the 'videojs-vjstranscribe' and 'useTranscripts' hook
 jest.mock('videojs-vjstranscribe');
+jest.mock('../data', () => ({
+  useTranscripts: jest.fn(),
+  usePlayerOptions: jest.fn(),
+}));
 
 const hlsUrl = 'https://test-domain.com/test-prefix/id.m3u8';
 const ytUrl = 'https://www.youtube.com/watch?v=oHg5SJYRHA0';
@@ -26,6 +33,14 @@ const YoutubeVideoOptions = {
 };
 
 describe('VideoJS', () => {
+  beforeEach(() => {
+    useTranscripts.mockReturnValue({
+      isLoading: false,
+      textTracks: {},
+      transcriptUrl: null,
+    });
+  });
+
   it('Renders VideoJS components correctly for HLS videos.', () => {
     const { container } = renderWithRouter(<VideoJS options={HLSVideoOptions} />);
     expect(container.querySelector('.video-js-wrapper')).toBeTruthy();
@@ -38,5 +53,54 @@ describe('VideoJS', () => {
     expect(container.querySelector('.video-js-wrapper')).toBeTruthy();
     expect(container.querySelector('.vjs-big-play-centered')).toBeTruthy();
     expect(container.querySelector('video-js')).toBeTruthy();
+  });
+
+  it('Renders VideoJS components correctly with transcripts.', async () => {
+    const customOptions = {
+      showTranscripts: true,
+      transcriptUrls: {
+        en: 'https://example.com/transcript-en.txt',
+      },
+    };
+
+    useTranscripts.mockReturnValue({
+      isLoading: false,
+      textTracks: {
+        en: 'https://example.com/transcript-en.txt',
+      },
+      transcriptUrl: 'https://example.com/transcript-en.txt',
+    });
+
+    const { container } = renderWithRouter(<VideoJS options={HLSVideoOptions} customOptions={customOptions} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.video-js-wrapper')).toBeTruthy();
+      expect(container.querySelector('.vjs-big-play-centered')).toBeTruthy();
+      expect(container.querySelector('video-js')).toBeTruthy();
+      expect(container.querySelector('#vjs-transcribe')).toBeTruthy();
+    });
+  });
+
+  it('Does not initialize VideoJS player while transcripts are loading.', async () => {
+    const customOptions = {
+      showTranscripts: true,
+      transcriptUrls: {
+        en: 'https://example.com/transcript-en.txt',
+      },
+    };
+
+    useTranscripts.mockReturnValue({
+      isLoading: true,
+      textTracks: {},
+      transcriptUrl: null,
+    });
+
+    const { container } = renderWithRouter(<VideoJS options={HLSVideoOptions} customOptions={customOptions} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.video-js-wrapper')).toBeTruthy();
+      expect(container.querySelector('.vjs-big-play-centered')).toBeFalsy();
+      expect(container.querySelector('video-js')).toBeFalsy();
+    });
   });
 });

--- a/src/components/video/tests/VideoPlayer.test.jsx
+++ b/src/components/video/tests/VideoPlayer.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { waitFor } from '@testing-library/react';
-import { VideoPlayer } from '..'; // Assuming VideoPlayer is exported as named export
+import VideoPlayer from '../VideoPlayer';
 import { renderWithRouter } from '../../../utils/tests';
 
 const hlsUrl = 'https://test-domain.com/test-prefix/id.m3u8';


### PR DESCRIPTION
On stage/production (and seemingly locally on some machines), the "AD" transcripts button, added via `vjstranscribe` plugin for `video.js`, does not consistently appear, preventing users from using the transcript feature as expected.

This PR ensures the "AD" transcripts button always appears, using the out-of-the-box plugin by fetching the asynchronous transcripts data prior to initializing the player with `videojs(...)`:

![image](https://github.com/user-attachments/assets/e059ab94-6200-4d74-8c32-141291553f62)

### Video demo of fix

https://github.com/user-attachments/assets/10e6afd4-21ea-4f52-a592-b7a49dbf9981

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
