### PR TITLE
[ENT-9343] Fix autoplay setting for YouTube videos on course previews

### DIFF
--- a/src/components/video/VideoPlayer.jsx
+++ b/src/components/video/VideoPlayer.jsx
@@ -4,7 +4,7 @@ import VideoJS from './VideoJS';
 
 const hlsExtension = '.m3u8';
 const defaultOptions = {
-  autoplay: false,
+  autoplay: true,
   controls: true,
   responsive: true,
   fluid: true,
@@ -17,6 +17,8 @@ const VideoPlayer = ({ videoURL, onReady, customOptions }) => {
     if (isMp4Video) {
       return {
         ...defaultOptions,
+        // Disable autoplay if `showTranscripts` is enabled (video detail page); enable autoplay otherwise.
+        autoplay: !customOptions?.showTranscripts,
         sources: [{ src: videoURL, type: 'video/mp4' }],
       };
     }
@@ -35,6 +37,7 @@ const VideoPlayer = ({ videoURL, onReady, customOptions }) => {
       controls: true,
       sources: [{ src: videoURL, type: 'application/x-mpegURL' }],
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [videoURL]);
 
   return (


### PR DESCRIPTION
**Ticket**
https://2u-internal.atlassian.net/browse/ENT-9343

**Description**
Set autoplay to true for YouTube videos on the course about page (restoring previous behavior) and false for videos on the video detail page. This change resolves issues where video previews were breaking on the course about page.


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
