### PR TITLE
fix: hide assignment card if existing in-progress enrollment card is upgradeable

### DIFF
--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -733,3 +733,17 @@ export const getSubsidyToApplyForCourse = ({
 
   return undefined;
 };
+
+/**
+ * Determines whether the course enrollment can be upgraded to verified enrollment.
+ *
+ * @param {Object} enrollment Metadata about a course enrollment, containing the course mode and enrollment deadline.
+ * @returns {boolean} Whether the course enrollment can be upgraded to verified enrollment.
+ */
+export function isEnrollmentUpgradeable(enrollment) {
+  // Determine whether the course enrollment can be upgraded to verified enrollment, based
+  // on the course mode and enrollment deadline (if any).
+  const isEnrollByLapsed = enrollment.enrollBy ? dayjs().isAfter(dayjs(enrollment.enrollBy)) : false;
+  const canUpgradeToVerifiedEnrollment = enrollment.mode === COURSE_MODES_MAP.AUDIT && !isEnrollByLapsed;
+  return canUpgradeToVerifiedEnrollment;
+}

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -21,7 +21,7 @@ import { PROGRAM_TYPE_MAP } from '../../program/data/constants';
 import { programIsMicroMasters, programIsProfessionalCertificate } from '../../program/data/utils';
 import { hasValidStartExpirationDates } from '../../../utils/common';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
-import { COURSE_MODES_MAP, findHighestLevelEntitlementSku, findHighestLevelSkuByEntityModeType } from '../../app/data';
+import { findHighestLevelEntitlementSku, findHighestLevelSkuByEntityModeType, isEnrollmentUpgradeable } from '../../app/data';
 
 export function hasCourseStarted(start) {
   const today = new Date();
@@ -320,7 +320,7 @@ export function shouldUpgradeUserEnrollment({
   subscriptionLicense,
   enrollmentUrl,
 }) {
-  const isAuditEnrollment = userEnrollment?.mode === COURSE_MODES_MAP.AUDIT;
+  const isAuditEnrollment = isEnrollmentUpgradeable(userEnrollment);
   return !!(isAuditEnrollment && isActiveSubscriptionLicense(subscriptionLicense) && enrollmentUrl);
 }
 

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -79,7 +79,7 @@ const CourseEnrollments = ({ children }) => {
     handleAcknowledgeExpiringAssignments,
     handleAcknowledgeAssignments,
     isAcknowledgingAssignments,
-  } = useContentAssignments(allEnrollmentsByStatus.assigned);
+  } = useContentAssignments();
 
   const isFirstVisit = useIsFirstDashboardVisit();
 

--- a/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
@@ -15,7 +15,7 @@ import {
 
 import { COURSE_STATUSES } from '../../../../constants';
 import { COURSE_SECTION_TITLES } from '../../data/constants';
-import { COURSE_MODES_MAP, useEnterpriseCustomer } from '../../../app/data';
+import { COURSE_MODES_MAP, isEnrollmentUpgradeable, useEnterpriseCustomer } from '../../../app/data';
 import DelayedFallbackContainer from '../../../DelayedFallback/DelayedFallbackContainer';
 
 const CARD_COMPONENT_BY_COURSE_STATUS = {
@@ -103,8 +103,8 @@ const CourseSection = ({
 
   const renderCourseCards = () => courseRuns.map(courseRun => {
     const Component = CARD_COMPONENT_BY_COURSE_STATUS[courseRun.courseRunStatus];
-    const isAuditOrHonorEnrollment = [COURSE_MODES_MAP.AUDIT, COURSE_MODES_MAP.HONOR].includes(courseRun.mode);
-    if (isAuditOrHonorEnrollment && courseRun.courseRunStatus === COURSE_STATUSES.inProgress) {
+    const isAuditEnrollment = isEnrollmentUpgradeable(courseRun);
+    if (isAuditEnrollment && courseRun.courseRunStatus === COURSE_STATUSES.inProgress) {
       return (
         <Suspense
           key={courseRun.courseRunId}

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
@@ -66,6 +66,7 @@ export const InProgressCourseCard = ({
   notifications,
   courseRunStatus,
   startDate,
+  enrollBy,
   resumeCourseRunUrl,
   mode,
   ...rest
@@ -76,7 +77,11 @@ export const InProgressCourseCard = ({
     subsidyForCourse,
     hasUpgradeAndConfirm,
     courseRunPrice,
-  } = useCourseUpgradeData({ courseRunKey: courseRunId, mode });
+  } = useCourseUpgradeData({
+    courseRunKey: courseRunId,
+    enrollBy,
+    mode,
+  });
   const [isMarkCompleteModalOpen, setIsMarkCompleteModalOpen] = useState(false);
   const { courseCards } = useContext(AppContext);
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
@@ -96,6 +101,7 @@ export const InProgressCourseCard = ({
           title={title}
           courseRunKey={courseRunId}
           mode={mode}
+          enrollBy={enrollBy}
         />
       )}
       <ContinueLearningButton
@@ -234,6 +240,7 @@ export const InProgressCourseCard = ({
       courseRunId={courseRunId}
       mode={mode}
       startDate={startDate}
+      enrollBy={enrollBy}
       courseUpgradePrice={renderCourseUpgradePrice()}
       {...rest}
     >
@@ -261,12 +268,14 @@ InProgressCourseCard.propTypes = {
   title: PropTypes.string.isRequired,
   courseRunStatus: PropTypes.string.isRequired,
   startDate: PropTypes.string,
+  enrollBy: PropTypes.string,
   mode: PropTypes.string,
   resumeCourseRunUrl: PropTypes.string,
 };
 
 InProgressCourseCard.defaultProps = {
   startDate: null,
+  enrollBy: null,
   mode: null,
   resumeCourseRunUrl: null,
 };

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/UpgradeCourseButton.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/UpgradeCourseButton.jsx
@@ -68,6 +68,7 @@ const UpgradeCourseButton = ({
   variant,
   courseRunKey,
   mode,
+  enrollBy,
 }) => {
   const intl = useIntl();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -104,6 +105,7 @@ const UpgradeCourseButton = ({
   } = useCourseUpgradeData({
     courseRunKey,
     mode,
+    enrollBy,
     onRedeem: handleRedeem,
     onRedeemSuccess: handleRedemptionSuccess,
     onRedeemError: handleRedemptionError,
@@ -169,11 +171,13 @@ UpgradeCourseButton.propTypes = {
   title: PropTypes.string.isRequired,
   courseRunKey: PropTypes.string.isRequired,
   mode: PropTypes.string.isRequired,
+  enrollBy: PropTypes.string,
 };
 
 UpgradeCourseButton.defaultProps = {
   className: undefined,
   variant: 'outline-primary',
+  enrollBy: undefined,
 };
 
 export default UpgradeCourseButton;

--- a/src/components/dashboard/main-content/course-enrollments/data/utils.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/utils.js
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 
 /**
- * TODO
+ * Sorts list of enrollments by the enrollment date (i.e., when the enrollment record was created).
  * @param {*} enrollments
  * @returns
  */


### PR DESCRIPTION
[ENT-9070](https://2u-internal.atlassian.net/browse/ENT-9070)

Ensures that when a learner has a (potentially) upgradeable course enrollment (i.e., audit mode and a not-yet-elapsed `enrollBy` timestamp) _and_ an assignment for the same top-level course associated with the existing upgradable enrollment, the assignment card is hidden in favor of encouraging the learner to upgrade their existing "audit" enrollment to "verified" with their assignment instead of navigating to the course about page to choose a (potentially different) course run.

In the below screenshot, my user is enrolled in the audit mode for a course run of "Intermediate Happiness", for which I also have an allocated assignment. Note the assignment card is _not_ displayed, giving priority to the upgrade/upsell messaging on the in-progress audit enrollment card (i.e., "Upgrade for free").

![image](https://github.com/user-attachments/assets/252227fe-b6e8-4be7-8112-8bd93bc499b4)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
