### PR TITLE
[ENT-9342] handle site lang with region subtags in text track sorting

### DIFF
--- a/src/components/video/data/tests/hooks.test.js
+++ b/src/components/video/data/tests/hooks.test.js
@@ -30,7 +30,11 @@ describe('useTranscripts', () => {
     const textTracks = { en: 'https://example.com/transcript-en.txt' };
     fetchAndAddTranscripts.mockResolvedValueOnce(textTracks);
 
-    const { result, waitForNextUpdate } = renderHook(() => useTranscripts({ player: mockPlayer, customOptions }));
+    const { result, waitForNextUpdate } = renderHook(() => useTranscripts({
+      player: mockPlayer,
+      customOptions,
+      siteLanguage: 'en',
+    }));
 
     await waitForNextUpdate();
 

--- a/src/components/video/data/utils.js
+++ b/src/components/video/data/utils.js
@@ -28,9 +28,13 @@ export const createWebVttFile = (webVttContent) => {
 };
 
 export const sortTextTracks = (tracks, siteLanguage) => {
+  // Some language codes returned by getLocale include a hyphen, which may not match the codes in the text tracks.
+  // To ensure proper matching, the hyphen is removed from the site language code if present.
+  const preferredLanguage = siteLanguage?.includes('-') ? siteLanguage.split('-')[0].toLowerCase() : siteLanguage.toLowerCase();
+
   const sortedKeys = Object.keys(tracks).sort((a, b) => {
-    if (a === siteLanguage) { return -1; }
-    if (b === siteLanguage) { return 1; }
+    if (a === preferredLanguage) { return -1; }
+    if (b === preferredLanguage) { return 1; }
     return a.localeCompare(b);
   });
 


### PR DESCRIPTION
**Ticket**
https://2u-internal.atlassian.net/browse/ENT-9342

**Description**
Some language codes returned by `getLocale` include a hyphen, which may not match the codes in the text tracks.
To ensure proper matching, the hyphen is removed from the site language code if present.


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
