### PR TITLE
[REFERENCE] feat: incrementally adopt Dashboard BFF API

### DIFF
--- a/src/components/app/data/hooks/useSubscriptions.js
+++ b/src/components/app/data/hooks/useSubscriptions.js
@@ -1,6 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
+import { useLocation } from 'react-router-dom';
+
 import { querySubscriptions } from '../queries';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { transformSubscriptionsData } from '../services';
+import { resolveBFFQuery } from '../../routes/data';
 
 /**
  * Custom hook to get subscriptions data for the enterprise.
@@ -9,8 +13,30 @@ import useEnterpriseCustomer from './useEnterpriseCustomer';
  */
 export default function useSubscriptions(queryOptions = {}) {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
+  const location = useLocation();
+
+  const matchedBFFQuery = resolveBFFQuery(location.pathname);
+
+  // Determine the query configuration: use the matched BFF query or fallback to default
+  let queryConfig;
+  if (matchedBFFQuery) {
+    queryConfig = {
+      ...matchedBFFQuery(enterpriseCustomer.uuid),
+      select: (data) => {
+        const { customerAgreement, subscriptionLicenses } = data?.enterpriseCustomerUserSubsidies?.subscriptions || {};
+        if (!customerAgreement || !subscriptionLicenses) {
+          return {};
+        }
+        // TODO: move transforms into the BFF response
+        const transformedSubscriptionsData = transformSubscriptionsData(customerAgreement, subscriptionLicenses);
+        return transformedSubscriptionsData;
+      },
+    };
+  } else {
+    queryConfig = querySubscriptions(enterpriseCustomer.uuid);
+  }
   return useQuery({
-    ...querySubscriptions(enterpriseCustomer.uuid),
+    ...queryConfig,
     ...queryOptions,
   });
 }

--- a/src/components/app/data/queries/queries.ts
+++ b/src/components/app/data/queries/queries.ts
@@ -265,3 +265,12 @@ export function queryVideoDetail(videoUUID: string, enterpriseUUID: string) {
     ._ctx.video
     ._ctx.detail(videoUUID);
 }
+
+// BFF queries
+
+export function queryEnterpriseLearnerDashboardBFF(enterpriseUuid: string) {
+  return queries
+    .enterprise
+    .enterpriseCustomer(enterpriseUuid)
+    ._ctx.bffs._ctx.dashboard;
+}

