### PR TITLE
feat: create a route to handle invite keys that includes the customer slug

### DIFF
--- a/src/components/app/routes/createAppRouter.test.jsx
+++ b/src/components/app/routes/createAppRouter.test.jsx
@@ -135,6 +135,14 @@ describe('createAppRouter', () => {
       }],
     },
     {
+      currentRoutePath: '/test-enterprise/invite/enterprise-customer-invite-key',
+      expectedRouteTestId: 'invite',
+      expectedRouteLoaders: [{
+        loader: makeEnterpriseInviteLoader,
+        usesQueryClient: false,
+      }],
+    },
+    {
       currentRoutePath: '/test-enterprise',
       expectedRouteTestId: 'dashboard',
       expectedRouteLoaders: [{

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -214,6 +214,28 @@ function getOtherRoutes() {
         };
       },
     },
+    {
+      /**
+       * We want to support a slug-"aware" version of the invite key route,
+       * but we don't want it nested under the root loader via
+       * enterpriseSlugRoutes above. Putting this route under the root loader
+       * would mean that the post-registration redirect back to this route
+       * would run through the root loader logic with a now-authenticated-but-unlinked
+       * requesting user, which will throw a 404 (until the async call to
+       * `link-user/` resolves and the page is reloaded).
+       */
+      path: ':enterpriseSlug/invite/:enterpriseCustomerInviteKey',
+      lazy: async () => {
+        const {
+          default: EnterpriseInviteRoute,
+          makeEnterpriseInviteLoader,
+        } = await import('./components/app/routes/EnterpriseInviteRoute');
+        return {
+          Component: EnterpriseInviteRoute,
+          loader: makeEnterpriseInviteLoader(),
+        };
+      },
+    },
   ];
   return otherRoutes;
 }


### PR DESCRIPTION
The existing universal link route does not contain the enterprise slug, so for unauthenticated users, the frontend has no knowledge of which customer’s branded logistration for which to redirect. This is typically relied upon based on the `:enterpriseSlug` route parameter in the URL, which is missing for the existing universal link route. This change adds a new invite key route that includes the enterprise slug. This will enable us to produce slug-aware invite URLs from the admin portal, that receiving learners can use to become linked to the enterprise via the B2B-specific auth flow (which is customer-aware). 
ENT-9428

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
