### PR TITLE
feat: Support course run based go to enrollment links

### DIFF
--- a/src/components/app/data/constants.js
+++ b/src/components/app/data/constants.js
@@ -53,3 +53,14 @@ export const LEARNER_CREDIT_SUBSIDY_TYPE = 'learnerCredit';
 
 export const ENROLL_BY_DATE_WARNING_THRESHOLD_DAYS = 10;
 export const MAX_HIGHLIGHT_SETS = 12;
+
+// Note: `cancelled` is correct and matches backend state
+// despite how the key is spelled
+export const ASSIGNMENT_TYPES = {
+  ACCEPTED: 'accepted',
+  ALLOCATED: 'allocated',
+  CANCELED: 'cancelled',
+  EXPIRED: 'expired',
+  ERRORED: 'errored',
+  EXPIRING: 'expiring',
+};

--- a/src/components/app/data/hooks/useIsAssignmentsOnlyLearner.test.jsx
+++ b/src/components/app/data/hooks/useIsAssignmentsOnlyLearner.test.jsx
@@ -8,8 +8,8 @@ import useCouponCodes from './useCouponCodes';
 import useEnterpriseOffers from './useEnterpriseOffers';
 import useRedeemablePolicies from './useRedeemablePolicies';
 import useSubscriptions from './useSubscriptions';
-import { ASSIGNMENT_TYPES, POLICY_TYPES } from '../../../enterprise-user-subsidy/enterprise-offers/data/constants';
-import { emptyRedeemableLearnerCreditPolicies } from '../constants';
+import { POLICY_TYPES } from '../../../enterprise-user-subsidy/enterprise-offers/data/constants';
+import { ASSIGNMENT_TYPES, emptyRedeemableLearnerCreditPolicies } from '../constants';
 
 jest.mock('./useEnterpriseCustomer');
 jest.mock('./useBrowseAndRequest');

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -368,7 +368,7 @@ export const transformSubsidyRequest = ({
   notifications: [], // required prop by CourseSection
 });
 
