### PR TITLE
[ENT-9342, ENT-9338] Video transcript updates

### DIFF
--- a/src/components/course/course-header/tests/CoursePreview.test.jsx
+++ b/src/components/course/course-header/tests/CoursePreview.test.jsx
@@ -11,6 +11,11 @@ const imageURL = 'https://test-domain.com/test-image/id.png';
 const hlsUrl = 'https://test-domain.com/test-prefix/id.m3u8';
 const ytUrl = 'https://www.youtube.com/watch?v=oHg5SJYRHA0';
 
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n'),
+  getLocale: () => 'en',
+}));
+
 describe('Course Preview Tests', () => {
   it('Renders preview image and not the video when video URL is not given.', () => {
     const { container, getByAltText } = renderWithRouter(<CoursePreview previewImage={imageURL} />);

--- a/src/components/microlearning/styles/VideoDetailPage.scss
+++ b/src/components/microlearning/styles/VideoDetailPage.scss
@@ -29,6 +29,7 @@
 
   .video-player-container-with-transcript {
     display: flex;
+    padding-bottom: 55px;
   }
 
   .video-js-wrapper {

--- a/src/components/video/VideoJS.jsx
+++ b/src/components/video/VideoJS.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import 'videojs-youtube';
 import videojs from 'video.js';
 import 'video.js/dist/video-js.css';
+import { getLocale } from '@edx/frontend-platform/i18n';
 import { PLAYBACK_RATES } from './data/constants';
 import { usePlayerOptions, useTranscripts } from './data';
 
@@ -14,10 +15,12 @@ require('videojs-vjstranscribe');
 const VideoJS = ({ options, onReady, customOptions }) => {
   const videoRef = useRef(null);
   const playerRef = useRef(null);
+  const siteLanguage = getLocale();
 
   const transcripts = useTranscripts({
     player: playerRef.current,
     customOptions,
+    siteLanguage,
   });
 
   const playerOptions = usePlayerOptions({

--- a/src/components/video/data/tests/hooks.test.js
+++ b/src/components/video/data/tests/hooks.test.js
@@ -49,7 +49,7 @@ describe('useTranscripts', () => {
 
     expect(logError).toHaveBeenCalledWith(`Error fetching transcripts for player: Error: ${errorMessage}`);
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.textTracks).toEqual([]);
+    expect(result.current.textTracks).toEqual({});
     expect(result.current.transcriptUrl).toBeNull();
   });
 
@@ -64,7 +64,7 @@ describe('useTranscripts', () => {
       customOptions: customOptionsWithoutTranscripts,
     }));
 
-    expect(result.current.textTracks).toEqual([]);
+    expect(result.current.textTracks).toEqual({});
     expect(result.current.transcriptUrl).toBeNull();
   });
 });

--- a/src/components/video/data/tests/utils.test.js
+++ b/src/components/video/data/tests/utils.test.js
@@ -1,4 +1,4 @@
-import { convertToWebVtt, createWebVttFile } from '../utils';
+import { convertToWebVtt, createWebVttFile, sortTextTracks } from '../utils';
 
 describe('Video utils tests', () => {
   it('should convert transcript data to WebVTT format correctly', () => {
@@ -39,5 +39,23 @@ describe('Video utils tests', () => {
     const blob = URL.createObjectURL.mock.calls[0][0];
     expect(blob.type).toBe('text/vtt');
     expect(blob.size).toBe(mockWebVttContent.length);
+  });
+  it('should sort text tracks with site language first and others alphabetically', () => {
+    const mockTracks = {
+      en: 'https://test-domain.com/transcript-en.txt',
+      ar: 'https://test-domain.com/transcript-ar.txt',
+      fr: 'https://test-domain.com/transcript-fr.txt',
+    };
+
+    const siteLanguage = 'fr';
+
+    const expectedSortedTracks = {
+      fr: 'https://test-domain.com/transcript-fr.txt',
+      ar: 'https://test-domain.com/transcript-ar.txt',
+      en: 'https://test-domain.com/transcript-en.txt',
+    };
+
+    const result = sortTextTracks(mockTracks, siteLanguage);
+    expect(result).toEqual(expectedSortedTracks);
   });
 });

--- a/src/components/video/data/utils.js
+++ b/src/components/video/data/utils.js
@@ -26,3 +26,16 @@ export const createWebVttFile = (webVttContent) => {
   const blob = new Blob([webVttContent], { type: 'text/vtt' });
   return URL.createObjectURL(blob);
 };
+
+export const sortTextTracks = (tracks, siteLanguage) => {
+  const sortedKeys = Object.keys(tracks).sort((a, b) => {
+    if (a === siteLanguage) { return -1; }
+    if (b === siteLanguage) { return 1; }
+    return a.localeCompare(b);
+  });
+
+  return sortedKeys.reduce((acc, key) => {
+    acc[key] = tracks[key];
+    return acc;
+  }, {});
+};

--- a/src/components/video/tests/VideoJS.test.jsx
+++ b/src/components/video/tests/VideoJS.test.jsx
@@ -11,6 +11,11 @@ jest.mock('../data', () => ({
   usePlayerOptions: jest.fn(),
 }));
 
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n'),
+  getLocale: () => 'en',
+}));
+
 const hlsUrl = 'https://test-domain.com/test-prefix/id.m3u8';
 const ytUrl = 'https://www.youtube.com/watch?v=oHg5SJYRHA0';
 

--- a/src/components/video/tests/VideoPlayer.test.jsx
+++ b/src/components/video/tests/VideoPlayer.test.jsx
@@ -7,6 +7,11 @@ const hlsUrl = 'https://test-domain.com/test-prefix/id.m3u8';
 const ytUrl = 'https://www.youtube.com/watch?v=oHg5SJYRHA0';
 const mp3Url = 'https://example.com/audio.mp3';
 
+jest.mock('@edx/frontend-platform/i18n', () => ({
+  ...jest.requireActual('@edx/frontend-platform/i18n'),
+  getLocale: () => 'en',
+}));
+
 describe('Video Player component', () => {
   it('Renders Video Player components correctly for HLS videos.', async () => {
     const { container } = renderWithRouter(<VideoPlayer videoURL={hlsUrl} />);


### PR DESCRIPTION
**Tickets**
- [ENT-9342](https://2u-internal.atlassian.net/browse/ENT-9342)
- [ENT-9338](https://2u-internal.atlassian.net/browse/ENT-9338)

**Description**
- Updated the videos to have a default transcript language that matches the browser's default.
- Fixed an issue where video player controls were missing for a specific video due to inconsistent size.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
