### PR TITLE
[ENT-9375] Fix: "AD" button appears but doesn't work for some videos

### DIFF
--- a/src/components/course/course-header/tests/CoursePreview.test.jsx
+++ b/src/components/course/course-header/tests/CoursePreview.test.jsx
@@ -14,6 +14,7 @@ const ytUrl = 'https://www.youtube.com/watch?v=oHg5SJYRHA0';
 jest.mock('@edx/frontend-platform/i18n', () => ({
   ...jest.requireActual('@edx/frontend-platform/i18n'),
   getLocale: () => 'en',
+  getPrimaryLanguageSubtag: () => 'en',
 }));
 
 describe('Course Preview Tests', () => {

--- a/src/components/video/data/hooks.js
+++ b/src/components/video/data/hooks.js
@@ -18,12 +18,13 @@ export function useTranscripts({ player, customOptions, siteLanguage }) {
           const result = await fetchAndAddTranscripts(customOptions.transcriptUrls, player);
 
           // Sort the text tracks to prioritize the site language at the top of the list.
-          // Currently, video.js selects the top language from the list of transcripts.
-          const sortedResult = sortTextTracks(result, siteLanguage);
+          // since video.js selects the top language from the list of transcripts.
+          // Preferred language is the site language, with English as the fallback.
+          const preferredLanguage = result?.[siteLanguage] ? siteLanguage : 'en';
+          const sortedResult = sortTextTracks(result, preferredLanguage);
           setTextTracks(sortedResult);
 
-          // Default to site language, fallback to English
-          const preferredTranscript = sortedResult[siteLanguage] || sortedResult.en;
+          const preferredTranscript = sortedResult?.[preferredLanguage];
           setTranscriptUrl(preferredTranscript);
         } catch (error) {
           logError(`Error fetching transcripts for player: ${error}`);

--- a/src/components/video/data/utils.js
+++ b/src/components/video/data/utils.js
@@ -27,11 +27,7 @@ export const createWebVttFile = (webVttContent) => {
   return URL.createObjectURL(blob);
 };
 
-export const sortTextTracks = (tracks, siteLanguage) => {
-  // Some language codes returned by getLocale include a hyphen, which may not match the codes in the text tracks.
-  // To ensure proper matching, the hyphen is removed from the site language code if present.
-  const preferredLanguage = siteLanguage?.includes('-') ? siteLanguage.split('-')[0].toLowerCase() : siteLanguage.toLowerCase();
-
+export const sortTextTracks = (tracks, preferredLanguage) => {
   const sortedKeys = Object.keys(tracks).sort((a, b) => {
     if (a === preferredLanguage) { return -1; }
     if (b === preferredLanguage) { return 1; }

--- a/src/components/video/tests/VideoPlayer.test.jsx
+++ b/src/components/video/tests/VideoPlayer.test.jsx
@@ -10,6 +10,7 @@ const mp3Url = 'https://example.com/audio.mp3';
 jest.mock('@edx/frontend-platform/i18n', () => ({
   ...jest.requireActual('@edx/frontend-platform/i18n'),
   getLocale: () => 'en',
+  getPrimaryLanguageSubtag: () => 'en',
 }));
 
 describe('Video Player component', () => {


### PR DESCRIPTION
**Ticket**
[ENT-9375](https://2u-internal.atlassian.net/browse/ENT-9375
)

**Description**
- Resolved an issue where the "AD" button appeared but didn't work for some videos due to text tracks being lost after `@tanstack/react-query` performed background re-fetches.  When the player is re-initialized or its sources are updated due to re-fetching, it loses the text tracks that were previously added, so made changes to re-add text tracks after background re-fetches.
- Additionally, added some improvements for [ENT-9342](https://2u-internal.atlassian.net/browse/ENT-9342) by using the `getPrimaryLanguageSubtag` method from `edx-platform` to strip full language locales and fallback to English when tracks are unavailable in the site language.



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
