### PR TITLE
fix: ensure course about page acknowledges run-based assignments

### DIFF
--- a/src/components/app/data/hooks/useCourseMetadata.js
+++ b/src/components/app/data/hooks/useCourseMetadata.js
@@ -3,7 +3,7 @@ import { useParams, useSearchParams } from 'react-router-dom';
 
 import { queryCourseMetadata } from '../queries';
 import {
-  determineAllocatedCourseRunAssignmentsForCourse,
+  determineAllocatedAssignmentsForCourse,
   getAvailableCourseRuns,
   transformCourseMetadataByAllocatedCourseRunAssignments,
 } from '../utils';
@@ -23,10 +23,7 @@ export default function useCourseMetadata(queryOptions = {}) {
     allocatedCourseRunAssignmentKeys,
     hasAssignedCourseRuns,
     hasMultipleAssignedCourseRuns,
-  } = determineAllocatedCourseRunAssignmentsForCourse({
-    courseKey,
-    redeemableLearnerCreditPolicies,
-  });
+  } = determineAllocatedAssignmentsForCourse({ courseKey, redeemableLearnerCreditPolicies });
   // `requestUrl.searchParams` uses `URLSearchParams`, which decodes `+` as a space, so we
   // need to replace it with `+` again to be a valid course run key.
   let courseRunKey = searchParams.get('course_run_key')?.replaceAll(' ', '+');

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -814,7 +814,7 @@ export function determineAllocatedAssignmentsForCourse({
   // note: checking the non-happy path first, with early return so happy path code isn't nested in conditional.
   if (!learnerContentAssignments.hasAllocatedAssignments) {
     return {
-      isCourseAssigned: [],
+      isCourseAssigned: false,
       allocatedAssignmentsForCourse: [],
       allocatedCourseRunAssignmentKeys: [],
       allocatedCourseRunAssignments: [],

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -806,7 +806,7 @@ export function isEnrollmentUpgradeable(enrollment) {
  *   }
  * }
  */
-export function determineAllocatedCourseRunAssignmentsForCourse({
+export function determineAllocatedAssignmentsForCourse({
   redeemableLearnerCreditPolicies,
   courseKey,
 }) {
@@ -814,19 +814,37 @@ export function determineAllocatedCourseRunAssignmentsForCourse({
   // note: checking the non-happy path first, with early return so happy path code isn't nested in conditional.
   if (!learnerContentAssignments.hasAllocatedAssignments) {
     return {
+      isCourseAssigned: [],
+      allocatedAssignmentsForCourse: [],
       allocatedCourseRunAssignmentKeys: [],
       allocatedCourseRunAssignments: [],
       hasAssignedCourseRuns: false,
       hasMultipleAssignedCourseRuns: false,
     };
   }
-  const allocatedCourseRunAssignments = learnerContentAssignments.allocatedAssignments.filter((assignment) => (
-    assignment.isAssignedCourseRun && assignment.parentContentKey === courseKey
-  ));
+
+  const allocatedAssignmentsForCourse = [];
+  const allocatedCourseRunAssignments = [];
+
+  learnerContentAssignments.allocatedAssignments.forEach((assignment) => {
+    const isCourseRunAssignment = assignment.isAssignedCourseRun && assignment.parentContentKey === courseKey;
+    const isCourseAssignment = !assignment.isAssignedCourseRun && assignment.contentKey === courseKey;
+    if (isCourseRunAssignment || isCourseAssignment) {
+      allocatedAssignmentsForCourse.push(assignment);
+    }
+    if (isCourseRunAssignment) {
+      allocatedCourseRunAssignments.push(assignment);
+    }
+  });
+
+  const isCourseAssigned = allocatedAssignmentsForCourse.length > 0;
   const allocatedCourseRunAssignmentKeys = allocatedCourseRunAssignments.map(assignment => assignment.contentKey);
   const hasAssignedCourseRuns = allocatedCourseRunAssignmentKeys.length > 0;
   const hasMultipleAssignedCourseRuns = allocatedCourseRunAssignmentKeys.length > 1;
+
   return {
+    isCourseAssigned,
+    allocatedAssignmentsForCourse,
     allocatedCourseRunAssignmentKeys,
     allocatedCourseRunAssignments,
     hasAssignedCourseRuns,

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -20,7 +20,7 @@ const CourseSidebarPrice = () => {
   const intl = useIntl();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { coursePrice, currency } = useCoursePrice();
-  const isCourseAssigned = useIsCourseAssigned();
+  const { isCourseAssigned } = useIsCourseAssigned();
   const canRequestSubsidy = useCanUserRequestSubsidyForCourse();
   const { userSubsidyApplicableToCourse } = useUserSubsidyApplicableToCourse();
 

--- a/src/components/course/course-header/CourseHeader.jsx
+++ b/src/components/course/course-header/CourseHeader.jsx
@@ -37,7 +37,7 @@ const CourseHeader = () => {
   const { data: { isPolicyRedemptionEnabled } } = useCourseRedemptionEligibility();
   const { data: { containsContentItems } } = useEnterpriseCustomerContainsContent([courseKey]);
   const isAssignmentsOnlyLearner = useIsAssignmentsOnlyLearner();
-  const isCourseAssigned = useIsCourseAssigned();
+  const { isCourseAssigned } = useIsCourseAssigned();
   const isCourseArchived = courseMetadata.courseRuns.every((courseRun) => isArchived(courseRun));
   const [partners] = useCoursePartners(courseMetadata);
   const defaultProgram = useMemo(

--- a/src/components/course/course-header/CourseImportantDates.jsx
+++ b/src/components/course/course-header/CourseImportantDates.jsx
@@ -3,17 +3,17 @@ import {
 } from '@openedx/paragon';
 import { Calendar } from '@openedx/paragon/icons';
 import dayjs from 'dayjs';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import {
-  DATE_FORMAT, DATETIME_FORMAT, getSoonestEarliestPossibleExpirationData, hasCourseStarted,
+  DATE_FORMAT,
+  DATETIME_FORMAT,
+  getSoonestEarliestPossibleExpirationData,
+  hasCourseStarted,
+  useIsCourseAssigned,
 } from '../data';
-import {
-  determineAllocatedCourseRunAssignmentsForCourse,
-  useCourseMetadata,
-  useRedeemablePolicies,
-} from '../../app/data';
+import { useCourseMetadata } from '../../app/data';
 
 const messages = defineMessages({
   importantDates: {
@@ -61,18 +61,13 @@ CourseImportantDate.propTypes = {
 };
 
 const CourseImportantDates = () => {
-  const { courseKey } = useParams();
-  const { data: redeemableLearnerCreditPolicies } = useRedeemablePolicies();
   const { data: courseMetadata } = useCourseMetadata();
   const intl = useIntl();
   const {
     allocatedCourseRunAssignments,
     allocatedCourseRunAssignmentKeys,
     hasAssignedCourseRuns,
-  } = determineAllocatedCourseRunAssignmentsForCourse({
-    redeemableLearnerCreditPolicies,
-    courseKey,
-  });
+  } = useIsCourseAssigned();
 
   const [searchParams] = useSearchParams();
   const courseRunKey = searchParams.get('course_run_key')?.replaceAll(' ', '+');

--- a/src/components/course/data/courseLoader.ts
+++ b/src/components/course/data/courseLoader.ts
@@ -1,7 +1,7 @@
 import { generatePath, redirect } from 'react-router-dom';
 
 import {
-  determineAllocatedCourseRunAssignmentsForCourse,
+  determineAllocatedAssignmentsForCourse,
   determineLearnerHasContentAssignmentsOnly,
   extractEnterpriseCustomer,
   getCatalogsForSubsidyRequests,
@@ -80,7 +80,7 @@ const makeCourseLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function 
       allocatedCourseRunAssignmentKeys,
       hasAssignedCourseRuns,
       hasMultipleAssignedCourseRuns,
-    } = determineAllocatedCourseRunAssignmentsForCourse({
+    } = determineAllocatedAssignmentsForCourse({
       courseKey,
       redeemableLearnerCreditPolicies,
     });

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -50,6 +50,7 @@ import {
   useSubscriptions,
   COUPON_CODE_SUBSIDY_TYPE,
   LICENSE_SUBSIDY_TYPE,
+  determineAllocatedAssignmentsForCourse,
 } from '../../app/data';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 import { CourseContext } from '../CourseContextProvider';
@@ -735,13 +736,27 @@ export const useExternalEnrollmentFailureReason = () => {
  * @returns {boolean} - Returns true if the course is assigned to the learner, false otherwise.
  */
 export const useIsCourseAssigned = () => {
-  const { data: { learnerContentAssignments } } = useRedeemablePolicies();
+  const { data: redeemableLearnerCreditPolicies } = useRedeemablePolicies();
   const { data: courseMetadata } = useCourseMetadata();
-  if (!learnerContentAssignments.hasAllocatedAssignments) {
-    return false;
-  }
-  const isCourseAssigned = learnerContentAssignments.allocatedAssignments.some(
-    (assignment) => assignment.contentKey === courseMetadata.key,
-  );
-  return isCourseAssigned;
+
+  const {
+    isCourseAssigned,
+    allocatedAssignmentsForCourse,
+    allocatedCourseRunAssignmentKeys,
+    allocatedCourseRunAssignments,
+    hasAssignedCourseRuns,
+    hasMultipleAssignedCourseRuns,
+  } = determineAllocatedAssignmentsForCourse({
+    courseKey: courseMetadata.key,
+    redeemableLearnerCreditPolicies,
+  });
+
+  return {
+    isCourseAssigned,
+    allocatedAssignmentsForCourse,
+    allocatedCourseRunAssignmentKeys,
+    allocatedCourseRunAssignments,
+    hasAssignedCourseRuns,
+    hasMultipleAssignedCourseRuns,
+  };
 };

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -928,7 +928,7 @@ export function getSoonestEarliestPossibleExpirationData({
   const sortedByExpirationDate = assignmentsWithExpiration.sort(
     (a, b) => (dayjs(a.earliestPossibleExpiration.date).isBefore(b.earliestPossibleExpiration.date) ? -1 : 1),
   );
-  let { date: soonestExpirationDate } = sortedByExpirationDate[0].earliestPossibleExpiration.date;
+  let soonestExpirationDate = sortedByExpirationDate[0].earliestPossibleExpiration.date;
   if (dateFormat) {
     soonestExpirationDate = dayjs(soonestExpirationDate).format(dateFormat);
   }

--- a/src/components/course/routes/ExternalCourseEnrollment.jsx
+++ b/src/components/course/routes/ExternalCourseEnrollment.jsx
@@ -33,7 +33,7 @@ const ExternalCourseEnrollment = () => {
   const config = getConfig();
   const { externalCourseFormSubmissionError } = useContext(CourseContext);
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const isCourseAssigned = useIsCourseAssigned();
+  const { isCourseAssigned } = useIsCourseAssigned();
   const { data: minimalCourseMetadata } = useMinimalCourseMetadata();
   const { userSubsidyApplicableToCourse } = useUserSubsidyApplicableToCourse();
   const { data: { redeemabilityPerContentKey } } = useCourseRedemptionEligibility();

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -65,7 +65,7 @@ describe('<CourseSidebarPrice/> ', () => {
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     useUserSubsidyApplicableToCourse.mockReturnValue({ userSubsidyApplicableToCourse: null });
     useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 7.5 }, currency: 'USD' });
-    useIsCourseAssigned.mockReturnValue(false);
+    useIsCourseAssigned.mockReturnValue({ isCourseAssigned: false });
     useCanUserRequestSubsidyForCourse.mockReturnValue(false);
   });
 
@@ -167,7 +167,7 @@ describe('<CourseSidebarPrice/> ', () => {
     });
 
     test('assigned course, shows no price, correct message', () => {
-      useIsCourseAssigned.mockReturnValue(true);
+      useIsCourseAssigned.mockReturnValue({ isCourseAssigned: true });
       useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 0 }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: { subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE },
@@ -229,7 +229,7 @@ describe('<CourseSidebarPrice/> ', () => {
       expect(screen.queryByText('This course is assigned to you. The price of this course is already covered by your organization.')).not.toBeInTheDocument();
     });
     test('assigned course, shows orig price, correct message', () => {
-      useIsCourseAssigned.mockReturnValue(true);
+      useIsCourseAssigned.mockReturnValue({ isCourseAssigned: true });
       useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 0 }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: { subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE },

--- a/src/components/microlearning/VideoBanner.jsx
+++ b/src/components/microlearning/VideoBanner.jsx
@@ -1,31 +1,23 @@
-import {
-  Card, Button,
-} from '@openedx/paragon';
-import './styles/VideoDetailPage.scss';
+import { Card, Button } from '@openedx/paragon';
 import { Link } from 'react-router-dom';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
-import { AppContext } from '@edx/frontend-platform/react';
-import { useContext } from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import BetaBadge from './BetaBadge';
 import { useEnterpriseCustomer } from '../app/data';
+import './styles/VideoDetailPage.scss';
 
 const VideoBanner = () => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const { authenticatedUser: { userId } } = useContext(AppContext);
   const sendPushEvent = () => {
     sendEnterpriseTrackEvent(
       enterpriseCustomer.uuid,
       'edx.ui.enterprise.learner_portal.video_banner.explore_videos_clicked',
-      {
-        userId,
-      },
     );
   };
   return (
     <div data-testid="video-banner" className="d-flex justify-content-center">
       <Card orientation="horizontal" className="video-banner-class bg-light-300">
-        <Card.Section className="col-9 text-primary-500">
+        <Card.Section className="col-9">
           <span className="d-flex justify-content-center align-items-end">
             <h3 className="text-brand-500 pr-1 m-0">
               <FormattedMessage
@@ -60,8 +52,8 @@ const VideoBanner = () => {
           >
             <FormattedMessage
               id="enterprise.microlearning.videoBanner.exploreVideos"
-              defaultMessage="Explore Videos"
-              description="Explore Videos button text for the video banner on the video page."
+              defaultMessage="Explore videos"
+              description="Button text for the Explore CTA within video banner on the video page."
             />
           </Button>
         </Card.Footer>

--- a/src/components/microlearning/tests/VideoBanner.test.jsx
+++ b/src/components/microlearning/tests/VideoBanner.test.jsx
@@ -46,21 +46,18 @@ describe('VideoBanner', () => {
   it('renders the explore videos button', () => {
     renderWithRouter(<VideoBannerWrapper />);
 
-    expect(screen.getByText('Explore Videos')).toBeInTheDocument();
+    expect(screen.getByText('Explore videos')).toBeInTheDocument();
   });
 
   it('calls sendEnterpriseTrackEvent when explore videos button is clicked', () => {
     renderWithRouter(<VideoBannerWrapper />);
 
-    const exploreVideosButton = screen.getByText('Explore Videos');
+    const exploreVideosButton = screen.getByText('Explore videos');
     exploreVideosButton.click();
 
     expect(sendEnterpriseTrackEvent).toHaveBeenCalledWith(
       mockEnterpriseCustomer.uuid,
       'edx.ui.enterprise.learner_portal.video_banner.explore_videos_clicked',
-      {
-        userId: mockAuthenticatedUser.userId,
-      },
     );
   });
   it('hover on Beta badge', async () => {


### PR DESCRIPTION
# Description

Ensures the course about page recognizes run-based assignments, displaying the `Assigned` badge and assignment-specific price strikeout messaging in the sidebar on the Course About page. This was supported by slightly refactoring to extend `useIsCourseAssigned` to utilize the util function `determineAllocatedAssignmentsForCourse`.

![image](https://github.com/user-attachments/assets/9e39cc13-bd1d-4133-96e6-304fffafdc2c)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
