### PR TITLE
fix: ensure consistency around start dates on course run cards in Course page

### DIFF
--- a/src/components/app/routes/loaders/rootLoader.ts
+++ b/src/components/app/routes/loaders/rootLoader.ts
@@ -39,10 +39,6 @@ const makeRootLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function ma
       return null;
     }
 
-    // TODO:
-    // - Make POST request to new onboarding API in enterprise-access (passing lms_user_id and enterprise_customer_uuid)
-    // - Remove `ensureActiveEnterpriseCustomerUser`, since it'll be abstracted in above API call.
-
     // Ensure the active enterprise customer user is updated, when applicable (e.g., the
     // current enterprise slug in the URL does not match the active enterprise customer's slug).
     const updateActiveEnterpriseCustomerUserResult = await ensureActiveEnterpriseCustomerUser({

--- a/src/components/app/routes/loaders/rootLoader.ts
+++ b/src/components/app/routes/loaders/rootLoader.ts
@@ -39,6 +39,10 @@ const makeRootLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function ma
       return null;
     }
 
+    // TODO:
+    // - Make POST request to new onboarding API in enterprise-access (passing lms_user_id and enterprise_customer_uuid)
+    // - Remove `ensureActiveEnterpriseCustomerUser`, since it'll be abstracted in above API call.
+
     // Ensure the active enterprise customer user is updated, when applicable (e.g., the
     // current enterprise slug in the URL does not match the active enterprise customer's slug).
     const updateActiveEnterpriseCustomerUserResult = await ensureActiveEnterpriseCustomerUser({

--- a/src/components/course/course-header/data/hooks/tests/useCourseRunCardHeading.test.jsx
+++ b/src/components/course/course-header/data/hooks/tests/useCourseRunCardHeading.test.jsx
@@ -1,6 +1,7 @@
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { renderHook } from '@testing-library/react-hooks';
 import MockDate from 'mockdate';
+import dayjs from 'dayjs';
 import '@testing-library/jest-dom/extend-expect';
 
 import { hasTimeToComplete } from '../../../../data/utils';
@@ -8,7 +9,6 @@ import { hasTimeToComplete } from '../../../../data/utils';
 import { MOCK_COURSE_RUN_START } from './constants';
 import useCourseRunCardHeading from '../useCourseRunCardHeading';
 import { COURSE_PACING_MAP } from '../../../../data/constants';
-import dayjs from 'dayjs';
 import { DATE_FORMAT } from '../../constants';
 
 jest.mock('../../../../data/utils', () => ({

--- a/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
+++ b/src/components/course/course-header/data/hooks/useCourseRunCardHeading.js
@@ -1,7 +1,12 @@
 import dayjs from 'dayjs';
 import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 
-import { getCourseStartDate, hasTimeToComplete, isCourseSelfPaced } from '../../../data/utils';
+import {
+  getCourseStartDate,
+  hasTimeToComplete,
+  isCourseSelfPaced,
+  isWithinMinimumStartDateThreshold,
+} from '../../../data/utils';
 import { DATE_FORMAT } from '../constants';
 
 const messages = defineMessages({
@@ -48,7 +53,7 @@ const useCourseRunCardHeading = ({
       return intl.formatMessage(messages.courseStarted);
     }
     if (isCourseSelfPaced(courseRun.pacingType)) {
-      if (hasTimeToComplete(courseRun)) {
+      if (hasTimeToComplete(courseRun) || isWithinMinimumStartDateThreshold(courseRun)) {
         // always today's date (incentives enrollment)
         return intl.formatMessage(messages.courseStartDate, {
           startDate: dayjs().format(DATE_FORMAT),

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -74,7 +74,7 @@ export function isCourseInstructorPaced(pacingType) {
   return [COURSE_PACING_MAP.INSTRUCTOR_PACED, COURSE_PACING_MAP.INSTRUCTOR].includes(pacingType);
 }
 
-const isWithinMinimumStartDateThreshold = ({ start }) => dayjs(start).isBefore(dayjs().subtract(START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS, 'days'));
+export const isWithinMinimumStartDateThreshold = ({ start }) => dayjs(start).isBefore(dayjs().subtract(START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS, 'days'));
 
 /**
  * If the start date of the course is before today offset by the START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS


### PR DESCRIPTION
Adds parity with start-based assignments by updating business logic around which start is displayed on the available course run cards in the Course page route.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
