### PR TITLE
chore: remove gating on learner credit enrollment upgrades from Dashboard

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AppContext } from '@edx/frontend-platform/react';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { logError } from '@edx/frontend-platform/logging';
-import { hasFeatureFlagEnabled, sendEnterpriseTrackEventWithDelay } from '@edx/frontend-enterprise-utils';
+import { sendEnterpriseTrackEventWithDelay } from '@edx/frontend-enterprise-utils';
 import _camelCase from 'lodash.camelcase';
 import _cloneDeep from 'lodash.clonedeep';
 
@@ -147,17 +147,13 @@ export const useCourseUpgradeData = ({
 }) => {
   const location = useLocation();
   const canUpgradeToVerifiedEnrollment = isEnrollmentUpgradeable({ mode, enrollBy });
-  const { authenticatedUser } = useContext(AppContext);
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { data: customerContainsContent } = useEnterpriseCustomerContainsContent([courseRunKey], {
     enabled: canUpgradeToVerifiedEnrollment,
   });
 
-  // TODO: Remove `isLearnerCreditUpgradeEnabled` flag when rolling out ENT-9135
-  // Metadata required to allow upgrade via applicable learner credit
-  const isLearnerCreditUpgradeEnabled = authenticatedUser.administrator || hasFeatureFlagEnabled('LEARNER_CREDIT_AUDIT_UPGRADE');
   const { data: learnerCreditMetadata } = useCanUpgradeWithLearnerCredit(courseRunKey, {
-    enabled: isLearnerCreditUpgradeEnabled && canUpgradeToVerifiedEnrollment,
+    enabled: canUpgradeToVerifiedEnrollment,
   });
 
   // Metadata required to allow upgrade via applicable subscription license
@@ -190,7 +186,7 @@ export const useCourseUpgradeData = ({
   });
 
   const { data: enterpriseCourseEnrollments } = useEnterpriseCourseEnrollments({
-    enabled: isLearnerCreditUpgradeEnabled && canUpgradeToVerifiedEnrollment,
+    enabled: canUpgradeToVerifiedEnrollment,
   });
 
   const { redeem: redeemLearnerCredit } = useStatefulEnroll({


### PR DESCRIPTION
[ENT-9135](https://2u-internal.atlassian.net/browse/ENT-9135)

Removes the gating (i.e., staff user or feature flag enabled via query parameter) on the API call to `can-redeem` within potentially upgradeable audit course enrollments.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