--- a/src/components/app/data/queries/queryKeyFactory.js
+++ b/src/components/app/data/queries/queryKeyFactory.js
@@ -16,6 +16,7 @@ import {
   fetchEnterpriseCourseEnrollments,
   fetchEnterpriseCuration,
   fetchEnterpriseCustomerContainsContent,
+  fetchEnterpriseLearnerDashboard,
   fetchEnterpriseLearnerData,
   fetchEnterpriseOffers,
   fetchInProgressPathways,
@@ -47,6 +48,15 @@ const enterprise = createQueryKeys('enterprise', {
   enterpriseCustomer: (enterpriseUuid) => ({
     queryKey: [enterpriseUuid],
     contextQueries: {
+      bffs: {
+        queryKey: null,
+        contextQueries: {
+          dashboard: ({
+            queryKey: null,
+            queryFn: ({ queryKey }) => fetchEnterpriseLearnerDashboard(queryKey[2]),
+          }),
+        },
+      },
       academies: {
         queryKey: null,
         contextQueries: {

--- a/src/components/app/data/services/bffs.js
+++ b/src/components/app/data/services/bffs.js
@@ -1,0 +1,21 @@
+import { getConfig } from '@edx/frontend-platform/config';
+import { logError } from '@edx/frontend-platform/logging';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
+
+export async function fetchEnterpriseLearnerDashboard(enterpriseId, lmsUserId) {
+  const { ENTERPRISE_ACCESS_BASE_URL } = getConfig();
+  const params = {
+    enterprise_customer_uuid: enterpriseId,
+    lms_user_id: lmsUserId,
+  };
+  const url = `${ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/dashboard/`;
+  try {
+    const result = await getAuthenticatedHttpClient().post(url, params);
+    return camelCaseObject(result.data);
+  } catch (error) {
+    logError(error);
+    // TODO: consider returning a sane default API response structure here to mitigate complete failure.
+    return {};
+  }
+}

--- a/src/components/app/data/services/index.js
+++ b/src/components/app/data/services/index.js
@@ -9,3 +9,4 @@ export * from './subsidies';
 export * from './user';
 export * from './utils';
 export * from './videos';
+export * from './bffs';

--- a/src/components/dashboard/data/dashboardLoader.ts
+++ b/src/components/dashboard/data/dashboardLoader.ts
@@ -1,9 +1,9 @@
 import { ensureAuthenticatedUser } from '../../app/routes/data';
 import {
   extractEnterpriseCustomer,
-  queryEnterpriseCourseEnrollments,
   queryEnterprisePathwaysList,
   queryEnterpriseProgramsList,
+  queryEnterpriseLearnerDashboardBFF,
 } from '../../app/data';
 
 type DashboardRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
@@ -31,8 +31,9 @@ const makeDashboardLoader: Types.MakeRouteLoaderFunctionWithQueryClient = functi
       authenticatedUser,
       enterpriseSlug,
     });
+
     await Promise.all([
-      queryClient.ensureQueryData(queryEnterpriseCourseEnrollments(enterpriseCustomer.uuid)),
+      queryClient.ensureQueryData(queryEnterpriseLearnerDashboardBFF(enterpriseCustomer.uuid)),
       queryClient.ensureQueryData(queryEnterpriseProgramsList(enterpriseCustomer.uuid)),
       queryClient.ensureQueryData(queryEnterprisePathwaysList(enterpriseCustomer.uuid)),
     ]);


### PR DESCRIPTION
## Description

[Context] [Tech Spec](https://2u-internal.atlassian.net/wiki/spaces/SOL/pages/1392640165/DRAFT+Tech+Spec+Auto-enrolling+in+default+enterprise+course+enrollments)

* Adds a new `queryEnterpriseLearnerDashboardBFF` to the `queryKeyFactory`, integrating with the new Dashboard BFF exposed via https://github.com/openedx/enterprise-access/pull/572.
* In `dashboardLoader`, the existing `ensureQueryData(queryEnterpriseCourseEnrollments)` is now replaced with `queryEnterpriseLearnerDashboardBFF`, which returns the same enterprise course enrollments metadata in its API response.
* In `rootLoader`, only executes the `ensureQueryData(querySubscriptions)` when not a page route configured with a BFF API endpoint. That is, since only the Dashboard page route has a BFF configured, all other page routes continue to work as normal (retrieving data from specific micro-services vs the BFF).
* Updates `useEnterpriseCourseEnrollments` to compose a new hook `useBaseEnterpriseCourseEnrollments`. The new hook is responsible for determining which query config to to retrieve enterprise course enrollments. It does so via a `resolveBFFQuery` helper function that determines which BFF query is configured for any given route pattern. In practice, when on the Dashboard page route, `useBaseEnterpriseCourseEnrollments` will extract `enterpriseCourseEnrollments` from the BFF query; when on non-Dashboard page routes, `useBaseEnterpriseCourseEnrollments` will continue extracting enrollments from `queryEnterpriseCourseEnrollments` (independent query to `enterprise_course_enrollments`).
* Updates `useSubscriptions` with a similar treatment as `useBaseEnterpriseCourseEnrollments`, described above. `useSubscriptions` will now extract subscriptions-related data from the BFF query for the current route, if configured; otherwise, falls back to current state `querySubscriptions` (independent query to `learner-licenses`).

### Jira

[ENT-9427](https://2u-internal.atlassian.net/browse/ENT-9427)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
