### PR TITLE
feat: default stale start dates to today

### DIFF
--- a/src/components/app/data/constants.js
+++ b/src/components/app/data/constants.js
@@ -65,5 +65,5 @@ export const ASSIGNMENT_TYPES = {
   EXPIRING: 'expiring',
 };
 
-// Start date threshold to default to today days, sets start date to today if course start date is beyond this value
+// When the start date is before this number of days before today, display the alternate start date (fixed to today).
 export const START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS = 14;

--- a/src/components/app/data/constants.js
+++ b/src/components/app/data/constants.js
@@ -64,3 +64,6 @@ export const ASSIGNMENT_TYPES = {
   ERRORED: 'errored',
   EXPIRING: 'expiring',
 };
+
+// Start date threshold to default to today days, sets start date to today if course start date is beyond this value
+export const START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS = 14;

--- a/src/components/app/data/hooks/useEnterpriseCourseEnrollments.js
+++ b/src/components/app/data/hooks/useEnterpriseCourseEnrollments.js
@@ -73,7 +73,7 @@ export default function useEnterpriseCourseEnrollments(queryOptions = {}) {
     },
     enabled: isEnabled,
   });
-
+  // TODO: Talk about how we don't have access to weeksToComplete on the dashboard page.
   const allEnrollmentsByStatus = useMemo(() => transformAllEnrollmentsByStatus({
     enterpriseCourseEnrollments,
     requests,

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -317,7 +317,6 @@ export const canUnenrollCourseEnrollment = (courseEnrollment) => {
  */
 export const transformCourseEnrollment = (rawCourseEnrollment) => {
   const courseEnrollment = { ...rawCourseEnrollment };
-
   // Return the fields expected by the component(s)
   courseEnrollment.title = courseEnrollment.displayName;
   courseEnrollment.microMastersTitle = courseEnrollment.micromastersTitle;
@@ -409,7 +408,6 @@ export const transformLearnerContentAssignment = (learnerContentAssignment, ente
     courseKey = parentContentKey;
     courseRunId = contentKey;
   }
-
   return {
     linkToCourse: `/${enterpriseSlug}/course/${courseKey}`,
     courseRunId,
@@ -879,7 +877,7 @@ export function transformCourseMetadataByAllocatedCourseRunAssignments({
       courseRuns: courseMetadata.courseRuns.filter(
         courseRun => allocatedCourseRunAssignmentKeys.includes(courseRun.key),
       ),
-      availableCourseRuns: courseMetadata.courseRuns.filter(
+      availableCourseRuns: courseMetadata.availableCourseRuns.filter(
         courseRun => allocatedCourseRunAssignmentKeys.includes(courseRun.key),
       ),
     };

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -508,7 +508,6 @@ export function getAvailableCourseRuns({ course, lateEnrollmentBufferDays }) {
   if (!course?.courseRuns) {
     return [];
   }
-
   // These are the standard rules used for determining whether a run is "available".
   const standardAvailableCourseRunsFilter = (courseRun) => (
     courseRun.isMarketable && !isArchived(courseRun) && courseRun.isEnrollable

--- a/src/components/course/course-header/CourseImportantDates.jsx
+++ b/src/components/course/course-header/CourseImportantDates.jsx
@@ -89,7 +89,7 @@ const CourseImportantDates = () => {
   // Match soonest expiring assignment to the corresponding course start date from course metadata
   let soonestExpiringAllocatedAssignmentCourseStartDate = null;
   if (soonestExpiringAssignment) {
-    const soonestExpiringAllocatedAssignment = courseMetadata.availableCourseRuns?.find(
+    const soonestExpiringAllocatedAssignment = courseMetadata.availableCourseRuns.find(
       (courseRun) => courseRun.key === soonestExpiringAssignment?.contentKey,
     );
     soonestExpiringAllocatedAssignmentCourseStartDate = soonestExpiringAllocatedAssignment

--- a/src/components/course/course-header/CourseImportantDates.jsx
+++ b/src/components/course/course-header/CourseImportantDates.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import {
   DATE_FORMAT,
   DATETIME_FORMAT,
+  getNormalizedStartDate,
   getSoonestEarliestPossibleExpirationData,
   hasCourseStarted,
   useIsCourseAssigned,
@@ -88,11 +89,11 @@ const CourseImportantDates = () => {
   // Match soonest expiring assignment to the corresponding course start date from course metadata
   let soonestExpiringAllocatedAssignmentCourseStartDate = null;
   if (soonestExpiringAssignment) {
-    soonestExpiringAllocatedAssignmentCourseStartDate = courseMetadata.availableCourseRuns.find(
+    const soonestExpiringAllocatedAssignment = courseMetadata.availableCourseRuns.find(
       (courseRun) => courseRun.key === soonestExpiringAssignment?.contentKey,
-    )?.start;
+    );
+    soonestExpiringAllocatedAssignmentCourseStartDate = getNormalizedStartDate(soonestExpiringAllocatedAssignment);
   }
-
   // Parse logic of date existence and labels
   const enrollByDate = soonestExpirationDate ?? null;
   const courseStartDate = soonestExpiringAllocatedAssignmentCourseStartDate

--- a/src/components/course/course-header/CourseImportantDates.jsx
+++ b/src/components/course/course-header/CourseImportantDates.jsx
@@ -89,10 +89,11 @@ const CourseImportantDates = () => {
   // Match soonest expiring assignment to the corresponding course start date from course metadata
   let soonestExpiringAllocatedAssignmentCourseStartDate = null;
   if (soonestExpiringAssignment) {
-    const soonestExpiringAllocatedAssignment = courseMetadata.availableCourseRuns.find(
+    const soonestExpiringAllocatedAssignment = courseMetadata.availableCourseRuns?.find(
       (courseRun) => courseRun.key === soonestExpiringAssignment?.contentKey,
     );
-    soonestExpiringAllocatedAssignmentCourseStartDate = getNormalizedStartDate(soonestExpiringAllocatedAssignment);
+    soonestExpiringAllocatedAssignmentCourseStartDate = soonestExpiringAllocatedAssignment
+      && getNormalizedStartDate(soonestExpiringAllocatedAssignment);
   }
   // Parse logic of date existence and labels
   const enrollByDate = soonestExpirationDate ?? null;

--- a/src/components/course/data/constants.js
+++ b/src/components/course/data/constants.js
@@ -1,5 +1,7 @@
 import GetSmarterLogo from '../../../assets/icons/getsmarter-header-icon.svg';
 
+// The SELF and INSTRUCTOR values are keys/value pairs used specifically for pacing sourced from the
+// enterprise_course_enrollments API.
 export const COURSE_PACING_MAP = {
   SELF_PACED: 'self_paced',
   INSTRUCTOR_PACED: 'instructor_paced',

--- a/src/components/course/data/constants.js
+++ b/src/components/course/data/constants.js
@@ -3,6 +3,8 @@ import GetSmarterLogo from '../../../assets/icons/getsmarter-header-icon.svg';
 export const COURSE_PACING_MAP = {
   SELF_PACED: 'self_paced',
   INSTRUCTOR_PACED: 'instructor_paced',
+  INSTRUCTOR: 'instructor',
+  SELF: 'self',
 };
 
 export const SUBSIDY_DISCOUNT_TYPE_MAP = {
@@ -122,5 +124,5 @@ export const DISABLED_ENROLL_USER_MESSAGES = {
 /* eslint-enable max-len */
 
 export const DATE_FORMAT = 'MMM D, YYYY';
-export const DATETIME_FORMAT = 'MMM D, YYYY h:mm, a';
+export const DATETIME_FORMAT = 'MMM D, YYYY h:mma';
 export const ZERO_PRICE = 0.00;

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -31,10 +31,6 @@ import {
 
 /**
  * Determines if the course has already started. Mostly used around text formatting for tense
- * Introduces 'jitter' in the form of a 30 second offset to take into account any additional
- * formatting that takes place down stream related to setting values to today's date through dayjs()
- *
- * This should also help with reducing 'flaky' tests.
  *
  * @param start
  * @returns {boolean}
@@ -68,11 +64,11 @@ export function hasTimeToComplete(courseRun) {
 }
 
 export function isCourseSelfPaced(pacingType) {
-  return pacingType === COURSE_PACING_MAP.SELF_PACED || pacingType === COURSE_PACING_MAP.SELF;
+  return [COURSE_PACING_MAP.SELF_PACED, COURSE_PACING_MAP.SELF].includes(pacingType);
 }
 
 export function isCourseInstructorPaced(pacingType) {
-  return pacingType === COURSE_PACING_MAP.INSTRUCTOR_PACED || pacingType === COURSE_PACING_MAP.INSTRUCTOR;
+  return [COURSE_PACING_MAP.INSTRUCTOR_PACED, COURSE_PACING_MAP.INSTRUCTOR].includes(pacingType);
 }
 
 const isWithinMinimumStartDateThreshold = ({ start }) => dayjs(start).isBefore(dayjs().subtract(START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS, 'days'));
@@ -81,10 +77,10 @@ const isWithinMinimumStartDateThreshold = ({ start }) => dayjs(start).isBefore(d
  * If the start date of the course is before today offset by the START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS
  * then return today's formatted date. Otherwise, pass-through the start date in ISO format.
  *
- * @param start
- * @param pacingType
- * @param end
- * @param weeksToComplete
+ * @param {String} start
+ * @param {String} pacingType
+ * @param {String} end
+ * @param {Number} weeksToComplete
  * @returns {string}
  */
 export const getNormalizedStartDate = ({
@@ -978,23 +974,3 @@ export function getSoonestEarliestPossibleExpirationData({
     sortedExpirationAssignments: sortedByExpirationDate,
   };
 }
-
-/**
- * If the start date of the course is before today offset by the START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS
- * then return today's formatted date. Otherwise, pass-through the start date in ISO format.
- *
- * For cases where a start date does not exist, just return today's date.
- *
- * @param start
- * @param format
- * @returns {string}
- */
-export const setStaleCourseStartDates = ({ start }) => {
-  if (!start) {
-    return dayjs().toISOString();
-  }
-  if (dayjs(start).isBefore(dayjs().subtract(START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS, 'days'))) {
-    return dayjs().toISOString();
-  }
-  return dayjs(start).toISOString();
-};

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -39,7 +39,7 @@ import {
  * @param start
  * @returns {boolean}
  */
-export const hasCourseStarted = (start) => dayjs(start).isBefore(dayjs().subtract(30, 'seconds'));
+export const hasCourseStarted = (start) => dayjs(start).isBefore(dayjs());
 
 export function findUserEnrollmentForCourseRun({ userEnrollments, key }) {
   return userEnrollments.find(

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -33,6 +33,7 @@ import {
   useEnterpriseCustomer,
 } from '../../../../app/data';
 import { isCourseEnded, isDefinedAndNotNull, isTodayWithinDateThreshold } from '../../../../../utils/common';
+import { getNormalizedStartDate } from '../../../../course/data';
 
 const messages = defineMessages({
   statusBadgeLabelInProgress: {
@@ -401,8 +402,15 @@ const BaseCourseCard = ({
   };
 
   const renderStartDate = () => {
-    const formattedStartDate = startDate ? dayjs(startDate).format('MMMM Do, YYYY') : null;
-    const isCourseStarted = dayjs(startDate) <= dayjs();
+    // TODO: Determine if its worth exposing weeks_to_complete in assignments to utilize this function effectively
+    const courseStartDate = getNormalizedStartDate({
+      start: startDate,
+      pacingType: pacing,
+      end: endDate,
+      weeksToComplete: null,
+    });
+    const formattedStartDate = dayjs(courseStartDate).format('MMMM Do, YYYY');
+    const isCourseStarted = dayjs(courseStartDate).isBefore(dayjs());
     if (formattedStartDate && !isCourseStarted) {
       return <span className="font-weight-light">Starts {formattedStartDate}</span>;
     }

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -498,7 +498,6 @@ export function useCourseEnrollmentsBySection(courseEnrollmentsByStatus) {
     ]),
     [courseEnrollmentsByStatus],
   );
-
   const completedCourseEnrollments = useMemo(
     () => sortedEnrollmentsByEnrollmentDate(courseEnrollmentsByStatus.completed),
     [courseEnrollmentsByStatus.completed],


### PR DESCRIPTION
Based on a heuristic, default stale course start dates to today to display in various locations in the learner journey

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
