### PR TITLE
feat: implemented some pre release requirements on video detail page

### DIFF
--- a/src/components/microlearning/tests/VideoDetailPage.test.jsx
+++ b/src/components/microlearning/tests/VideoDetailPage.test.jsx
@@ -10,8 +10,11 @@ import VideoDetailPage from '../VideoDetailPage';
 import {
   useVideoDetails, useEnterpriseCustomer, useVideoCourseMetadata,
   useVideoCourseReviews,
+  useSubscriptions,
 } from '../../app/data';
 import { COURSE_PACING_MAP } from '../../course/data';
+import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
+import { features } from '../../../config';
 
 const APP_CONFIG = {
   USE_API_CACHE: true,
@@ -44,6 +47,7 @@ jest.mock('../../app/data', () => ({
   useRedeemablePolicies: jest.fn(() => ({ data: { redeemablePolicies: [] } })),
   useVideoCourseMetadata: jest.fn(() => ({ data: { courseKey: 'test-course-key' } })),
   useVideoCourseReviews: jest.fn(() => ({ data: { courseKey: 'test-course-key' } })),
+  useSubscriptions: jest.fn(),
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -97,6 +101,18 @@ describe('VideoDetailPage Tests', () => {
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     useVideoDetails.mockReturnValue({ data: VIDEO_MOCK_DATA });
     useVideoCourseReviews.mockReturnValue({ data: mockCourseReviews });
+    useSubscriptions.mockReturnValue({
+      data: {
+        subscriptionLicense: {
+          status: LICENSE_STATUS.ACTIVATED,
+          subscriptionPlan: {
+            enterpriseCatalogUuid: 'test-catalog-uuid',
+            isCurrent: true,
+          },
+        },
+      },
+    });
+    features.FEATURE_ENABLE_VIDEO_CATALOG = true;
   });
 
   it('Renders video details when data is available', () => {
@@ -132,6 +148,21 @@ describe('VideoDetailPage Tests', () => {
 
   it('renders a not found page when video data is not found', () => {
     useVideoDetails.mockReturnValue({ data: null });
+    renderWithRouter(<VideoDetailPageWrapper />);
+    expect(screen.getByTestId('not-found-page')).toBeInTheDocument();
+  });
+  it('renders a not found page when user do not have active subscription', () => {
+    useSubscriptions.mockReturnValue({
+      data: {
+        subscriptionLicense: {
+          status: LICENSE_STATUS.ACTIVATED,
+          subscriptionPlan: {
+            enterpriseCatalogUuid: 'test-catalog-uuid',
+            isCurrent: false,
+          },
+        },
+      },
+    });
     renderWithRouter(<VideoDetailPageWrapper />);
     expect(screen.getByTestId('not-found-page')).toBeInTheDocument();
   });


### PR DESCRIPTION
**Description**
This PR covers the following things

[ENT-9339](https://2u-internal.atlassian.net/browse/ENT-9339)
- Remove breadcrumbs. 
- Ensure there is Paragon spacer 4 (24 px) between header and video title.

[ENT-9340](https://2u-internal.atlassian.net/browse/ENT-9340)
-  Change the course info section links to open the course about page within the same window, instead of a new tab.

[ENT-9357](https://2u-internal.atlassian.net/browse/ENT-9357)

- Restrict the video detail page for learners who doesn't have active subscription

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
