### PR TITLE
feat: read from fixed priced usd for course sidebar

### DIFF
--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -34,18 +34,18 @@ import {
   getSubscriptionDisabledEnrollmentReasonType,
   transformedCourseMetadata,
 } from '../utils';
-import {
-  DISABLED_ENROLL_REASON_TYPES,
-  DISABLED_ENROLL_USER_MESSAGES,
-  REASON_USER_MESSAGES,
-} from '../constants';
+import { DISABLED_ENROLL_REASON_TYPES, DISABLED_ENROLL_USER_MESSAGES, REASON_USER_MESSAGES } from '../constants';
 import { mockSubscriptionLicense } from '../../tests/constants';
 import * as optimizelyUtils from '../../../../utils/optimizely';
 import { LICENSE_STATUS } from '../../../enterprise-user-subsidy/data/constants';
 import { SUBSIDY_TYPE } from '../../../../constants';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../../app/data/services/data/__factories__';
 import {
+  COUPON_CODE_SUBSIDY_TYPE,
+  ENTERPRISE_OFFER_SUBSIDY_TYPE,
   getSubsidyToApplyForCourse,
+  LEARNER_CREDIT_SUBSIDY_TYPE,
+  LICENSE_SUBSIDY_TYPE,
   useBrowseAndRequest,
   useCatalogsForSubsidyRequests,
   useCouponCodes,
@@ -56,10 +56,6 @@ import {
   useEnterpriseOffers,
   useRedeemablePolicies,
   useSubscriptions,
-  COUPON_CODE_SUBSIDY_TYPE,
-  ENTERPRISE_OFFER_SUBSIDY_TYPE,
-  LEARNER_CREDIT_SUBSIDY_TYPE,
-  LICENSE_SUBSIDY_TYPE,
 } from '../../../app/data';
 import { CourseContext } from '../../CourseContextProvider';
 
@@ -1714,6 +1710,22 @@ describe('useCourseListPrice', () => {
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
     delete baseCourseMetadataValue.entitlements;
     useCourseMetadata.mockReturnValue(updatedListPrice || getCoursePrice(baseCourseMetadataValue));
+    const { result } = renderHook(
+      () => useCourseListPrice(),
+      { wrapper: Wrapper },
+    );
+    expect(result.current).toEqual(undefined);
+  });
+  it('should return fixed_price_usd from fallback getCoursePrice', () => {
+    const updatedListPrice = undefined;
+    useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
+    const updatedBaseCourseMetadataValue = {
+      ...baseCourseMetadataValue,
+      activeCourseRun: {
+        fixed_price_usd: 20,
+      },
+    };
+    useCourseMetadata.mockReturnValue(updatedListPrice || getCoursePrice(updatedBaseCourseMetadataValue));
     const { result } = renderHook(
       () => useCourseListPrice(),
       { wrapper: Wrapper },

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -817,6 +817,9 @@ export function getEntitlementPrice(entitlements) {
  * @returns Price for the course run.
  */
 export function getCoursePrice(course) {
+  if (course.activeCourseRun?.fixedPriceUsd) {
+    return course.activeCourseRun.fixedPriceUsd;
+  }
   if (course.activeCourseRun?.firstEnrollablePaidSeatPrice) {
     return course.activeCourseRun.firstEnrollablePaidSeatPrice;
   }

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -25,10 +25,13 @@ const SubscriptionExpirationModal = () => {
   } = useContext(AppContext);
 
   const intl = useIntl();
-  const [isOpen, , close] = useToggle(true);
-  const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { data: subscriptions } = useSubscriptions();
   const { subscriptionPlan, subscriptionLicense } = subscriptions;
+  const seenExpiredSubscriptionModal = !!global.localStorage.getItem(
+    EXPIRED_SUBSCRIPTION_MODAL_LOCALSTORAGE_KEY(subscriptionLicense),
+  );
+  const [isOpen, , close] = useToggle(!seenExpiredSubscriptionModal);
+  const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const {
     daysUntilExpirationIncludingRenewals,
     expirationDate,
@@ -89,9 +92,6 @@ const SubscriptionExpirationModal = () => {
     global.localStorage.setItem(EXPIRED_SUBSCRIPTION_MODAL_LOCALSTORAGE_KEY(subscriptionLicense), 'true');
   };
 
-  const seenExpiredSubscriptionModal = !!global.localStorage.getItem(
-    EXPIRED_SUBSCRIPTION_MODAL_LOCALSTORAGE_KEY(subscriptionLicense),
-  );
   // If the subscription has already expired, we show a different un-dismissible modal
   if (!isCurrent) {
     if (seenExpiredSubscriptionModal) {

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -109,6 +109,7 @@ const SubscriptionExpirationModal = () => {
           </ActionRow>
         )}
         hasCloseButton
+        onClose={handleSubscriptionExpiredModalDismissal}
       >
         <p>
           Your organization&#39;s access to your subscription has expired. You will only have audit
@@ -170,6 +171,7 @@ const SubscriptionExpirationModal = () => {
         </ActionRow>
       )}
       hasCloseButton
+      onClose={handleSubscriptionExpiringModalDismissal}
     >
       <p>
         Your organization&#39;s access to your current subscription is expiring in


### PR DESCRIPTION
Updates `getCoursePrice` to read from `fixedPriceUsd` if it exists.

Since the listPrice which is defined upstream of getCoursePrice is defined by the listPrice.usd value from canRedeem, no further changes are needed in the frontend to ensure that the fixed price is displayed if it exists. This is because the source of truth for price (`NormalizedContentMetadataSerializer.get_content_price` [[source](https://github.com/openedx/enterprise-catalog/blob/4db5daa4c5f7b8172e99174e3e036683c8886da1/enterprise_catalog/apps/catalog/serializers.py#L147-L154)]) has been updated to read `fixed_price_usd` if it exist, and propogates to the `listPrice.usd` downstream within canRedeem once these PRs are merged. 

- https://github.com/openedx/enterprise-catalog/pull/931
- https://github.com/openedx/enterprise-subsidy/pull/300

[Bug fix]
Fixed a bug I ran into where the subscription expiration modal became a blocking modal. 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
