### PR TITLE
fix: sort licenses by whether they are current in ascending order before further processing

### DIFF
--- a/src/components/app/data/services/subsidies/subscriptions.js
+++ b/src/components/app/data/services/subsidies/subscriptions.js
@@ -233,8 +233,19 @@ export async function fetchSubscriptions(enterpriseUUID) {
     if (customerAgreement) {
       subscriptionsData.customerAgreement = customerAgreement;
     }
-    subscriptionsData.subscriptionLicenses = subscriptionLicenses;
     subscriptionsData.showExpirationNotifications = !(customerAgreement?.disableExpirationNotifications);
+
+    // Sort licenses within each license status by whether the associated subscription plans
+    // are current; current plans should be prioritized over non-current plans.
+    subscriptionLicenses.sort((a, b) => {
+      const aIsCurrent = a.subscriptionPlan.isCurrent;
+      const bIsCurrent = b.subscriptionPlan.isCurrent;
+      if (aIsCurrent && bIsCurrent) { return 0; }
+      return aIsCurrent ? -1 : 1;
+    });
+    subscriptionsData.subscriptionLicenses = subscriptionLicenses;
+
+    // Group licenses by status.
     subscriptionLicenses.forEach((license) => {
       const { subscriptionPlan, status } = license;
       const isUnassignedLicense = status === LICENSE_STATUS.UNASSIGNED;
@@ -243,6 +254,8 @@ export async function fetchSubscriptions(enterpriseUUID) {
       }
       licensesByStatus[license.status].push(license);
     });
+
+    // Extracts a single subscription license for the user, from the ordered licenses by status.
     const applicableSubscriptionLicense = Object.values(licensesByStatus).flat()[0];
     if (applicableSubscriptionLicense) {
       subscriptionsData.subscriptionLicense = applicableSubscriptionLicense;


### PR DESCRIPTION
## Bug 🐛 

[(ENT-9373)](https://2u-internal.atlassian.net/browse/ENT-9373)

tl;dr; Some subscription licenses are getting treated as expired in the UX, even though they have activated license in a _current_ subscription plan:

<img width="393" alt="image" src="https://github.com/user-attachments/assets/f64a34f5-d4f0-4e29-a065-84070def77a4">

Learners who have an activated subscription license at the time a subscription plan renewal was processed (i.e., where their activated license is copied to the renewal plan), end up incorrectly seeing their activated license as expired for the _current_ subscription plan.

In this case of a processed renewal for a learner who had an activated license, the `learner-licenses` API begins returning the activated renewal license first in the list of licenses tied to the authenticated learner. As a result, the `fetchSubscriptions` logic which parses the list of subscription licenses ends up extracting the first activated subscription license returned by the API, aka the activated _renewal_ license, not the _current_ license.

Given this, because the determined subscription license to use throughout the UX ends up being the renewal license, the plan's `isCurrent` flag is false, triggering the expiration experience.

## Resolution 💪 

Sort the returned list of subscription licenses from the `learner-licenses` API to prioritize the _current_ licenses when grouping licenses by status. By doing so, we will ensure the extracted license from `fetchSubscriptions` will be a _current_ license, if one exists.

### Alternative approaches to consider

* **Introduce query parameter to `learner-licenses` to exclude upcoming subscription plans.** We currently pass `current_plans_only: false` to ensure we include expired plans to support the expiration UX, but this pulls in upcoming/scheduled plans as a result.
* Introduce query parameter to `learner-licenses` to order the response list of licenses by whether the associated subscription plan `isCurrent`.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
