### PR TITLE
feat: add alert modal and conditional text for expired subscriptions

### DIFF
--- a/src/components/course/ExpiredSubscriptionModal.jsx
+++ b/src/components/course/ExpiredSubscriptionModal.jsx
@@ -1,0 +1,28 @@
+import {
+  StandardModal, useToggle,
+} from '@openedx/paragon';
+import { Link } from 'react-router-dom';
+import { useSubscriptions } from '../app/data';
+
+const ExpiredSubscriptionModal = () => {
+  const { data: { customerAgreement } } = useSubscriptions();
+  const [isOpen, ,close] = useToggle(true);
+  if (!customerAgreement?.hasCustomLicenseExpirationMessaging) {
+    return null;
+  }
+  return (
+    <StandardModal
+      isOpen={isOpen}
+      className="d-flex justify-content-center align-items-center text-wrap text-right "
+      hasCloseButton
+      onClose={close}
+    >
+      <p className="text-center">
+        {customerAgreement?.expiredSubscriptionModalMessaging}
+        <Link className="text-decoration-none" to={customerAgreement?.urlForExpiredModal}> {customerAgreement?.hyperLinkTextForExpiredModal}</Link>
+      </p>
+    </StandardModal>
+  );
+};
+
+export default ExpiredSubscriptionModal;

--- a/src/components/course/course-header/CourseRunCardStatus.jsx
+++ b/src/components/course/course-header/CourseRunCardStatus.jsx
@@ -4,6 +4,7 @@ import { Card } from '@openedx/paragon';
 import { Lock } from '@openedx/paragon/icons';
 
 import { DISABLED_ENROLL_REASON_TYPES } from '../data/constants';
+import { useSubscriptions } from '../../app/data';
 
 /**
  * Display under these situations:
@@ -28,25 +29,33 @@ const CourseRunCardStatus = ({
   isUserEnrolled,
   userCanRequestSubsidyForCourse,
 }) => {
+  const { data: { customerAgreement } } = useSubscriptions();
   const missingUserSubsidyReasonType = missingUserSubsidyReason?.reason;
   const missingUserSubsidyReasonUserMessage = missingUserSubsidyReason?.userMessage;
   const missingUserSubsidyReasonActions = missingUserSubsidyReason?.actions;
-
   const hasValidReason = !!(missingUserSubsidyReasonType && missingUserSubsidyReasonUserMessage);
   if (isUserEnrolled || !hasValidReason || userCanRequestSubsidyForCourse) {
     return null;
   }
-
   return (
-    <Card.Status
-      variant="primary"
-      icon={Lock}
-      actions={missingUserSubsidyReasonActions}
-    >
-      <p className="font-weight-bold">
-        {missingUserSubsidyReasonUserMessage}
-      </p>
-    </Card.Status>
+    customerAgreement?.hasCustomLicenseExpirationMessaging ? (
+      <Card.Status
+        data-testid="custom-license-expiration-message-id"
+        variant="primary"
+        className="d-flex justify-content-center align-items-center"
+        icon={Lock}
+      />
+    ) : (
+      <Card.Status
+        variant="primary"
+        icon={Lock}
+        actions={missingUserSubsidyReasonActions}
+      >
+        <p className="font-weight-bold">
+          {missingUserSubsidyReasonUserMessage}
+        </p>
+      </Card.Status>
+    )
   );
 };
 

--- a/src/components/course/routes/CourseAbout.jsx
+++ b/src/components/course/routes/CourseAbout.jsx
@@ -13,6 +13,7 @@ import {
   useIsAssignmentsOnlyLearner,
   usePassLearnerCsodParams,
 } from '../../app/data';
+import ExpiredSubscriptionModal from '../ExpiredSubscriptionModal';
 
 const CourseAbout = () => {
   const { data: canOnlyViewHighlightSets } = useCanOnlyViewHighlights();
@@ -28,6 +29,7 @@ const CourseAbout = () => {
 
   return (
     <>
+      <ExpiredSubscriptionModal />
       <CourseHeader />
       <Container size="lg" className="py-5">
         <Row>

--- a/src/components/course/routes/tests/CourseAbout.test.jsx
+++ b/src/components/course/routes/tests/CourseAbout.test.jsx
@@ -6,7 +6,7 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import CourseAbout from '../CourseAbout';
 import { renderWithRouter } from '../../../../utils/tests';
-import { useEnterpriseCustomer, useCanOnlyViewHighlights } from '../../../app/data';
+import { useEnterpriseCustomer, useCanOnlyViewHighlights, useSubscriptions } from '../../../app/data';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../../app/data/services/data/__factories__';
 
 jest.mock('../../../app/data', () => ({
@@ -15,6 +15,7 @@ jest.mock('../../../app/data', () => ({
   useIsAssignmentsOnlyLearner: jest.fn().mockReturnValue(false),
   useCanOnlyViewHighlights: jest.fn().mockReturnValue(false),
   usePassLearnerCsodParams: jest.fn(),
+  useSubscriptions: jest.fn(),
 }));
 
 jest.mock('../../course-header/CourseHeader', () => jest.fn(() => (
@@ -67,6 +68,16 @@ describe('CourseAbout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    useSubscriptions.mockReturnValue({
+      data: {
+        customerAgreement: {
+          hasCustomLicenseExpirationMessaging: false,
+          expiredSubscriptionModalMessaging: null,
+          urlForExpiredModal: null,
+          hyperLinkTextForExpiredModal: null,
+        },
+      },
+    });
   });
 
   it('renders', () => {


### PR DESCRIPTION
**Description**

- Conditionally override the "Disabled_enroll_Reason" on the Course about Page

![image](https://github.com/user-attachments/assets/1376dd63-504e-43f8-bd4b-842ab3e42dd8)

- Create AlertModal to Display Custom Text when `has_custom_license_expiration_messaging` Enabled

![image](https://github.com/user-attachments/assets/a9eb0b28-ea04-4715-b5db-82aca4121e52)




# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
