### PR TITLE
feat: update course about sidebar to take into account usd fixed price

### DIFF
--- a/src/components/app/data/hooks/useCourseMetadata.js
+++ b/src/components/app/data/hooks/useCourseMetadata.js
@@ -39,7 +39,6 @@ export default function useCourseMetadata(queryOptions = {}) {
     enabled: !!courseKey,
     ...queryOptionsRest,
     select: (data) => {
-      console.log(data, 'useC');
       if (!data) {
         return data;
       }

--- a/src/components/app/data/hooks/useCourseMetadata.js
+++ b/src/components/app/data/hooks/useCourseMetadata.js
@@ -39,6 +39,7 @@ export default function useCourseMetadata(queryOptions = {}) {
     enabled: !!courseKey,
     ...queryOptionsRest,
     select: (data) => {
+      console.log(data, 'useC');
       if (!data) {
         return data;
       }

--- a/src/components/app/data/hooks/useCourseRedemptionEligibility.js
+++ b/src/components/app/data/hooks/useCourseRedemptionEligibility.js
@@ -41,7 +41,6 @@ export function transformCourseRedemptionEligibility({
   // redeemable subsidy access policy for any of the content keys.
   const redeemableSubsidyAccessPolicy = preferredSubsidyAccessPolicy || otherSubsidyAccessPolicy;
   const isPolicyRedemptionEnabled = hasSuccessfulRedemption || !!redeemableSubsidyAccessPolicy;
-  console.log(listPrice);
   return {
     isPolicyRedemptionEnabled,
     redeemabilityPerContentKey: canRedeemData,

--- a/src/components/app/data/hooks/useCourseRedemptionEligibility.js
+++ b/src/components/app/data/hooks/useCourseRedemptionEligibility.js
@@ -6,6 +6,21 @@ import { queryCanRedeem } from '../queries';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 import useLateEnrollmentBufferDays from './useLateEnrollmentBufferDays';
 
+const getContentListPrice = ({ courseRuns }) => {
+  const flatContentPrice = courseRuns.flatMap(run => run.listPrice?.usd).filter(x => !!x);
+  // Find the max and min prices
+  if (!flatContentPrice.length) {
+    return null;
+  }
+  const maxPrice = Math.max(...flatContentPrice);
+  const minPrice = Math.min(...flatContentPrice);
+  // Heuristic for displaying the price as a range or a singular price based on runs
+  if (maxPrice !== minPrice) {
+    return [minPrice, maxPrice];
+  }
+  return [flatContentPrice[0]];
+};
+
 export function transformCourseRedemptionEligibility({
   courseMetadata,
   canRedeemData,
@@ -17,7 +32,7 @@ export function transformCourseRedemptionEligibility({
   const otherSubsidyAccessPolicy = canRedeemData.find(
     r => r.redeemableSubsidyAccessPolicy,
   )?.redeemableSubsidyAccessPolicy;
-  const listPrice = redeemabilityForActiveCourseRun?.listPrice?.usd;
+  const listPrice = getContentListPrice({ courseRuns: canRedeemData });
   const hasSuccessfulRedemption = courseRunKey
     ? !!canRedeemData.find(r => r.contentKey === courseRunKey)?.hasSuccessfulRedemption
     : canRedeemData.some(r => r.hasSuccessfulRedemption);
@@ -26,6 +41,7 @@ export function transformCourseRedemptionEligibility({
   // redeemable subsidy access policy for any of the content keys.
   const redeemableSubsidyAccessPolicy = preferredSubsidyAccessPolicy || otherSubsidyAccessPolicy;
   const isPolicyRedemptionEnabled = hasSuccessfulRedemption || !!redeemableSubsidyAccessPolicy;
+  console.log(listPrice);
   return {
     isPolicyRedemptionEnabled,
     redeemabilityPerContentKey: canRedeemData,

--- a/src/components/app/data/hooks/useCourseRedemptionEligibility.js
+++ b/src/components/app/data/hooks/useCourseRedemptionEligibility.js
@@ -6,11 +6,11 @@ import { queryCanRedeem } from '../queries';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 import useLateEnrollmentBufferDays from './useLateEnrollmentBufferDays';
 
-const getContentListPrice = ({ courseRuns }) => {
+const getContentListPriceRange = ({ courseRuns }) => {
   const flatContentPrice = courseRuns.flatMap(run => run.listPrice?.usd).filter(x => !!x);
   // Find the max and min prices
   if (!flatContentPrice.length) {
-    return null;
+    return [];
   }
   const maxPrice = Math.max(...flatContentPrice);
   const minPrice = Math.min(...flatContentPrice);
@@ -32,7 +32,7 @@ export function transformCourseRedemptionEligibility({
   const otherSubsidyAccessPolicy = canRedeemData.find(
     r => r.redeemableSubsidyAccessPolicy,
   )?.redeemableSubsidyAccessPolicy;
-  const listPrice = getContentListPrice({ courseRuns: canRedeemData });
+  const listPrice = getContentListPriceRange({ courseRuns: canRedeemData });
   const hasSuccessfulRedemption = courseRunKey
     ? !!canRedeemData.find(r => r.contentKey === courseRunKey)?.hasSuccessfulRedemption
     : canRedeemData.some(r => r.hasSuccessfulRedemption);

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -36,7 +36,8 @@ const CourseSidebarPrice = () => {
           defaultMessage="Priced reduced from:"
           description="Message to indicate that the price has been reduced."
         />
-      </span>${originalPriceDisplay} {currency}
+      </span>
+      ${originalPriceDisplay} {currency}
     </del>
   );
 
@@ -66,7 +67,9 @@ const CourseSidebarPrice = () => {
   if (!hasDiscountedPrice && canRequestSubsidy) {
     return (
       <span style={{ whiteSpace: 'pre-wrap' }} data-testid="browse-and-request-pricing">
-        <s>${originalPriceDisplay} {currency}</s><br />
+        <s>
+          ${originalPriceDisplay} {currency}
+        </s><br />
         <FormattedMessage
           id="enterprise.course.about.course.sidebar.price.free.when.approved"
           defaultMessage="Free to me{br}(when approved)"
@@ -125,7 +128,8 @@ const CourseSidebarPrice = () => {
                 defaultMessage="Discounted price:"
                 description="Message to indicate that the price has been discounted."
               />
-            </span>${discountedPriceDisplay}
+            </span>
+            ${discountedPriceDisplay}
           </>
         )}
       </div>

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -1,14 +1,12 @@
 import { Skeleton } from '@openedx/paragon';
 import classNames from 'classnames';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
-
-import { numberWithPrecision } from './data/utils';
 import {
+  getContentPriceDisplay,
   useCanUserRequestSubsidyForCourse,
   useCoursePrice,
   useIsCourseAssigned,
   useUserSubsidyApplicableToCourse,
-  ZERO_PRICE,
 } from './data';
 import {
   ENTERPRISE_OFFER_SUBSIDY_TYPE,
@@ -18,18 +16,6 @@ import {
 } from '../app/data';
 import { sumOfArray } from '../../utils/common';
 
-const getContentPriceDisplay = (priceRange) => {
-  if (!priceRange?.length) {
-    return numberWithPrecision(ZERO_PRICE);
-  }
-  const minPrice = Math.min(...priceRange);
-  const maxPrice = Math.max(...priceRange);
-  if (maxPrice !== minPrice) {
-    return `${numberWithPrecision(minPrice)} - ${numberWithPrecision(maxPrice)}`;
-  }
-  return numberWithPrecision(priceRange.sort((a, b) => a - b)[0]);
-};
-
 const CourseSidebarPrice = () => {
   const intl = useIntl();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
@@ -37,11 +23,9 @@ const CourseSidebarPrice = () => {
   const { isCourseAssigned } = useIsCourseAssigned();
   const canRequestSubsidy = useCanUserRequestSubsidyForCourse();
   const { userSubsidyApplicableToCourse } = useUserSubsidyApplicableToCourse();
-  console.log(coursePrice, 'hi');
   if (!coursePrice) {
     return <Skeleton containerTestId="course-price-skeleton" height={24} />;
   }
-  console.log(coursePrice);
   const originalPriceDisplay = getContentPriceDisplay(coursePrice.listRange);
   const showOrigPrice = !enterpriseCustomer.hideCourseOriginalPrice;
   const crossedOutOriginalPrice = (
@@ -76,7 +60,8 @@ const CourseSidebarPrice = () => {
     );
   }
 
-  const hasDiscountedPrice = coursePrice.discounted && sumOfArray(coursePrice.discounted) < sumOfArray(coursePrice.listRange);
+  const hasDiscountedPrice = coursePrice.discounted
+    && sumOfArray(coursePrice.discounted) < sumOfArray(coursePrice.listRange);
   // Case 2: No subsidies found but learner can request a subsidy
   if (!hasDiscountedPrice && canRequestSubsidy) {
     return (

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -37,7 +37,7 @@ const CourseSidebarPrice = () => {
           description="Message to indicate that the price has been reduced."
         />
       </span>
-      ${originalPriceDisplay} {currency}
+      {originalPriceDisplay} {currency}
     </del>
   );
 
@@ -61,15 +61,13 @@ const CourseSidebarPrice = () => {
     );
   }
 
-  const hasDiscountedPrice = coursePrice.discounted
-    && sumOfArray(coursePrice.discounted) < sumOfArray(coursePrice.listRange);
+  const hasDiscountedPrice = coursePrice.discountedList
+    && sumOfArray(coursePrice.discountedList) < sumOfArray(coursePrice.listRange);
   // Case 2: No subsidies found but learner can request a subsidy
   if (!hasDiscountedPrice && canRequestSubsidy) {
     return (
       <span style={{ whiteSpace: 'pre-wrap' }} data-testid="browse-and-request-pricing">
-        <s>
-          ${originalPriceDisplay} {currency}
-        </s><br />
+        <s>{originalPriceDisplay} {currency}</s><br />
         <FormattedMessage
           id="enterprise.course.about.course.sidebar.price.free.when.approved"
           defaultMessage="Free to me{br}(when approved)"
@@ -84,7 +82,7 @@ const CourseSidebarPrice = () => {
   if (!hasDiscountedPrice) {
     return (
       <span className="d-block">
-        ${originalPriceDisplay} {currency}
+        {originalPriceDisplay} {currency}
       </span>
     );
   }
@@ -114,22 +112,22 @@ const CourseSidebarPrice = () => {
       });
     }
   }
-  const discountedPriceDisplay = `${getContentPriceDisplay(coursePrice.discounted)} ${currency}`;
+  const discountedPriceDisplay = `${getContentPriceDisplay(coursePrice.discountedList)} ${currency}`;
   return (
     <>
-      <div className={classNames({ 'mb-2': coursePrice.discounted > 0 || showOrigPrice })}>
-        {/* discounted > 0 means partial discount */}
+      <div className={classNames({ 'mb-2': coursePrice.discountedList > 0 || showOrigPrice })}>
+        {/* discountedList > 0 means partial discount */}
         {showOrigPrice && <>{crossedOutOriginalPrice}{' '}</>}
-        {sumOfArray(coursePrice.discounted) > 0 && (
+        {sumOfArray(coursePrice.discountedList) > 0 && (
           <>
             <span className="sr-only">
               <FormattedMessage
                 id="enterprise.course.about.price.discounted"
                 defaultMessage="Discounted price:"
-                description="Message to indicate that the price has been discounted."
+                description="Message to indicate that the price has been discountedList."
               />
             </span>
-            ${discountedPriceDisplay}
+            {discountedPriceDisplay}
           </>
         )}
       </div>

--- a/src/components/course/CourseSidebarPrice.jsx
+++ b/src/components/course/CourseSidebarPrice.jsx
@@ -115,7 +115,7 @@ const CourseSidebarPrice = () => {
   const discountedPriceDisplay = `${getContentPriceDisplay(coursePrice.discountedList)} ${currency}`;
   return (
     <>
-      <div className={classNames({ 'mb-2': coursePrice.discountedList > 0 || showOrigPrice })}>
+      <div className={classNames({ 'mb-2': sumOfArray(coursePrice.discountedList) > 0 || showOrigPrice })}>
         {/* discountedList > 0 means partial discount */}
         {showOrigPrice && <>{crossedOutOriginalPrice}{' '}</>}
         {sumOfArray(coursePrice.discountedList) > 0 && (

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -173,8 +173,8 @@ export function useCoursePacingType(courseRun) {
 
 /**
  * @typedef {Object} CoursePrice
- * @property {number} list The list price.
- * @property {number} discounted The discounted price.
+ * @property {number} listRange The list price.
+ * @property {number} discountedList The discountedList price.
  */
 
 /**
@@ -208,29 +208,29 @@ export const useCoursePriceForUserSubsidy = ({
 
       if (userSubsidyApplicableToCourse) {
         const { discountType, discountValue } = userSubsidyApplicableToCourse;
-        let discountedPrice = [];
+        let discountedPriceList = [];
 
         if (discountType && discountType.toLowerCase() === SUBSIDY_DISCOUNT_TYPE_MAP.PERCENTAGE.toLowerCase()) {
-          discountedPrice = onlyListPrice.listRange.map(
+          discountedPriceList = onlyListPrice.listRange.map(
             (individualPrice) => individualPrice - (individualPrice * (discountValue / 100)),
           );
         }
 
         if (discountType && discountType.toLowerCase() === SUBSIDY_DISCOUNT_TYPE_MAP.ABSOLUTE.toLowerCase()) {
-          discountedPrice = onlyListPrice.listRange.map(
+          discountedPriceList = onlyListPrice.listRange.map(
             (individualPrice) => Math.max(individualPrice - discountValue, 0),
           );
         }
 
-        if (isDefinedAndNotNull(discountedPrice)) {
+        if (isDefinedAndNotNull(discountedPriceList)) {
           return {
             ...onlyListPrice,
-            discounted: discountedPrice,
+            discountedList: discountedPriceList,
           };
         }
         return {
           ...onlyListPrice,
-          discounted: onlyListPrice.listRange,
+          discountedList: onlyListPrice.listRange,
         };
       }
 

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -173,8 +173,8 @@ export function useCoursePacingType(courseRun) {
 
 /**
  * @typedef {Object} CoursePrice
- * @property {number} listRange The list price.
- * @property {number} discountedList The discountedList price.
+ * @property {number[]} listRange The list price.
+ * @property {number[]} discountedList The discountedList price.
  */
 
 /**

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -198,11 +198,9 @@ export const useCoursePriceForUserSubsidy = ({
   const currency = CURRENCY_USD;
   const coursePrice = useMemo(
     () => {
-      console.log(listPrice, 'hamzah');
       if (!listPrice) {
         return null;
       }
-      console.log(listPrice, userSubsidyApplicableToCourse);
 
       const onlyListPrice = {
         listRange: listPrice,
@@ -637,7 +635,6 @@ export const useUserSubsidyApplicableToCourse = () => {
 export function useCoursePrice() {
   const { data: courseListPrice } = useCourseListPrice();
   const { userSubsidyApplicableToCourse } = useUserSubsidyApplicableToCourse();
-  console.log(courseListPrice, userSubsidyApplicableToCourse);
   return useCoursePriceForUserSubsidy({
     userSubsidyApplicableToCourse,
     listPrice: courseListPrice,

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -801,7 +801,7 @@ describe('useCoursePriceForUserSubsidy', () => {
       userSubsidyApplicableToCourse,
     }));
     const { coursePrice } = result.current;
-    expect(coursePrice).toEqual({ listRange: [100], discounted: [90] });
+    expect(coursePrice).toEqual({ listRange: [100], discountedList: [90] });
   });
 
   it('should return the correct course price when a user subsidy is applicable with unknown discount type', () => {
@@ -818,7 +818,7 @@ describe('useCoursePriceForUserSubsidy', () => {
       userSubsidyApplicableToCourse,
     }));
     const { coursePrice } = result.current;
-    expect(coursePrice).toEqual({ listRange: [100], discounted: [] });
+    expect(coursePrice).toEqual({ listRange: [100], discountedList: [] });
   });
 
   it('should return the correct course price when a user subsidy is applicable with absolute discount', () => {
@@ -835,7 +835,7 @@ describe('useCoursePriceForUserSubsidy', () => {
       userSubsidyApplicableToCourse,
     }));
     const { coursePrice } = result.current;
-    expect(coursePrice).toEqual({ listRange: [150], discounted: [140] });
+    expect(coursePrice).toEqual({ listRange: [150], discountedList: [140] });
   });
 
   it('should return the correct course price when a user subsidy is not applicable', () => {
@@ -1676,47 +1676,47 @@ describe('useCourseListPrice', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: mockListPrice } });
-    useCourseMetadata.mockReturnValue(mockListPrice || getCoursePrice(baseCourseMetadataValue));
+    useCourseMetadata.mockReturnValue({ data: mockListPrice || getCoursePrice(baseCourseMetadataValue) });
   });
   it('should return the list price if one exist', () => {
     const { result } = renderHook(
       () => useCourseListPrice(),
       { wrapper: Wrapper },
     );
-    expect(result.current).toEqual(mockListPrice);
+    expect(result.current).toEqual({ data: mockListPrice });
   });
-  it('should not return the list price if one doesnt, first fallback, fixed_price_usd', () => {
+  it('should not return the list price if one doesnt exist, first fallback price, fixed_price_usd', () => {
     const updatedListPrice = undefined;
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
-    useCourseMetadata.mockReturnValue(updatedListPrice || getCoursePrice(baseCourseMetadataValue));
+    useCourseMetadata.mockReturnValue({ data: updatedListPrice || getCoursePrice(baseCourseMetadataValue) });
     const { result } = renderHook(
       () => useCourseListPrice(),
       { wrapper: Wrapper },
     );
-    expect(result.current).toEqual([baseCourseMetadataValue.activeCourseRun.fixedPriceUsd]);
+    expect(result.current).toEqual({ data: [baseCourseMetadataValue.activeCourseRun.fixedPriceUsd] });
   });
-  it('should not return the list price if one doesnt, second fallback, firstEnrollablePaidSeatPrice', () => {
+  it('should not return the list price if one doesnt exist, second fallback price, firstEnrollablePaidSeatPrice', () => {
     const updatedListPrice = undefined;
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
     delete baseCourseMetadataValue.activeCourseRun.fixedPriceUsd;
-    useCourseMetadata.mockReturnValue(updatedListPrice || getCoursePrice(baseCourseMetadataValue));
+    useCourseMetadata.mockReturnValue({ data: updatedListPrice || getCoursePrice(baseCourseMetadataValue) });
     const { result } = renderHook(
       () => useCourseListPrice(),
       { wrapper: Wrapper },
     );
-    expect(result.current).toEqual([baseCourseMetadataValue.activeCourseRun.firstEnrollablePaidSeatPrice]);
+    expect(result.current).toEqual({ data: [baseCourseMetadataValue.activeCourseRun.firstEnrollablePaidSeatPrice] });
   });
-  it('should not return the list price if one doesnt, third fallback, entitlements', () => {
+  it('should not return the list price if one doesnt exit, third fallback price, entitlements', () => {
     const updatedListPrice = undefined;
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
     delete baseCourseMetadataValue.activeCourseRun.fixedPriceUsd;
     delete baseCourseMetadataValue.activeCourseRun.firstEnrollablePaidSeatPrice;
-    useCourseMetadata.mockReturnValue(updatedListPrice || getCoursePrice(baseCourseMetadataValue));
+    useCourseMetadata.mockReturnValue({ data: updatedListPrice || getCoursePrice(baseCourseMetadataValue) });
     const { result } = renderHook(
       () => useCourseListPrice(),
       { wrapper: Wrapper },
     );
-    expect(result.current).toEqual([baseCourseMetadataValue.entitlements[0].price]);
+    expect(result.current).toEqual({ data: [baseCourseMetadataValue.entitlements[0].price] });
   });
   it('should not return the list price if one doesnt exist or the course metadata doesnt include it', () => {
     const updatedListPrice = undefined;
@@ -1725,12 +1725,12 @@ describe('useCourseListPrice', () => {
       ...baseCourseMetadataValue,
       entitlements: [],
     };
-    useCourseMetadata.mockReturnValue(updatedListPrice || getCoursePrice(updatedCourseMetadata));
+    useCourseMetadata.mockReturnValue({ data: updatedListPrice || getCoursePrice(updatedCourseMetadata) });
     const { result } = renderHook(
       () => useCourseListPrice(),
       { wrapper: Wrapper },
     );
-    expect(result.current).toEqual(null);
+    expect(result.current).toEqual({ data: null });
   });
 });
 

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -1683,9 +1683,12 @@ describe('useCourseListPrice', () => {
       () => useCourseListPrice(),
       { wrapper: Wrapper },
     );
-    expect(result.current).toEqual({ data: mockListPrice });
+    const expectedListPrice = mockListPrice;
+    const courseMetadataSelectFn = useCourseMetadata.mock.calls[0][0].select;
+    expect(expectedListPrice).toEqual(courseMetadataSelectFn({ transformed: baseCourseMetadataValue }));
+    expect(result.current).toEqual({ data: expectedListPrice });
   });
-  it('should not return the list price if one doesnt exist, first fallback price, fixed_price_usd', () => {
+  it('should not return the list price if one doesnt exist, fall back to fixed_price_usd from getCoursePrice', () => {
     const updatedListPrice = undefined;
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
     useCourseMetadata.mockReturnValue({ data: updatedListPrice || getCoursePrice(baseCourseMetadataValue) });
@@ -1693,9 +1696,12 @@ describe('useCourseListPrice', () => {
       () => useCourseListPrice(),
       { wrapper: Wrapper },
     );
-    expect(result.current).toEqual({ data: [baseCourseMetadataValue.activeCourseRun.fixedPriceUsd] });
+    const expectedListPrice = [baseCourseMetadataValue.activeCourseRun.fixedPriceUsd];
+    const courseMetadataSelectFn = useCourseMetadata.mock.calls[0][0].select;
+    expect(expectedListPrice).toEqual(courseMetadataSelectFn({ transformed: baseCourseMetadataValue }));
+    expect(result.current).toEqual({ data: expectedListPrice });
   });
-  it('should not return the list price if one doesnt exist, second fallback price, firstEnrollablePaidSeatPrice', () => {
+  it('should not return the list price if one doesnt exist, fall back to firstEnrollablePaidSeatPrice from getCoursePrice', () => {
     const updatedListPrice = undefined;
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
     delete baseCourseMetadataValue.activeCourseRun.fixedPriceUsd;
@@ -1704,9 +1710,12 @@ describe('useCourseListPrice', () => {
       () => useCourseListPrice(),
       { wrapper: Wrapper },
     );
-    expect(result.current).toEqual({ data: [baseCourseMetadataValue.activeCourseRun.firstEnrollablePaidSeatPrice] });
+    const expectedListPrice = [baseCourseMetadataValue.activeCourseRun.firstEnrollablePaidSeatPrice];
+    const courseMetadataSelectFn = useCourseMetadata.mock.calls[0][0].select;
+    expect(expectedListPrice).toEqual(courseMetadataSelectFn({ transformed: baseCourseMetadataValue }));
+    expect(result.current).toEqual({ data: expectedListPrice });
   });
-  it('should not return the list price if one doesnt exit, third fallback price, entitlements', () => {
+  it('should not return the list price if one doesnt exit, fall back to entitlements from getCoursePrice', () => {
     const updatedListPrice = undefined;
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
     delete baseCourseMetadataValue.activeCourseRun.fixedPriceUsd;
@@ -1716,13 +1725,21 @@ describe('useCourseListPrice', () => {
       () => useCourseListPrice(),
       { wrapper: Wrapper },
     );
-    expect(result.current).toEqual({ data: [baseCourseMetadataValue.entitlements[0].price] });
+    const expectedListPrice = [baseCourseMetadataValue.entitlements[0].price];
+    const courseMetadataSelectFn = useCourseMetadata.mock.calls[0][0].select;
+    expect(expectedListPrice).toEqual(courseMetadataSelectFn({ transformed: baseCourseMetadataValue }));
+    expect(result.current).toEqual({ data: expectedListPrice });
   });
   it('should not return the list price if one doesnt exist or the course metadata doesnt include it', () => {
     const updatedListPrice = undefined;
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
     const updatedCourseMetadata = {
       ...baseCourseMetadataValue,
+      activeCourseRun: {
+        ...baseCourseMetadataValue.activeCourseRun,
+        fixedPriceUsd: null,
+        firstEnrollablePaidSeatPrice: null,
+      },
       entitlements: [],
     };
     useCourseMetadata.mockReturnValue({ data: updatedListPrice || getCoursePrice(updatedCourseMetadata) });
@@ -1730,7 +1747,10 @@ describe('useCourseListPrice', () => {
       () => useCourseListPrice(),
       { wrapper: Wrapper },
     );
-    expect(result.current).toEqual({ data: null });
+    const expectedListPrice = null;
+    const courseMetadataSelectFn = useCourseMetadata.mock.calls[0][0].select;
+    expect(expectedListPrice).toEqual(courseMetadataSelectFn({ transformed: updatedCourseMetadata }));
+    expect(result.current).toEqual({ data: expectedListPrice });
   });
 });
 

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -1676,6 +1676,8 @@ describe('useCourseListPrice', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: mockListPrice } });
+    // NOTE: `useCourseMetadata`'s mocked return value assumes the returned value
+    // from the `select` function passed to the hook.
     useCourseMetadata.mockReturnValue({ data: mockListPrice || getCoursePrice(baseCourseMetadataValue) });
   });
   it('should return the list price if one exist', () => {

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -788,7 +788,7 @@ describe('CoursePacingType', () => {
 
 describe('useCoursePriceForUserSubsidy', () => {
   it('should return the correct course price when a user subsidy is applicable with percentage discount', () => {
-    const listPrice = 100;
+    const listPrice = [100];
     const userSubsidyApplicableToCourse = {
       discountType: 'percentage',
       discountValue: 10,
@@ -801,11 +801,11 @@ describe('useCoursePriceForUserSubsidy', () => {
       userSubsidyApplicableToCourse,
     }));
     const { coursePrice } = result.current;
-    expect(coursePrice).toEqual({ list: 100, discounted: 90 });
+    expect(coursePrice).toEqual({ listRange: [100], discounted: [90] });
   });
 
   it('should return the correct course price when a user subsidy is applicable with unknown discount type', () => {
-    const listPrice = 100;
+    const listPrice = [100];
     const userSubsidyApplicableToCourse = {
       discountType: 'unknown',
       discountValue: 100,
@@ -818,11 +818,11 @@ describe('useCoursePriceForUserSubsidy', () => {
       userSubsidyApplicableToCourse,
     }));
     const { coursePrice } = result.current;
-    expect(coursePrice).toEqual({ list: 100, discounted: 100 });
+    expect(coursePrice).toEqual({ listRange: [100], discounted: [] });
   });
 
   it('should return the correct course price when a user subsidy is applicable with absolute discount', () => {
-    const listPrice = 150;
+    const listPrice = [150];
     const userSubsidyApplicableToCourse = {
       discountType: 'absolute',
       discountValue: 10,
@@ -835,22 +835,22 @@ describe('useCoursePriceForUserSubsidy', () => {
       userSubsidyApplicableToCourse,
     }));
     const { coursePrice } = result.current;
-    expect(coursePrice).toEqual({ list: 150, discounted: 140 });
+    expect(coursePrice).toEqual({ listRange: [150], discounted: [140] });
   });
 
   it('should return the correct course price when a user subsidy is not applicable', () => {
-    const listPrice = 100;
+    const listPrice = [100];
     const userSubsidyApplicableToCourse = null;
     const { result } = renderHook(() => useCoursePriceForUserSubsidy({
       listPrice,
       userSubsidyApplicableToCourse,
     }));
     const { coursePrice } = result.current;
-    expect(coursePrice).toEqual({ list: 100 });
+    expect(coursePrice).toEqual({ listRange: [100] });
   });
 
   it('should return the correct course price for exec ed course', () => {
-    const listPrice = 200;
+    const listPrice = [200];
 
     const userSubsidyApplicableToCourse = null;
     const { result } = renderHook(() => useCoursePriceForUserSubsidy({
@@ -858,11 +858,11 @@ describe('useCoursePriceForUserSubsidy', () => {
       userSubsidyApplicableToCourse,
     }));
     const { coursePrice } = result.current;
-    expect(coursePrice).toEqual({ list: 200 });
+    expect(coursePrice).toEqual({ listRange: [200] });
   });
 
   it('should return the correct currency', () => {
-    const listPrice = 100;
+    const listPrice = [100];
     const userSubsidyApplicableToCourse = null;
     const { result } = renderHook(() => useCoursePriceForUserSubsidy({
       listPrice,
@@ -1291,7 +1291,7 @@ describe('useMinimalCourseMetadata', () => {
   const mockLogoImageUrl = 'https://fake-logo.url';
   const mockOrgMarketingUrl = 'https://fake-mktg.url';
   const mockWeeksToComplete = 8;
-  const mockListPrice = 100;
+  const mockListPrice = [100];
   const mockCurrency = 'USD';
   const mockCourseTitle = 'Test Course Title';
   const mockCourseRunStartDate = '2023-04-20T12:00:00Z';
@@ -1322,7 +1322,7 @@ describe('useMinimalCourseMetadata', () => {
     }],
   };
   const coursePrice = {
-    list: mockListPrice,
+    listRange: mockListPrice,
   };
 
   const Wrapper = ({ children }) => (
@@ -1385,7 +1385,7 @@ describe('useMinimalCourseMetadata', () => {
       title: 'Test Course Title',
       startDate: '2023-04-20T12:00:00Z',
       duration: '8 Weeks',
-      priceDetails: { price: 100, currency: 'USD' },
+      priceDetails: { price: [100], currency: 'USD' },
     };
     useCourseMetadata.mockReturnValue(courseMetadataTransformer({ transformed: baseCourseMetadataValue }));
     const { result } = renderHook(() => useMinimalCourseMetadata(), { wrapper: Wrapper });
@@ -1406,7 +1406,7 @@ describe('useMinimalCourseMetadata', () => {
       title: 'Test Course Title',
       startDate: undefined,
       duration: '-',
-      priceDetails: { price: 100, currency: 'USD' },
+      priceDetails: { price: [100], currency: 'USD' },
     };
     useCourseMetadata.mockReturnValue(courseMetadataTransformer({ transformed: updatedCourseMetadataValue }));
     const { result } = renderHook(
@@ -1433,7 +1433,7 @@ describe('useMinimalCourseMetadata', () => {
       title: 'Test Course Title',
       startDate: '2023-04-20T12:00:00Z',
       duration: '1 Week',
-      priceDetails: { price: 100, currency: 'USD' },
+      priceDetails: { price: [100], currency: 'USD' },
     };
     useCourseMetadata.mockReturnValue(courseMetadataTransformer({ transformed: updatedCourseMetadataValue }));
     const { result } = renderHook(
@@ -1463,7 +1463,7 @@ describe('useMinimalCourseMetadata', () => {
       title: 'Test Course Title',
       startDate: '2023-04-20T12:00:00Z',
       duration: '8 Weeks',
-      priceDetails: { price: 100, currency: 'USD' },
+      priceDetails: { price: [100], currency: 'USD' },
     };
     useCourseMetadata.mockReturnValue(courseMetadataTransformer({ transformed: updatedCourseMetadataValue }));
     const { result } = renderHook(

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -4,9 +4,7 @@ import MockDate from 'mockdate';
 import '@testing-library/jest-dom/extend-expect';
 
 import { getConfig } from '@edx/frontend-platform';
-import {
-  DISABLED_ENROLL_REASON_TYPES,
-} from '../constants';
+import { DISABLED_ENROLL_REASON_TYPES } from '../constants';
 import {
   findCouponCodeForCourse,
   findEnterpriseOfferForCourse,
@@ -919,7 +917,7 @@ describe('transformedCourseMetadata', () => {
   const mockLogoImageUrl = 'https://fake-logo.url';
   const mockOrgMarketingUrl = 'https://fake-mktg.url';
   const mockWeeksToComplete = 8;
-  const mockListPrice = 100;
+  const mockListPrice = [100];
   const mockCurrency = 'USD';
   const mockCourseTitle = 'Test Course Title';
   const mockCourseRunStartDate = '2023-04-20T12:00:00Z';
@@ -958,7 +956,7 @@ describe('transformedCourseMetadata', () => {
     },
   };
   const coursePrice = {
-    list: mockListPrice,
+    listRange: mockListPrice,
   };
   const expectedValue = {
     duration: '8 Weeks',
@@ -969,7 +967,7 @@ describe('transformedCourseMetadata', () => {
     },
     priceDetails: {
       currency: 'USD',
-      price: 100,
+      price: [100],
     },
     startDate: '2023-04-20T12:00:00Z',
     title: 'Test Course Title',

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -153,8 +153,6 @@ export function getProgramIcon(type) {
   }
 }
 
-export const numberWithPrecision = (number, precision = 2) => number.toFixed(precision);
-
 /**
  * Displays content price with precision as a range or singular price
  * @param priceRange
@@ -162,7 +160,7 @@ export const numberWithPrecision = (number, precision = 2) => number.toFixed(pre
  */
 export const getContentPriceDisplay = (priceRange) => {
   if (!priceRange?.length) {
-    return numberWithPrecision(ZERO_PRICE);
+    return formatPrice(ZERO_PRICE);
   }
   const minPrice = Math.min(...priceRange);
   const maxPrice = Math.max(...priceRange);

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -21,7 +21,7 @@ import XSeriesSvgIcon from '../../../assets/icons/xseries.svg';
 import CreditSvgIcon from '../../../assets/icons/credit.svg';
 import { PROGRAM_TYPE_MAP } from '../../program/data/constants';
 import { programIsMicroMasters, programIsProfessionalCertificate } from '../../program/data/utils';
-import { hasValidStartExpirationDates } from '../../../utils/common';
+import { formatPrice, hasValidStartExpirationDates } from '../../../utils/common';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 import {
   findHighestLevelEntitlementSku,
@@ -167,19 +167,9 @@ export const getContentPriceDisplay = (priceRange) => {
   const minPrice = Math.min(...priceRange);
   const maxPrice = Math.max(...priceRange);
   if (maxPrice !== minPrice) {
-    return `${numberWithPrecision(minPrice)} - ${numberWithPrecision(maxPrice)}`;
+    return `${formatPrice(minPrice)} - ${formatPrice(maxPrice)}`;
   }
-  return numberWithPrecision(priceRange[0]);
-};
-
-export const formatPrice = (price, options = {}) => {
-  const USDollar = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 0,
-    ...options,
-  });
-  return USDollar.format(Math.abs(price));
+  return formatPrice(priceRange[0]);
 };
 
 /**
@@ -831,7 +821,7 @@ export function getLinkToCourse(course, slug) {
  */
 export function getEntitlementPrice(entitlements) {
   if (entitlements?.length) {
-    return Number(entitlements[0].price);
+    return parseFloat(entitlements[0].price);
   }
   return undefined;
 }
@@ -846,10 +836,7 @@ export function getEntitlementPrice(entitlements) {
  */
 export function getCoursePrice(course) {
   if (course.activeCourseRun?.fixedPriceUsd) {
-    if (typeof course.activeCourseRun.fixedPriceUsd === 'string') {
-      return [Number(course.activeCourseRun.fixedPriceUsd)];
-    }
-    return [course.activeCourseRun?.fixedPriceUsd];
+    return [parseFloat(course.activeCourseRun.fixedPriceUsd)];
   }
   if (course.activeCourseRun?.firstEnrollablePaidSeatPrice) {
     return [course.activeCourseRun?.firstEnrollablePaidSeatPrice];

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -169,7 +169,7 @@ export const getContentPriceDisplay = (priceRange) => {
   if (maxPrice !== minPrice) {
     return `${numberWithPrecision(minPrice)} - ${numberWithPrecision(maxPrice)}`;
   }
-  return numberWithPrecision(priceRange.sort((a, b) => a - b)[0]);
+  return numberWithPrecision(priceRange[0]);
 };
 
 export const formatPrice = (price, options = {}) => {

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -846,6 +846,9 @@ export function getEntitlementPrice(entitlements) {
  */
 export function getCoursePrice(course) {
   if (course.activeCourseRun?.fixedPriceUsd) {
+    if (typeof course.activeCourseRun.fixedPriceUsd === 'string') {
+      return [Number(course.activeCourseRun.fixedPriceUsd)];
+    }
     return [course.activeCourseRun?.fixedPriceUsd];
   }
   if (course.activeCourseRun?.firstEnrollablePaidSeatPrice) {

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -21,7 +21,7 @@ import XSeriesSvgIcon from '../../../assets/icons/xseries.svg';
 import CreditSvgIcon from '../../../assets/icons/credit.svg';
 import { PROGRAM_TYPE_MAP } from '../../program/data/constants';
 import { programIsMicroMasters, programIsProfessionalCertificate } from '../../program/data/utils';
-import { formatPrice, hasValidStartExpirationDates } from '../../../utils/common';
+import { formatPrice, hasValidStartExpirationDates, isDefinedAndNotNull } from '../../../utils/common';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 import {
   findHighestLevelEntitlementSku,
@@ -835,11 +835,11 @@ export function getEntitlementPrice(entitlements) {
  * @returns Price for the course run.
  */
 export function getCoursePrice(course) {
-  if (course.activeCourseRun?.fixedPriceUsd) {
+  if (isDefinedAndNotNull(course.activeCourseRun?.fixedPriceUsd)) {
     return [parseFloat(course.activeCourseRun.fixedPriceUsd)];
   }
-  if (course.activeCourseRun?.firstEnrollablePaidSeatPrice) {
-    return [course.activeCourseRun?.firstEnrollablePaidSeatPrice];
+  if (isDefinedAndNotNull(course.activeCourseRun?.firstEnrollablePaidSeatPrice)) {
+    return [course.activeCourseRun.firstEnrollablePaidSeatPrice];
   }
   if (course.entitlements.length > 0) {
     return [getEntitlementPrice(course.entitlements)];

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -154,6 +154,16 @@ export function getProgramIcon(type) {
 
 export const numberWithPrecision = (number, precision = 2) => number.toFixed(precision);
 
+export const formatPrice = (price, options = {}) => {
+  const USDollar = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    ...options,
+  });
+  return USDollar.format(Math.abs(price));
+};
+
 /**
  *
  * @param couponCodes
@@ -817,10 +827,17 @@ export function getEntitlementPrice(entitlements) {
  * @returns Price for the course run.
  */
 export function getCoursePrice(course) {
-  if (course.activeCourseRun?.firstEnrollablePaidSeatPrice) {
-    return course.activeCourseRun.firstEnrollablePaidSeatPrice;
+  console.log(course, course.activeCourseRun?.fixedPriceUsd, course.activeCourseRun?.firstEnrollablePaidSeatPrice, course.entitlements);
+  if (course.activeCourseRun?.fixedPriceUsd) {
+    return [course.activeCourseRun?.fixedPriceUsd];
   }
-  return getEntitlementPrice(course.entitlements);
+  if (course.activeCourseRun?.firstEnrollablePaidSeatPrice) {
+    return [course.activeCourseRun?.firstEnrollablePaidSeatPrice];
+  }
+  if (course.entitlements.length > 0) {
+    return [course.entitlements];
+  }
+  return null;
 }
 
 /**

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -12,6 +12,7 @@ import {
   DISABLED_ENROLL_USER_MESSAGES,
   ENROLLMENT_COURSE_RUN_KEY_QUERY_PARAM,
   ENROLLMENT_FAILED_QUERY_PARAM,
+  ZERO_PRICE,
 } from './constants';
 import MicroMastersSvgIcon from '../../../assets/icons/micromasters.svg';
 import ProfessionalSvgIcon from '../../../assets/icons/professional.svg';
@@ -153,6 +154,23 @@ export function getProgramIcon(type) {
 }
 
 export const numberWithPrecision = (number, precision = 2) => number.toFixed(precision);
+
+/**
+ * Displays content price with precision as a range or singular price
+ * @param priceRange
+ * @returns {*|string}
+ */
+export const getContentPriceDisplay = (priceRange) => {
+  if (!priceRange?.length) {
+    return numberWithPrecision(ZERO_PRICE);
+  }
+  const minPrice = Math.min(...priceRange);
+  const maxPrice = Math.max(...priceRange);
+  if (maxPrice !== minPrice) {
+    return `${numberWithPrecision(minPrice)} - ${numberWithPrecision(maxPrice)}`;
+  }
+  return numberWithPrecision(priceRange.sort((a, b) => a - b)[0]);
+};
 
 export const formatPrice = (price, options = {}) => {
   const USDollar = new Intl.NumberFormat('en-US', {
@@ -827,7 +845,6 @@ export function getEntitlementPrice(entitlements) {
  * @returns Price for the course run.
  */
 export function getCoursePrice(course) {
-  console.log(course, course.activeCourseRun?.fixedPriceUsd, course.activeCourseRun?.firstEnrollablePaidSeatPrice, course.entitlements);
   if (course.activeCourseRun?.fixedPriceUsd) {
     return [course.activeCourseRun?.fixedPriceUsd];
   }
@@ -835,7 +852,7 @@ export function getCoursePrice(course) {
     return [course.activeCourseRun?.firstEnrollablePaidSeatPrice];
   }
   if (course.entitlements.length > 0) {
-    return [course.entitlements];
+    return [getEntitlementPrice(course.entitlements)];
   }
   return null;
 }
@@ -921,7 +938,7 @@ export function transformedCourseMetadata({
     startDate: getCourseStartDate({ courseRun }),
     duration: getDuration(),
     priceDetails: {
-      price: coursePrice.list,
+      price: coursePrice.listRange,
       currency,
     },
   };

--- a/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
+++ b/src/components/course/routes/tests/ExternalCourseEnrollment.test.jsx
@@ -5,17 +5,15 @@ import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { renderWithRouterProvider } from '../../../../utils/tests';
 
-import {
-  DISABLED_ENROLL_REASON_TYPES,
-} from '../../data/constants';
+import { DISABLED_ENROLL_REASON_TYPES } from '../../data/constants';
 import ExternalCourseEnrollment from '../ExternalCourseEnrollment';
 import { CourseContext } from '../../CourseContextProvider';
 import {
+  LEARNER_CREDIT_SUBSIDY_TYPE,
+  LICENSE_SUBSIDY_TYPE,
   useCourseRedemptionEligibility,
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
-  LEARNER_CREDIT_SUBSIDY_TYPE,
-  LICENSE_SUBSIDY_TYPE,
 } from '../../../app/data';
 import { enterpriseCustomerFactory } from '../../../app/data/services/data/__factories__';
 import {
@@ -108,7 +106,7 @@ describe('ExternalCourseEnrollment', () => {
         startDate: '2023-03-05',
         duration: '3 Weeks',
         priceDetails: {
-          price: 100,
+          price: [100],
           currency: 'USD',
         },
       },

--- a/src/components/course/routes/tests/ExternalCourseEnrollmentConfirmation.test.jsx
+++ b/src/components/course/routes/tests/ExternalCourseEnrollmentConfirmation.test.jsx
@@ -54,7 +54,7 @@ describe('ExternalCourseEnrollmentConfirmation', () => {
           logoImgUrl: 'https://example.com/logo.png',
         },
         priceDetails: {
-          price: 100,
+          price: [100],
           currency: 'USD',
         },
         startDate: '2023-03-05T12:00:00Z',

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -1,17 +1,15 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import CourseSidebarPrice from '../CourseSidebarPrice';
+import { SUBSIDY_DISCOUNT_TYPE_MAP } from '../data/constants';
 import {
-  SUBSIDY_DISCOUNT_TYPE_MAP,
-} from '../data/constants';
-import {
-  useEnterpriseCustomer,
+  COUPON_CODE_SUBSIDY_TYPE,
   ENTERPRISE_OFFER_SUBSIDY_TYPE,
   LEARNER_CREDIT_SUBSIDY_TYPE,
   LICENSE_SUBSIDY_TYPE,
-  COUPON_CODE_SUBSIDY_TYPE,
+  useEnterpriseCustomer,
 } from '../../app/data';
 import { enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
 import {
@@ -64,7 +62,7 @@ describe('<CourseSidebarPrice/> ', () => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     useUserSubsidyApplicableToCourse.mockReturnValue({ userSubsidyApplicableToCourse: null });
-    useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 7.5 }, currency: 'USD' });
+    useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [7.5] }, currency: 'USD' });
     useIsCourseAssigned.mockReturnValue({ isCourseAssigned: false });
     useCanUserRequestSubsidyForCourse.mockReturnValue(false);
   });
@@ -95,7 +93,7 @@ describe('<CourseSidebarPrice/> ', () => {
         subsidyType: ENTERPRISE_OFFER_SUBSIDY_TYPE,
       };
       useUserSubsidyApplicableToCourse.mockReturnValue({ userSubsidyApplicableToCourse: mockEnterpriseOfferSubsidy });
-      useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 0 }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
       render(<CourseSidebarPriceWrapper />);
       expect(screen.getByText('Priced reduced from:')).toBeInTheDocument();
       expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
@@ -126,7 +124,7 @@ describe('<CourseSidebarPrice/> ', () => {
     });
 
     test('subscription license subsidy, shows no price, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 0 }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: 7.5, discounted: 0 }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: { subsidyType: LICENSE_SUBSIDY_TYPE },
       });
@@ -140,7 +138,7 @@ describe('<CourseSidebarPrice/> ', () => {
     });
 
     test('coupon code 100% subsidy, shows no price, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 0 }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: FULL_COUPON_CODE_SUBSIDY,
       });
@@ -154,7 +152,7 @@ describe('<CourseSidebarPrice/> ', () => {
     });
 
     test('coupon code non-full subsidy, shows discounted price only, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 3.75 }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [3.75] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: PARTIAL_COUPON_CODE_SUBSIDY,
       });
@@ -168,7 +166,7 @@ describe('<CourseSidebarPrice/> ', () => {
 
     test('assigned course, shows no price, correct message', () => {
       useIsCourseAssigned.mockReturnValue({ isCourseAssigned: true });
-      useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 0 }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: { subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE },
       });
@@ -192,7 +190,7 @@ describe('<CourseSidebarPrice/> ', () => {
       expect(screen.queryByText('This course is assigned to you. The price of this course is already covered by your organization.')).not.toBeInTheDocument();
     });
     test('subscription license subsidy, shows orig crossed out price, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 0 }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: { subsidyType: LICENSE_SUBSIDY_TYPE },
       });
@@ -204,7 +202,7 @@ describe('<CourseSidebarPrice/> ', () => {
       expect(screen.queryByText('This course is assigned to you. The price of this course is already covered by your organization.')).not.toBeInTheDocument();
     });
     test('coupon code 100% subsidy, shows orig price, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 0 }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: FULL_COUPON_CODE_SUBSIDY,
       });
@@ -216,7 +214,7 @@ describe('<CourseSidebarPrice/> ', () => {
       expect(screen.queryByText('This course is assigned to you. The price of this course is already covered by your organization.')).not.toBeInTheDocument();
     });
     test('coupon code non-full subsidy, shows orig and discounted price only, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 3.75 }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [3.75] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: PARTIAL_COUPON_CODE_SUBSIDY,
       });
@@ -230,7 +228,7 @@ describe('<CourseSidebarPrice/> ', () => {
     });
     test('assigned course, shows orig price, correct message', () => {
       useIsCourseAssigned.mockReturnValue({ isCourseAssigned: true });
-      useCoursePrice.mockReturnValue({ coursePrice: { list: 7.5, discounted: 0 }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: { subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE },
       });

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -62,7 +62,7 @@ describe('<CourseSidebarPrice/> ', () => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     useUserSubsidyApplicableToCourse.mockReturnValue({ userSubsidyApplicableToCourse: null });
-    useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [7.5] }, currency: 'USD' });
+    useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discountedList: [7.5] }, currency: 'USD' });
     useIsCourseAssigned.mockReturnValue({ isCourseAssigned: false });
     useCanUserRequestSubsidyForCourse.mockReturnValue(false);
   });
@@ -93,7 +93,7 @@ describe('<CourseSidebarPrice/> ', () => {
         subsidyType: ENTERPRISE_OFFER_SUBSIDY_TYPE,
       };
       useUserSubsidyApplicableToCourse.mockReturnValue({ userSubsidyApplicableToCourse: mockEnterpriseOfferSubsidy });
-      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discountedList: [0] }, currency: 'USD' });
       render(<CourseSidebarPriceWrapper />);
       expect(screen.getByText('Priced reduced from:')).toBeInTheDocument();
       expect(screen.getByText(/\$7.50 USD/)).toBeInTheDocument();
@@ -124,7 +124,7 @@ describe('<CourseSidebarPrice/> ', () => {
     });
 
     test('subscription license subsidy, shows no price, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { listRange: 7.5, discounted: 0 }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discountedList: [0] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: { subsidyType: LICENSE_SUBSIDY_TYPE },
       });
@@ -138,7 +138,7 @@ describe('<CourseSidebarPrice/> ', () => {
     });
 
     test('coupon code 100% subsidy, shows no price, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discountedList: [0] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: FULL_COUPON_CODE_SUBSIDY,
       });
@@ -151,8 +151,8 @@ describe('<CourseSidebarPrice/> ', () => {
       expect(screen.queryByText('This course is assigned to you. The price of this course is already covered by your organization.')).not.toBeInTheDocument();
     });
 
-    test('coupon code non-full subsidy, shows discounted price only, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [3.75] }, currency: 'USD' });
+    test('coupon code non-full subsidy, shows discountedList price only, correct message', () => {
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discountedList: [3.75] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: PARTIAL_COUPON_CODE_SUBSIDY,
       });
@@ -166,7 +166,7 @@ describe('<CourseSidebarPrice/> ', () => {
 
     test('assigned course, shows no price, correct message', () => {
       useIsCourseAssigned.mockReturnValue({ isCourseAssigned: true });
-      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discountedList: [0] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: { subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE },
       });
@@ -190,7 +190,7 @@ describe('<CourseSidebarPrice/> ', () => {
       expect(screen.queryByText('This course is assigned to you. The price of this course is already covered by your organization.')).not.toBeInTheDocument();
     });
     test('subscription license subsidy, shows orig crossed out price, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discountedList: [0] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: { subsidyType: LICENSE_SUBSIDY_TYPE },
       });
@@ -202,7 +202,7 @@ describe('<CourseSidebarPrice/> ', () => {
       expect(screen.queryByText('This course is assigned to you. The price of this course is already covered by your organization.')).not.toBeInTheDocument();
     });
     test('coupon code 100% subsidy, shows orig price, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discountedList: [0] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: FULL_COUPON_CODE_SUBSIDY,
       });
@@ -213,8 +213,8 @@ describe('<CourseSidebarPrice/> ', () => {
       expect(screen.queryByText("This course can be purchased with your organization's learner credit")).not.toBeInTheDocument();
       expect(screen.queryByText('This course is assigned to you. The price of this course is already covered by your organization.')).not.toBeInTheDocument();
     });
-    test('coupon code non-full subsidy, shows orig and discounted price only, correct message', () => {
-      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [3.75] }, currency: 'USD' });
+    test('coupon code non-full subsidy, shows orig and discountedList price only, correct message', () => {
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discountedList: [3.75] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: PARTIAL_COUPON_CODE_SUBSIDY,
       });
@@ -228,7 +228,7 @@ describe('<CourseSidebarPrice/> ', () => {
     });
     test('assigned course, shows orig price, correct message', () => {
       useIsCourseAssigned.mockReturnValue({ isCourseAssigned: true });
-      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discounted: [0] }, currency: 'USD' });
+      useCoursePrice.mockReturnValue({ coursePrice: { listRange: [7.5], discountedList: [0] }, currency: 'USD' });
       useUserSubsidyApplicableToCourse.mockReturnValue({
         userSubsidyApplicableToCourse: { subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE },
       });

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -30,7 +30,6 @@ const SubscriptionExpirationModal = () => {
   const seenExpiredSubscriptionModal = !!global.localStorage.getItem(
     EXPIRED_SUBSCRIPTION_MODAL_LOCALSTORAGE_KEY(subscriptionLicense),
   );
-  console.log(seenExpiredSubscriptionModal);
   const [isOpen, , close] = useToggle(!seenExpiredSubscriptionModal);
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const {

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -25,10 +25,14 @@ const SubscriptionExpirationModal = () => {
   } = useContext(AppContext);
 
   const intl = useIntl();
-  const [isOpen, , close] = useToggle(true);
-  const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { data: subscriptions } = useSubscriptions();
   const { subscriptionPlan, subscriptionLicense } = subscriptions;
+  const seenExpiredSubscriptionModal = !!global.localStorage.getItem(
+    EXPIRED_SUBSCRIPTION_MODAL_LOCALSTORAGE_KEY(subscriptionLicense),
+  );
+  console.log(seenExpiredSubscriptionModal);
+  const [isOpen, , close] = useToggle(!seenExpiredSubscriptionModal);
+  const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const {
     daysUntilExpirationIncludingRenewals,
     expirationDate,
@@ -88,10 +92,6 @@ const SubscriptionExpirationModal = () => {
     close();
     global.localStorage.setItem(EXPIRED_SUBSCRIPTION_MODAL_LOCALSTORAGE_KEY(subscriptionLicense), 'true');
   };
-
-  const seenExpiredSubscriptionModal = !!global.localStorage.getItem(
-    EXPIRED_SUBSCRIPTION_MODAL_LOCALSTORAGE_KEY(subscriptionLicense),
-  );
   // If the subscription has already expired, we show a different un-dismissible modal
   if (!isCurrent) {
     if (seenExpiredSubscriptionModal) {
@@ -109,6 +109,7 @@ const SubscriptionExpirationModal = () => {
           </ActionRow>
         )}
         hasCloseButton
+        onClose={handleSubscriptionExpiredModalDismissal}
       >
         <p>
           Your organization&#39;s access to your subscription has expired. You will only have audit
@@ -170,6 +171,7 @@ const SubscriptionExpirationModal = () => {
         </ActionRow>
       )}
       hasCloseButton
+      onClose={handleSubscriptionExpiringModalDismissal}
     >
       <p>
         Your organization&#39;s access to your current subscription is expiring in

--- a/src/components/executive-education-2u/components/CourseSummaryCard.jsx
+++ b/src/components/executive-education-2u/components/CourseSummaryCard.jsx
@@ -1,22 +1,23 @@
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
 import {
-  Card, Image, Row, Col, Hyperlink,
+  Card, Col, Hyperlink, Image, Row,
 } from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import {
-  useMinimalCourseMetadata,
   DATE_FORMAT,
-  ZERO_PRICE,
+  getContentPriceDisplay,
   numberWithPrecision,
+  useMinimalCourseMetadata,
+  ZERO_PRICE,
 } from '../../course/data';
 
 const CourseSummaryCard = ({ enrollmentCompleted }) => {
   const { data: minimalCourseMetadata } = useMinimalCourseMetadata();
 
   let coursePrice = null;
-  const precisePrice = minimalCourseMetadata.priceDetails?.price ? `$${numberWithPrecision(
+  const precisePrice = minimalCourseMetadata.priceDetails?.price ? `$${getContentPriceDisplay(
     minimalCourseMetadata.priceDetails.price,
   )} ${minimalCourseMetadata.priceDetails.currency}` : '-';
   if (enrollmentCompleted && minimalCourseMetadata.priceDetails?.price) {

--- a/src/components/executive-education-2u/components/CourseSummaryCard.jsx
+++ b/src/components/executive-education-2u/components/CourseSummaryCard.jsx
@@ -6,24 +6,21 @@ import {
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import {
-  DATE_FORMAT,
-  getContentPriceDisplay,
-  numberWithPrecision,
-  useMinimalCourseMetadata,
-  ZERO_PRICE,
+  DATE_FORMAT, getContentPriceDisplay, useMinimalCourseMetadata, ZERO_PRICE,
 } from '../../course/data';
+import { formatPrice } from '../../../utils/common';
 
 const CourseSummaryCard = ({ enrollmentCompleted }) => {
   const { data: minimalCourseMetadata } = useMinimalCourseMetadata();
 
   let coursePrice = null;
-  const precisePrice = minimalCourseMetadata.priceDetails?.price ? `$${getContentPriceDisplay(
+  const precisePrice = minimalCourseMetadata.priceDetails?.price ? `${getContentPriceDisplay(
     minimalCourseMetadata.priceDetails.price,
   )} ${minimalCourseMetadata.priceDetails.currency}` : '-';
   if (enrollmentCompleted && minimalCourseMetadata.priceDetails?.price) {
     coursePrice = (
       <><del>{precisePrice}</del>
-        ${numberWithPrecision(ZERO_PRICE)} {minimalCourseMetadata.priceDetails.currency}
+        {formatPrice(ZERO_PRICE)} {minimalCourseMetadata.priceDetails.currency}
       </>
     );
   } else {

--- a/src/components/executive-education-2u/components/RegistrationSummaryCard.jsx
+++ b/src/components/executive-education-2u/components/RegistrationSummaryCard.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Card, Col, Row } from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { getContentPriceDisplay, numberWithPrecision } from '../../course/data/utils';
-import { CURRENCY_USD } from '../../course/data/constants';
+import { getContentPriceDisplay } from '../../course/data/utils';
+import { CURRENCY_USD, ZERO_PRICE } from '../../course/data/constants';
+import { formatPrice } from '../../../utils/common';
 
 const RegistrationSummaryCard = ({ priceDetails }) => (
   <Card
@@ -43,11 +44,11 @@ const RegistrationSummaryCard = ({ priceDetails }) => (
                 <Col xs={12} lg={{ span: 6, offset: 0 }} className="justify-content-end">
                   <div className="d-flex justify-content-end mr-2.5">
                     <del>
-                      {priceDetails?.price ? `$${getContentPriceDisplay(priceDetails.price)} ${priceDetails.currency}` : '-'}
+                      {priceDetails?.price ? `${getContentPriceDisplay(priceDetails.price)} ${priceDetails.currency}` : '-'}
                     </del>
                   </div>
                   <div className="d-flex justify-content-end mr-2.5">
-                    {priceDetails?.price ? `$${numberWithPrecision(0)} ${priceDetails?.currency ? priceDetails.currency : CURRENCY_USD}` : '-'}
+                    {priceDetails?.price ? `${formatPrice(ZERO_PRICE)} ${priceDetails?.currency ? priceDetails.currency : CURRENCY_USD}` : '-'}
                   </div>
                   <div className="d-flex justify-content-end small font-weight-light text-gray-500 mr-2.5">
                     <FormattedMessage

--- a/src/components/executive-education-2u/components/RegistrationSummaryCard.jsx
+++ b/src/components/executive-education-2u/components/RegistrationSummaryCard.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Card, Row, Col,
-} from '@openedx/paragon';
+import { Card, Col, Row } from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { numberWithPrecision } from '../../course/data/utils';
+import { getContentPriceDisplay, numberWithPrecision } from '../../course/data/utils';
 import { CURRENCY_USD } from '../../course/data/constants';
 
 const RegistrationSummaryCard = ({ priceDetails }) => (
@@ -45,7 +43,7 @@ const RegistrationSummaryCard = ({ priceDetails }) => (
                 <Col xs={12} lg={{ span: 6, offset: 0 }} className="justify-content-end">
                   <div className="d-flex justify-content-end mr-2.5">
                     <del>
-                      {priceDetails?.price ? `$${numberWithPrecision(priceDetails.price)} ${priceDetails.currency}` : '-'}
+                      {priceDetails?.price ? `$${getContentPriceDisplay(priceDetails.price)} ${priceDetails.currency}` : '-'}
                     </del>
                   </div>
                   <div className="d-flex justify-content-end mr-2.5">

--- a/src/components/microlearning/VideoDetailPage.jsx
+++ b/src/components/microlearning/VideoDetailPage.jsx
@@ -3,24 +3,19 @@ import React, { useContext, useEffect } from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import {
-  Container, Row, Badge, Skeleton,
-  Icon,
-  Button,
+  Badge, Button, Container, Icon, Row, Skeleton,
 } from '@openedx/paragon';
 import loadable from '@loadable/component';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
-import {
-  Person, Speed, Timelapse,
-} from '@openedx/paragon/icons';
+import { Person, Speed, Timelapse } from '@openedx/paragon/icons';
 import { Link } from 'react-router-dom';
 import {
-  useVideoDetails, useEnterpriseCustomer, useVideoCourseMetadata,
-  useSubscriptions,
+  useEnterpriseCustomer, useSubscriptions, useVideoCourseMetadata, useVideoDetails,
 } from '../app/data';
 import './styles/VideoDetailPage.scss';
 import DelayedFallbackContainer from '../DelayedFallback/DelayedFallbackContainer';
 import NotFoundPage from '../NotFoundPage';
-import { getCoursePrice, useCoursePacingType } from '../course/data';
+import { getContentPriceDisplay, getCoursePrice, useCoursePacingType } from '../course/data';
 import VideoCourseReview from './VideoCourseReview';
 import { hasTruthyValue, isDefinedAndNotNull } from '../../utils/common';
 import { getLevelType } from './data/utils';
@@ -40,6 +35,7 @@ const VideoDetailPage = () => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { data: videoData } = useVideoDetails();
   const { data: courseMetadata } = useVideoCourseMetadata(videoData?.courseKey);
+  const coursePrice = getCoursePrice(courseMetadata);
   const [pacingType, pacingTypeContent] = useCoursePacingType(courseMetadata?.activeCourseRun);
   const { data: { subscriptionLicense } } = useSubscriptions();
   const playerRef = React.useRef(null);
@@ -204,7 +200,7 @@ const VideoDetailPage = () => {
                       description="Label for the original price of the course."
                     />
                   </strong>
-                  <s>${getCoursePrice(courseMetadata)} USD</s>
+                  <s>${getContentPriceDisplay(coursePrice)} USD</s>
                   <h4 className="text-danger ml-2 m-0">
                     <FormattedMessage
                       id="enterprise.courseAbout.courseSidebar.price.free"

--- a/src/components/microlearning/VideoDetailPage.jsx
+++ b/src/components/microlearning/VideoDetailPage.jsx
@@ -200,7 +200,7 @@ const VideoDetailPage = () => {
                       description="Label for the original price of the course."
                     />
                   </strong>
-                  <s>${getContentPriceDisplay(coursePrice)} USD</s>
+                  <s>{getContentPriceDisplay(coursePrice)} USD</s>
                   <h4 className="text-danger ml-2 m-0">
                     <FormattedMessage
                       id="enterprise.courseAbout.courseSidebar.price.free"

--- a/src/components/microlearning/tests/VideoDetailPage.test.jsx
+++ b/src/components/microlearning/tests/VideoDetailPage.test.jsx
@@ -19,6 +19,7 @@ import {
 import { COURSE_PACING_MAP } from '../../course/data';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 import { features } from '../../../config';
+import { formatPrice } from '../../../utils/common';
 
 const APP_CONFIG = {
   USE_API_CACHE: true,
@@ -187,7 +188,7 @@ describe('VideoDetailPage', () => {
   it('renders the price', () => {
     useVideoCourseMetadata.mockReturnValue({ data: { ...mockCourseMetadata, activeCourseRun: { ...mockCourseRun, levelType: 'Unknown' } } });
     renderWithRouter(<VideoDetailPageWrapper />);
-    expect(screen.getByText(`$${mockCourseRun.firstEnrollablePaidSeatPrice}.00 USD`)).toBeInTheDocument();
+    expect(screen.getByText(`${formatPrice(mockCourseRun.firstEnrollablePaidSeatPrice)} USD`)).toBeInTheDocument();
   });
 
   it('renders a not found page when video data is not found', () => {

--- a/src/components/microlearning/tests/VideoDetailPage.test.jsx
+++ b/src/components/microlearning/tests/VideoDetailPage.test.jsx
@@ -10,9 +10,11 @@ import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../app/d
 import { renderWithRouter } from '../../../utils/tests';
 import VideoDetailPage from '../VideoDetailPage';
 import {
-  useVideoDetails, useEnterpriseCustomer, useVideoCourseMetadata,
-  useVideoCourseReviews,
+  useEnterpriseCustomer,
   useSubscriptions,
+  useVideoCourseMetadata,
+  useVideoCourseReviews,
+  useVideoDetails,
 } from '../../app/data';
 import { COURSE_PACING_MAP } from '../../course/data';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
@@ -85,13 +87,15 @@ const mockCourseRun = {
   minEffort: 2,
   maxEffort: 4,
   levelType: 'Introductory',
+  firstEnrollablePaidSeatPrice: 100,
 };
 const mockCourseMetadata = {
   key: 'test-course-key',
-  outcome: '<ul><li>hello i am descritpion</li></ul>',
+  outcome: '<ul><li>hello i am description</li></ul>',
   title: 'Test Course Title',
   activeCourseRun: mockCourseRun,
   courseRuns: [mockCourseRun],
+  entitlements: [],
 };
 const mockCourseReviews = {
   course_key: 'course-test-key',
@@ -117,7 +121,7 @@ const VideoDetailPageWrapper = ({
   </IntlProvider>
 );
 
-describe('VideoDetailPage Tests', () => {
+describe('VideoDetailPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
@@ -178,6 +182,12 @@ describe('VideoDetailPage Tests', () => {
     useVideoCourseMetadata.mockReturnValue({ data: { ...mockCourseMetadata, activeCourseRun: { ...mockCourseRun, levelType: 'Unknown' } } });
     renderWithRouter(<VideoDetailPageWrapper />);
     expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+
+  it('renders the price', () => {
+    useVideoCourseMetadata.mockReturnValue({ data: { ...mockCourseMetadata, activeCourseRun: { ...mockCourseRun, levelType: 'Unknown' } } });
+    renderWithRouter(<VideoDetailPageWrapper />);
+    expect(screen.getByText(`$${mockCourseRun.firstEnrollablePaidSeatPrice}.00 USD`)).toBeInTheDocument();
   });
 
   it('renders a not found page when video data is not found', () => {

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -25,6 +25,9 @@ export const isNull = (value) => {
 };
 
 export const isDefinedAndNotNull = (value) => {
+  if (Array.isArray(value)) {
+    return value.every(item => isDefined(item) && !isNull(item));
+  }
   const values = createArrayFromValue(value);
   return values.every(item => isDefined(item) && !isNull(item));
 };
@@ -38,6 +41,8 @@ export const hasTruthyValue = (value) => {
   const values = createArrayFromValue(value);
   return values.every(item => !!item);
 };
+
+export const sumOfArray = (values) => values.reduce((prev, next) => prev + next, 0);
 
 export const hasValidStartExpirationDates = ({ startDate, expirationDate, endDate }) => {
   const now = dayjs();

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -25,9 +25,6 @@ export const isNull = (value) => {
 };
 
 export const isDefinedAndNotNull = (value) => {
-  if (Array.isArray(value)) {
-    return value.every(item => isDefined(item) && !isNull(item));
-  }
   const values = createArrayFromValue(value);
   return values.every(item => isDefined(item) && !isNull(item));
 };
@@ -42,7 +39,9 @@ export const hasTruthyValue = (value) => {
   return values.every(item => !!item);
 };
 
-export const sumOfArray = (values) => values.reduce((prev, next) => prev + next, 0);
+export const sumOfArray = (values) => (values.every(item => typeof item === 'number' && !Number.isNaN(item))
+  ? values.reduce((prev, next) => prev + next, 0)
+  : null);
 
 export const hasValidStartExpirationDates = ({ startDate, expirationDate, endDate }) => {
   const now = dayjs();
@@ -183,3 +182,14 @@ export function i18nFormatTimestamp({ intl, timestamp, formatOpts = {} }) {
     ...formatOpts,
   });
 }
+
+export const formatPrice = (price, options = {}) => {
+  const USDollar = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+    ...options,
+  });
+  return USDollar.format(Math.abs(price));
+};


### PR DESCRIPTION
This change would take into account price ranges for the course sidebar based on the run price. 👍🏽 

Example UI:
![Screenshot 2024-10-02 at 9 58 02 AM](https://github.com/user-attachments/assets/0e807b08-c018-4472-97da-64e713258124)

[Bug fix]
Fixed a bug I ran into where the subscription expiration modal became a blocking modal.
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
