### PR TITLE
[ENT-9383] chore: upgrade @edx/frontend-enterprise-catalog-search to 10.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@1.2.3",
         "@edx/frontend-component-footer": "13.0.3",
-        "@edx/frontend-enterprise-catalog-search": "10.6.0",
+        "@edx/frontend-enterprise-catalog-search": "10.7.0",
         "@edx/frontend-enterprise-hotjar": "6.0.0",
         "@edx/frontend-enterprise-logistration": "8.0.0",
         "@edx/frontend-enterprise-utils": "8.0.0",
@@ -2258,9 +2258,9 @@
       }
     },
     "node_modules/@edx/frontend-enterprise-catalog-search": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-10.6.0.tgz",
-      "integrity": "sha512-ECnNRzq4Vnh2lvlG+8HdHYRpp/1iDYjEuHA6syvbKZMpz6oU0ccb3SL2K4tGVzfQhBUEHduVZHet4d3odlIeKg==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-10.7.0.tgz",
+      "integrity": "sha512-hAKqSQ9BMpwvpaV2AVbqLxKlJJD62otQYgSOh0pY3JAr+fNxWmEsvtFvX/laPQdjsF2MKPp/ZuihnoD22xm8Wg==",
       "dependencies": {
         "@edx/frontend-enterprise-utils": "^9.1.0",
         "classnames": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@1.2.3",
     "@edx/frontend-component-footer": "13.0.3",
-    "@edx/frontend-enterprise-catalog-search": "10.6.0",
+    "@edx/frontend-enterprise-catalog-search": "10.7.0",
     "@edx/frontend-enterprise-hotjar": "6.0.0",
     "@edx/frontend-enterprise-logistration": "8.0.0",
     "@edx/frontend-enterprise-utils": "8.0.0",


### PR DESCRIPTION
**Ticket:**
https://2u-internal.atlassian.net/browse/ENT-9383

**Description:**
Bumped the version of catalog search to display **Beta** label with videos in the learning type facet.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
