### PR TITLE
[ENT-9376] Fix: Actively playing video restarts due to background query re-fetches

### DIFF
--- a/src/components/video/VideoJS.jsx
+++ b/src/components/video/VideoJS.jsx
@@ -74,7 +74,8 @@ const VideoJS = ({ options, onReady, customOptions }) => {
       videoRef.current.appendChild(videoElement);
 
       playerRef.current = videojs(videoElement, playerOptions, handlePlayerReady);
-    } else {
+    } else if (playerOptions?.sources[0]?.src !== playerRef?.current?.currentSrc()) {
+      // Only update player if the source changes
       playerRef.current.autoplay(playerOptions.autoplay);
       playerRef.current.src(playerOptions.sources);
 


### PR DESCRIPTION
**Ticket:**
https://2u-internal.atlassian.net/browse/ENT-9376

**Description**
Made changes to ensure that the video player does not re-render / restart when `@tanstack/react-query` performs background re-fetches on queries rendered within the video detail page.

**Screen Recording:**
https://github.com/user-attachments/assets/77656631-bdbd-46a7-bec4-7ed1f50d8cc8



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
