### PR TITLE
ENT-9290: Show the videos section only to the learners who have an active subscription

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@1.2.3",
         "@edx/frontend-component-footer": "13.0.2",
-        "@edx/frontend-enterprise-catalog-search": "10.5.0",
+        "@edx/frontend-enterprise-catalog-search": "10.6.0",
         "@edx/frontend-enterprise-hotjar": "6.0.0",
         "@edx/frontend-enterprise-logistration": "8.0.0",
         "@edx/frontend-enterprise-utils": "8.0.0",
@@ -2330,9 +2330,9 @@
       }
     },
     "node_modules/@edx/frontend-enterprise-catalog-search": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-10.5.0.tgz",
-      "integrity": "sha512-okvigALMRd6DPxEsGHX4x6b/Rm/0tD3GGLIGOPMO2aippegTj/7Fp1STaRorZQF1iWJmtHRsawd5PNh8qrB39w==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-10.6.0.tgz",
+      "integrity": "sha512-ECnNRzq4Vnh2lvlG+8HdHYRpp/1iDYjEuHA6syvbKZMpz6oU0ccb3SL2K4tGVzfQhBUEHduVZHet4d3odlIeKg==",
       "dependencies": {
         "@edx/frontend-enterprise-utils": "^9.1.0",
         "classnames": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@1.2.3",
     "@edx/frontend-component-footer": "13.0.2",
-    "@edx/frontend-enterprise-catalog-search": "10.5.0",
+    "@edx/frontend-enterprise-catalog-search": "10.6.0",
     "@edx/frontend-enterprise-hotjar": "6.0.0",
     "@edx/frontend-enterprise-logistration": "8.0.0",
     "@edx/frontend-enterprise-utils": "8.0.0",

--- a/src/components/search/SearchPage.jsx
+++ b/src/components/search/SearchPage.jsx
@@ -2,15 +2,28 @@ import React from 'react';
 import { SearchData } from '@edx/frontend-enterprise-catalog-search';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
+import { useSubscriptions } from '../app/data';
+import { LICENSE_STATUS } from '../enterprise-user-subsidy/data/constants';
 import Search from './Search';
 import { SEARCH_TRACKING_NAME } from './constants';
 import { getSearchFacetFilters } from './utils';
+import { features } from '../../config';
 
 const SearchPage = () => {
   const intl = useIntl();
 
+  const { data: { subscriptionLicense } } = useSubscriptions();
+  const hasActivatedAndCurrentSubscription = (
+    subscriptionLicense?.status === LICENSE_STATUS.ACTIVATED
+    && subscriptionLicense?.subscriptionPlan?.isCurrent
+  );
+
   return (
-    <SearchData searchFacetFilters={getSearchFacetFilters(intl)} trackingName={SEARCH_TRACKING_NAME}>
+    <SearchData
+      searchFacetFilters={getSearchFacetFilters(intl)}
+      trackingName={SEARCH_TRACKING_NAME}
+      enableVideos={features.FEATURE_ENABLE_VIDEO_CATALOG && hasActivatedAndCurrentSubscription}
+    >
       <Search />
     </SearchData>
   );

--- a/src/components/search/tests/SearchPage.test.jsx
+++ b/src/components/search/tests/SearchPage.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { AppContext } from '@edx/frontend-platform/react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { useSubscriptions } from '../../app/data';
+import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
+import SearchPage from '../SearchPage';
+import { features } from '../../../config';
+import { renderWithRouter } from '../../../utils/tests';
+
+jest.mock('../../app/data', () => ({
+  useSubscriptions: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  getSearchFacetFilters: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('../Search', () => function () {
+  return <div>Mock Search Component</div>;
+});
+
+const initialAppState = {
+  authenticatedUser: { userId: 'test-user-id', username: 'test-username' },
+};
+
+const renderSearchPage = () => renderWithRouter(
+  <IntlProvider locale="en">
+    <AppContext.Provider value={initialAppState}>
+      <SearchPage />
+    </AppContext.Provider>
+  </IntlProvider>,
+);
+
+describe('SearchPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    features.FEATURE_ENABLE_VIDEO_CATALOG = true;
+  });
+
+  it('renders SearchPage component', () => {
+    useSubscriptions.mockReturnValue({
+      data: {
+        subscriptionLicense: {
+          status: LICENSE_STATUS.ACTIVATED,
+          subscriptionPlan: { isCurrent: true },
+        },
+      },
+    });
+
+    renderSearchPage();
+    expect(screen.queryByText('Mock Search Component')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
**Ticket:**
[ENT-9290](https://2u-internal.atlassian.net/browse/ENT-9290
)

**Description**
Made changes to show the videos section only to the enterprise learners who have an active subscription.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