-export const assignmentTypeStates = ({ state }) => ({
+export const determineAssignmentState = ({ state }) => ({
   isAcceptedAssignment: state === ASSIGNMENT_TYPES.ACCEPTED,
   isAllocatedAssignment: state === ASSIGNMENT_TYPES.ALLOCATED,
   isCanceledAssignment: state === ASSIGNMENT_TYPES.CANCELED,
@@ -388,9 +388,11 @@ export const transformLearnerContentAssignment = (learnerContentAssignment, ente
   const {
     isExpiredAssignment,
     isCanceledAssignment,
-  } = assignmentTypeStates({ state });
+  } = determineAssignmentState({ state });
   const { date: assignmentEnrollByDeadline } = earliestPossibleExpiration;
 
+  // This logic is intended to remain backwards
+  // compatible with assignments for top-level courses
   let courseKey = contentKey;
   let courseRunId = courseKey;
   if (isAssignedCourseRun) {

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -1,12 +1,13 @@
 import dayjs from 'dayjs';
 import { logError } from '@edx/frontend-platform/logging';
 
-import { ASSIGNMENT_TYPES, POLICY_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
+import { POLICY_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 import { getBrandColorsFromCSSVariables, isDefinedAndNotNull, isTodayWithinDateThreshold } from '../../../utils/common';
 import { COURSE_STATUSES, SUBSIDY_TYPE } from '../../../constants';
 import { LATE_ENROLLMENTS_BUFFER_DAYS } from '../../../config/constants';
 import {
+  ASSIGNMENT_TYPES,
   COUPON_CODE_SUBSIDY_TYPE,
   COURSE_AVAILABILITY_MAP,
   COURSE_MODES_MAP,
@@ -367,17 +368,40 @@ export const transformSubsidyRequest = ({
   notifications: [], // required prop by CourseSection
 });
 
+export const assignmentTypeStates = ({ state }) => ({
+  isAcceptedAssignment: state === ASSIGNMENT_TYPES.ACCEPTED,
+  isAllocatedAssignment: state === ASSIGNMENT_TYPES.ALLOCATED,
+  isCanceledAssignment: state === ASSIGNMENT_TYPES.CANCELED,
+  isExpiredAssignment: state === ASSIGNMENT_TYPES.EXPIRED,
+  isErroredAssignment: state === ASSIGNMENT_TYPES.ERRORED,
+  isExpiringAssignment: state === ASSIGNMENT_TYPES.EXPIRING,
+});
+
 export const transformLearnerContentAssignment = (learnerContentAssignment, enterpriseSlug) => {
-  const isCanceledAssignment = learnerContentAssignment.state === ASSIGNMENT_TYPES.CANCELED;
-  const isExpiredAssignment = learnerContentAssignment.state === ASSIGNMENT_TYPES.EXPIRED;
-  const { date: assignmentEnrollByDeadline } = learnerContentAssignment.earliestPossibleExpiration;
+  const {
+    contentKey,
+    parentContentKey,
+    isAssignedCourseRun,
+    state,
+    earliestPossibleExpiration,
+  } = learnerContentAssignment;
+  const {
+    isExpiredAssignment,
+    isCanceledAssignment,
+  } = assignmentTypeStates({ state });
+  const { date: assignmentEnrollByDeadline } = earliestPossibleExpiration;
+
+  let courseKey = contentKey;
+  let courseRunId = courseKey;
+  if (isAssignedCourseRun) {
+    courseKey = parentContentKey;
+    courseRunId = contentKey;
+  }
+
   return {
-    linkToCourse: `/${enterpriseSlug}/course/${learnerContentAssignment.contentKey}`,
-    // Note: we are using `courseRunId` instead of `contentKey` or `courseKey` because the `CourseSection`
-    // and `BaseCourseCard` components expect `courseRunId` to be used as the content identifier. Consider
-    // refactoring to rename `courseRunId` to `contentKey` in the future given learner content assignments
-    // are for top-level courses, not course runs.
-    courseRunId: learnerContentAssignment.contentKey,
+    linkToCourse: `/${enterpriseSlug}/course/${courseKey}`,
+    courseRunId,
+    isAssignedCourseRun,
     title: learnerContentAssignment.contentTitle,
     isRevoked: false,
     notifications: [],

--- a/src/components/app/data/utils.test.js
+++ b/src/components/app/data/utils.test.js
@@ -2,7 +2,7 @@ import MockDate from 'mockdate';
 
 import dayjs from 'dayjs';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
-import { ASSIGNMENT_TYPES, POLICY_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
+import { POLICY_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
 import {
   determineLearnerHasContentAssignmentsOnly,
   filterPoliciesByExpirationAndActive,
@@ -11,6 +11,7 @@ import {
   transformGroupMembership,
 } from './utils';
 import {
+  ASSIGNMENT_TYPES,
   COUPON_CODE_SUBSIDY_TYPE,
   COURSE_AVAILABILITY_MAP,
   emptyRedeemableLearnerCreditPolicies,

--- a/src/components/app/data/utils.test.js
+++ b/src/components/app/data/utils.test.js
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 import { POLICY_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
 import {
-  assignmentTypeStates,
+  determineAssignmentState,
   determineLearnerHasContentAssignmentsOnly,
   filterPoliciesByExpirationAndActive,
   getAvailableCourseRuns,
@@ -867,7 +867,7 @@ describe('getSubsidyToApplyForCourse', () => {
   });
 });
 
-describe('assignmentTypeStates', () => {
+describe('determineAssignmentState', () => {
   it.each([{
     state: 'accepted',
   },
@@ -890,7 +890,7 @@ describe('assignmentTypeStates', () => {
     state: 'pikachu',
   },
   ])('returns expected object when state is passed (%s)', ({ state }) => {
-    const currentAssignmentStates = assignmentTypeStates({ state });
+    const currentAssignmentStates = determineAssignmentState({ state });
     const baseAssignmentStates = {
       isAcceptedAssignment: false,
       isAllocatedAssignment: false,

--- a/src/components/dashboard/main-content/course-enrollments/CourseAssignmentAlert.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseAssignmentAlert.jsx
@@ -4,8 +4,7 @@ import { Info, Warning } from '@openedx/paragon/icons';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 
 import { getContactEmail } from '../../../../utils/common';
-import { ASSIGNMENT_TYPES } from '../../../enterprise-user-subsidy/enterprise-offers/data/constants';
-import { useEnterpriseCustomer } from '../../../app/data';
+import { ASSIGNMENT_TYPES, useEnterpriseCustomer } from '../../../app/data';
 
 const alertMessagingByVariant = {
   [ASSIGNMENT_TYPES.CANCELED]: {

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -7,9 +7,8 @@ import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import CourseSection from './CourseSection';
 import CourseAssignmentAlert from './CourseAssignmentAlert';
 import { features } from '../../../../config';
-import { useCourseEnrollmentsBySection, useContentAssignments, useGroupAssociationsAlert } from './data';
-import { ASSIGNMENT_TYPES } from '../../../enterprise-user-subsidy/enterprise-offers/data/constants';
-import { useEnterpriseCourseEnrollments, useEnterpriseFeatures } from '../../../app/data';
+import { useContentAssignments, useCourseEnrollmentsBySection, useGroupAssociationsAlert } from './data';
+import { ASSIGNMENT_TYPES, useEnterpriseCourseEnrollments, useEnterpriseFeatures } from '../../../app/data';
 import CourseEnrollmentsAlert from './CourseEnrollmentsAlert';
 import NewGroupAssignmentAlert from './NewGroupAssignmentAlert';
 

--- a/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
@@ -66,10 +66,14 @@ const CourseSection = ({
     notifications,
     courseRunStatus,
     isRevoked,
+    parentContentKey,
     ...rest
   }) => {
     const courseRunProps = { courseRunStatus };
     switch (courseRunStatus) {
+      case COURSE_STATUSES.assigned:
+        courseRunProps.parentContentKey = parentContentKey;
+        break;
       case COURSE_STATUSES.inProgress:
         courseRunProps.linkToCertificate = linkToCertificate;
         courseRunProps.notifications = notifications;

--- a/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
@@ -66,14 +66,10 @@ const CourseSection = ({
     notifications,
     courseRunStatus,
     isRevoked,
-    parentContentKey,
     ...rest
   }) => {
     const courseRunProps = { courseRunStatus };
     switch (courseRunStatus) {
-      case COURSE_STATUSES.assigned:
-        courseRunProps.parentContentKey = parentContentKey;
-        break;
       case COURSE_STATUSES.inProgress:
         courseRunProps.linkToCertificate = linkToCertificate;
         courseRunProps.notifications = notifications;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/AssignedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/AssignedCourseCard.jsx
@@ -16,14 +16,14 @@ const AssignedCourseCard = (props) => {
     // refactoring to rename `courseRunId` to `contentKey` in the future given learner content assignments
     // are for top-level courses, not course runs.
     courseRunId: courseKey,
+    parentContentKey,
     isCanceledAssignment,
     isExpiredAssignment,
   } = props;
-
   const renderButtons = () => (
     <Button
       as={Link}
-      to={`/${enterpriseCustomer.slug}/course/${courseKey}`}
+      to={`/${enterpriseCustomer.slug}/course/${parentContentKey ?? courseKey}`}
       className={classNames('btn-xs-block', { disabled: isCanceledAssignment || isExpiredAssignment })}
       // TODO: Not all assignment cards are rendered with a darker background (e.g., external courses
       // such as Executive Education) should use the inverse-brand variant while Open Courses (with white
@@ -53,6 +53,7 @@ const AssignedCourseCard = (props) => {
 
 AssignedCourseCard.propTypes = {
   courseRunId: PropTypes.string.isRequired,
+  parentContentKey: PropTypes.string,
   title: PropTypes.string.isRequired,
   isRevoked: PropTypes.bool,
   courseRunStatus: PropTypes.string.isRequired,
@@ -66,6 +67,7 @@ AssignedCourseCard.propTypes = {
 
 AssignedCourseCard.defaultProps = {
   endDate: null,
+  parentContentKey: null,
   isRevoked: false,
   startDate: null,
   mode: null,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/AssignedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/AssignedCourseCard.jsx
@@ -6,24 +6,21 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import BaseCourseCard from './BaseCourseCard';
 import { COURSE_STATUSES } from '../data';
-import { useEnterpriseCustomer } from '../../../../app/data';
 
 const AssignedCourseCard = (props) => {
-  const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const {
     // Note: we are using `courseRunId` instead of `contentKey` or `courseKey` because the `CourseSection`
     // and `BaseCourseCard` components expect `courseRunId` to be used as the content identifier. Consider
     // refactoring to rename `courseRunId` to `contentKey` in the future given learner content assignments
     // are for top-level courses, not course runs.
-    courseRunId: courseKey,
-    parentContentKey,
+    linkToCourse,
     isCanceledAssignment,
     isExpiredAssignment,
   } = props;
   const renderButtons = () => (
     <Button
       as={Link}
-      to={`/${enterpriseCustomer.slug}/course/${parentContentKey ?? courseKey}`}
+      to={linkToCourse}
       className={classNames('btn-xs-block', { disabled: isCanceledAssignment || isExpiredAssignment })}
       // TODO: Not all assignment cards are rendered with a darker background (e.g., external courses
       // such as Executive Education) should use the inverse-brand variant while Open Courses (with white
@@ -53,7 +50,6 @@ const AssignedCourseCard = (props) => {
 
 AssignedCourseCard.propTypes = {
   courseRunId: PropTypes.string.isRequired,
-  parentContentKey: PropTypes.string,
   title: PropTypes.string.isRequired,
   isRevoked: PropTypes.bool,
   courseRunStatus: PropTypes.string.isRequired,
@@ -67,7 +63,6 @@ AssignedCourseCard.propTypes = {
 
 AssignedCourseCard.defaultProps = {
   endDate: null,
-  parentContentKey: null,
   isRevoked: false,
   startDate: null,
   mode: null,

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -19,8 +19,8 @@ import {
   findHighestLevelSeatSku,
 } from '../../../../course/data/utils';
 import { getExpiringAssignmentsAcknowledgementState, getHasUnacknowledgedAssignments } from '../../../data/utils';
-import { ASSIGNMENT_TYPES } from '../../../../enterprise-user-subsidy/enterprise-offers/data/constants';
 import {
+  ASSIGNMENT_TYPES,
   COUPON_CODE_SUBSIDY_TYPE,
   getSubsidyToApplyForCourse,
   groupCourseEnrollmentsByStatus,

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import * as logger from '@edx/frontend-platform/logging';
 import { AppContext } from '@edx/frontend-platform/react';
 import { sendEnterpriseTrackEventWithDelay } from '@edx/frontend-enterprise-utils';
@@ -20,27 +20,30 @@ import * as service from '../service';
 import { COURSE_STATUSES, HAS_USER_DISMISSED_NEW_GROUP_ALERT } from '../constants';
 import { createRawCourseEnrollment } from '../../tests/enrollment-testutils';
 import {
-  createEnrollWithLicenseUrl,
   createEnrollWithCouponCodeUrl,
+  createEnrollWithLicenseUrl,
   findHighestLevelSeatSku,
 } from '../../../../../course/data/utils';
-import { ASSIGNMENT_TYPES } from '../../../../../enterprise-user-subsidy/enterprise-offers/data/constants';
 import {
-  ENROLL_BY_DATE_WARNING_THRESHOLD_DAYS,
+  ASSIGNMENT_TYPES,
   COURSE_MODES_MAP,
   emptyRedeemableLearnerCreditPolicies,
+  ENROLL_BY_DATE_WARNING_THRESHOLD_DAYS,
   transformCourseEnrollment,
   transformLearnerContentAssignment,
   useCanUpgradeWithLearnerCredit,
   useCouponCodes,
+  useCourseRunMetadata,
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
   useEnterpriseCustomerContainsContent,
   useRedeemablePolicies,
   useSubscriptions,
-  useCourseRunMetadata,
 } from '../../../../../app/data';
-import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../../../../app/data/services/data/__factories__';
+import {
+  authenticatedUserFactory,
+  enterpriseCustomerFactory,
+} from '../../../../../app/data/services/data/__factories__';
 import { ASSIGNMENTS_EXPIRING_WARNING_LOCALSTORAGE_KEY } from '../../../../data/constants';
 import { LICENSE_STATUS } from '../../../../../enterprise-user-subsidy/data/constants';
 import { useStatefulEnroll } from '../../../../../stateful-enroll/data';

--- a/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
@@ -13,12 +13,14 @@ import { createCourseEnrollmentWithStatus } from './enrollment-testutils';
 
 import { COURSE_SECTION_TITLES } from '../../../data/constants';
 import CourseEnrollments from '../CourseEnrollments';
-import { MARK_MOVE_TO_IN_PROGRESS_DEFAULT_LABEL } from '../course-cards/move-to-in-progress-modal/MoveToInProgressModal';
+import {
+  MARK_MOVE_TO_IN_PROGRESS_DEFAULT_LABEL,
+} from '../course-cards/move-to-in-progress-modal/MoveToInProgressModal';
 import { MARK_SAVED_FOR_LATER_DEFAULT_LABEL } from '../course-cards/mark-complete-modal/MarkCompleteModal';
 import { updateCourseCompleteStatusRequest } from '../course-cards/mark-complete-modal/data/service';
 import { COURSE_STATUSES } from '../data/constants';
-import { ASSIGNMENT_TYPES } from '../../../../enterprise-user-subsidy/enterprise-offers/data/constants';
 import {
+  ASSIGNMENT_TYPES,
   COURSE_MODES_MAP,
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
@@ -30,7 +32,8 @@ import {
   useContentAssignments,
   useCourseEnrollments,
   useCourseEnrollmentsBySection,
-  useCourseUpgradeData, useGroupAssociationsAlert,
+  useCourseUpgradeData,
+  useGroupAssociationsAlert,
 } from '../data/hooks';
 
 jest.mock('@edx/frontend-enterprise-utils');

--- a/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
+++ b/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
@@ -19,8 +19,9 @@ import {
   SUBSCRIPTION_SUMMARY_CARD_TITLE,
 } from '../data/constants';
 import { LICENSE_STATUS } from '../../../enterprise-user-subsidy/data/constants';
-import { ASSIGNMENT_TYPES, POLICY_TYPES } from '../../../enterprise-user-subsidy/enterprise-offers/data/constants';
+import { POLICY_TYPES } from '../../../enterprise-user-subsidy/enterprise-offers/data/constants';
 import {
+  ASSIGNMENT_TYPES,
   emptyRedeemableLearnerCreditPolicies,
   useAcademies,
   useBrowseAndRequest,

--- a/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/data/constants.js
@@ -30,15 +30,6 @@ export const NO_BALANCE_CONTACT_ADMIN_TEXT = 'Contact administrator';
 
 export const OFFER_BALANCE_CLICK_EVENT = 'edx.ui.enterprise.learner_portal.offer_balance_alert.clicked';
 
-// TODO: why are these Learner Credit policies and content assignments related constants in this file?
-export const ASSIGNMENT_TYPES = {
-  ACCEPTED: 'accepted',
-  ALLOCATED: 'allocated',
-  CANCELED: 'cancelled',
-  EXPIRED: 'expired',
-  ERRORED: 'errored',
-  EXPIRING: 'expiring',
-};
 export const POLICY_TYPES = {
   ASSIGNED_CREDIT: 'AssignedLearnerCreditAccessPolicy',
   PER_LEARNER_CREDIT: 'PerLearnerSpendCreditAccessPolicy',


### PR DESCRIPTION
Adds support for the `parentContentKey` on assignment based dashboard course cards to use the `parentContentKey` field to generate the course enrollment link.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
