### PR TITLE
fix: ensure run-based assignments are taken into account on course page redirect

### DIFF
--- a/src/components/course/data/courseLoader.ts
+++ b/src/components/course/data/courseLoader.ts
@@ -133,9 +133,10 @@ const makeCourseLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function 
           redeemableLearnerCreditPolicies,
           hasCurrentEnterpriseOffers,
         });
-        const isCourseAssigned = redeemableLearnerCreditPolicies.learnerContentAssignments.allocatedAssignments.some(
-          (assignment) => assignment.contentKey === courseKey,
-        );
+        const { isCourseAssigned } = determineAllocatedAssignmentsForCourse({
+          courseKey,
+          redeemableLearnerCreditPolicies,
+        });
         // If learner is an assignment-only learner and is not assigned to the currently
         // viewed course, redirect to the Dashboard page route.
         if (isAssignmentOnlyLearner && !isCourseAssigned) {


### PR DESCRIPTION
When a learner only has an assignment available, there is logic on the course about page that checks whether or not the learner _only_ has an allocated assignment (i.e., no other subsidies available). If the learner is assignment-only and the course is not assigned, we redirect back to the dashboard.

In the case of a run-based assignment, we were missing a check for assignment-only learners against both the `assignment.contentKey` vs. `assignment.parentContentKey` when comparing to the top-level course key in the course page route URL.

### With fix

https://github.com/user-attachments/assets/7aa8e385-c273-4ba1-9a27-5341497bc1b2

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
