### PR TITLE
feat: allow auto applied with universal link via toggle

### DIFF
--- a/src/components/app/data/services/subsidies/subscriptions.js
+++ b/src/components/app/data/services/subsidies/subscriptions.js
@@ -96,11 +96,14 @@ export async function getAutoAppliedSubscriptionLicense({
 
   const hasSubscriptionForAutoAppliedLicenses = !!customerAgreement.subscriptionForAutoAppliedLicenses;
   const hasIdentityProvider = enterpriseCustomer.identityProvider;
+  const hasAutoAppliedWithUniversalLink = !!customerAgreement.enableAutoAppliedSubscriptionsWithUniversalLink;
+  const hasIdpOrAutoAppliedWithUniversalLink = hasIdentityProvider || hasAutoAppliedWithUniversalLink;
 
   // If customer agreement has no configured subscription plan for auto-applied
-  // licenses, or the enterprise customer does not have an identity provider,
+  // licenses, or the enterprise customer does not have either a identity provider or
+  // the field `enableAutoAppliedSubscriptionsWithUniversalLink` enabled
   // return early.
-  if (!hasSubscriptionForAutoAppliedLicenses || !hasIdentityProvider) {
+  if (!(hasSubscriptionForAutoAppliedLicenses && hasIdpOrAutoAppliedWithUniversalLink)) {
     return null;
   }
 

--- a/src/components/app/data/services/subsidies/subscriptions.test.js
+++ b/src/components/app/data/services/subsidies/subscriptions.test.js
@@ -377,36 +377,77 @@ describe('activateOrAutoApplySubscriptionLicense', () => {
     {
       identityProvider: null,
       subscriptionForAutoAppliedLicenses: null,
+      enableAutoAppliedSubscriptionsWithUniversalLink: false,
       isLinkedToEnterpriseCustomer: false,
       shouldAutoApply: false,
     },
     {
       identityProvider: null,
       subscriptionForAutoAppliedLicenses: mockSubscriptionPlanUUID,
+      enableAutoAppliedSubscriptionsWithUniversalLink: false,
       isLinkedToEnterpriseCustomer: false,
       shouldAutoApply: false,
     },
     {
       identityProvider: 'identity-provider',
       subscriptionForAutoAppliedLicenses: null,
+      enableAutoAppliedSubscriptionsWithUniversalLink: false,
       isLinkedToEnterpriseCustomer: false,
       shouldAutoApply: false,
     },
     {
       identityProvider: 'identity-provider',
       subscriptionForAutoAppliedLicenses: mockSubscriptionPlanUUID,
+      enableAutoAppliedSubscriptionsWithUniversalLink: false,
       isLinkedToEnterpriseCustomer: false,
       shouldAutoApply: false,
     },
     {
       identityProvider: 'identity-provider',
       subscriptionForAutoAppliedLicenses: mockSubscriptionPlanUUID,
+      enableAutoAppliedSubscriptionsWithUniversalLink: false,
+      isLinkedToEnterpriseCustomer: true,
+      shouldAutoApply: true,
+    },
+    {
+      identityProvider: null,
+      subscriptionForAutoAppliedLicenses: null,
+      enableAutoAppliedSubscriptionsWithUniversalLink: true,
+      isLinkedToEnterpriseCustomer: false,
+      shouldAutoApply: false,
+    },
+    {
+      identityProvider: null,
+      subscriptionForAutoAppliedLicenses: mockSubscriptionPlanUUID,
+      enableAutoAppliedSubscriptionsWithUniversalLink: true,
+      isLinkedToEnterpriseCustomer: false,
+      shouldAutoApply: false,
+    },
+    {
+      identityProvider: 'identity-provider',
+      subscriptionForAutoAppliedLicenses: null,
+      enableAutoAppliedSubscriptionsWithUniversalLink: true,
+      isLinkedToEnterpriseCustomer: false,
+      shouldAutoApply: false,
+    },
+    {
+      identityProvider: 'identity-provider',
+      subscriptionForAutoAppliedLicenses: mockSubscriptionPlanUUID,
+      enableAutoAppliedSubscriptionsWithUniversalLink: true,
+      isLinkedToEnterpriseCustomer: false,
+      shouldAutoApply: false,
+    },
+    {
+      identityProvider: 'identity-provider',
+      subscriptionForAutoAppliedLicenses: mockSubscriptionPlanUUID,
+      enableAutoAppliedSubscriptionsWithUniversalLink: true,
       isLinkedToEnterpriseCustomer: true,
       shouldAutoApply: true,
     },
   ])('auto-applies subscription license (%s)', async ({
     identityProvider,
     subscriptionForAutoAppliedLicenses,
+    enableAutoAppliedSubscriptionsWithUniversalLink,
     isLinkedToEnterpriseCustomer,
     shouldAutoApply,
   }) => {
@@ -418,6 +459,7 @@ describe('activateOrAutoApplySubscriptionLicense', () => {
     const mockCustomerAgreementWithAutoApplied = {
       ...mockCustomerAgreement,
       subscriptionForAutoAppliedLicenses,
+      enableAutoAppliedSubscriptionsWithUniversalLink,
     };
     const mockSubscriptionsData = {
       customerAgreement: mockCustomerAgreementWithAutoApplied,


### PR DESCRIPTION
Uses the net new field on the customer agreement labled `enable_auto_applied_subscriptions_with_universal_link` to allow a customer without SSO enabled to use auto applied licenses via universal link.

Dependent on : https://github.com/openedx/license-manager/pull/718

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
