### PR TITLE
fix: prevent `NotFoundPage` on successful redemption while still on `ExternalCourseEnrollment`

### DIFF
--- a/src/components/course/routes/ExternalCourseEnrollment.jsx
+++ b/src/components/course/routes/ExternalCourseEnrollment.jsx
@@ -77,7 +77,7 @@ const ExternalCourseEnrollment = () => {
   //   current date is outside the enrollment window of the run.
   if (userSubsidyApplicableToCourse.subsidyType === LEARNER_CREDIT_SUBSIDY_TYPE) {
     const canRedeemDataCourseRun = redeemabilityPerContentKey.find(r => r.contentKey === courseRunKey);
-    if (!canRedeemDataCourseRun?.canRedeem) {
+    if (!canRedeemDataCourseRun?.canRedeem && !canRedeemDataCourseRun?.hasSuccessfulRedemption) {
       return <NotFoundPage />;
     }
   }

--- a/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
+++ b/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
@@ -145,12 +145,21 @@ describe('ExternalCourseEnrollment', () => {
       },
       LEARNER_CREDIT_SUBSIDY_TYPE,
     ],
+    // The auto-selected subsidy type is learner credit, and the specific requested run is already redeemed.
+    [
+      {
+        contentKey: mockCourseRunKey,
+        hasSuccessfulRedemption: true,
+        canRedeem: false,
+      },
+      LEARNER_CREDIT_SUBSIDY_TYPE,
+    ],
     // The specific run is not redeemable via LC, but that's okay because we're not using learner credit anyway.
     [
       {
         contentKey: mockCourseRunKey,
         hasSuccessfulRedemption: false,
-        canRedeem: false, // Not redeemable!?
+        canRedeem: false, // Not redeemable
       },
       LICENSE_SUBSIDY_TYPE, // Auto-selected subsidy type is not learner credit anyway, so allow the page to render.
     ],

--- a/src/components/executive-education-2u/components/RegistrationSummaryCard.jsx
+++ b/src/components/executive-education-2u/components/RegistrationSummaryCard.jsx
@@ -49,7 +49,7 @@ const RegistrationSummaryCard = ({ priceDetails }) => (
                     </del>
                   </div>
                   <div className="d-flex justify-content-end mr-2.5">
-                    ${priceDetails?.price ? `${String(0).padStart(priceDetails.price.toString().length, '0') }.00` : '0.00'} {priceDetails?.currency ? priceDetails.currency : CURRENCY_USD}
+                    {priceDetails?.price ? `$${numberWithPrecision(0)} ${priceDetails?.currency ? priceDetails.currency : CURRENCY_USD}` : '-'}
                   </div>
                   <div className="d-flex justify-content-end small font-weight-light text-gray-500 mr-2.5">
                     <FormattedMessage


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-9423

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
