### PR TITLE
fix: changing number of max highlights allowed

### DIFF
--- a/src/components/app/data/constants.js
+++ b/src/components/app/data/constants.js
@@ -52,7 +52,7 @@ export const ENTERPRISE_OFFER_SUBSIDY_TYPE = 'enterpriseOffer';
 export const LEARNER_CREDIT_SUBSIDY_TYPE = 'learnerCredit';
 
 export const ENROLL_BY_DATE_WARNING_THRESHOLD_DAYS = 10;
-export const MAX_HIGHLIGHT_SETS = 12;
+export const MAX_HIGHLIGHT_SETS = 16;
 
 // Note: `cancelled` is correct and matches backend state
 // despite how the key is spelled


### PR DESCRIPTION
Changing the maximum number of highlights allowed
Associated PRs in https://github.com/openedx/frontend-app-admin-portal/pull/1306 and [enterprise-catalog](https://github.com/openedx/enterprise-catalog/pull/944)
[Jira ticket](https://2u-internal.atlassian.net/browse/ENT-9493)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
