### PR TITLE
feat: take into account enrollments in dashboard -> search route redirect for new users

### DIFF
--- a/src/components/app/routes/loaders/rootLoader.ts
+++ b/src/components/app/routes/loaders/rootLoader.ts
@@ -3,7 +3,6 @@ import {
   ensureAuthenticatedUser,
   ensureEnterpriseAppData,
   redirectToRemoveTrailingSlash,
-  redirectToSearchPageForNewUser,
   ensureActiveEnterpriseCustomerUser,
 } from '../data';
 
@@ -62,19 +61,12 @@ const makeRootLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function ma
     }
 
     // Fetch all enterprise app data.
-    const enterpriseAppData = await ensureEnterpriseAppData({
+    await ensureEnterpriseAppData({
       enterpriseCustomer,
       allLinkedEnterpriseCustomerUsers,
       userId,
       userEmail,
       queryClient,
-      requestUrl,
-    });
-
-    // Redirect user to search page, for first-time users with no assignments.
-    redirectToSearchPageForNewUser({
-      enterpriseSlug: enterpriseSlug as string,
-      enterpriseAppData,
       requestUrl,
     });
 

--- a/src/components/dashboard/data/dashboardLoader.test.jsx
+++ b/src/components/dashboard/data/dashboardLoader.test.jsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import { when } from 'jest-when';
 import '@testing-library/jest-dom/extend-expect';
 
 import { renderWithRouterProvider } from '../../../utils/tests';
@@ -8,6 +9,7 @@ import {
   queryEnterpriseCourseEnrollments,
   queryEnterprisePathwaysList,
   queryEnterpriseProgramsList,
+  queryRedeemablePolicies,
 } from '../../app/data';
 import { ensureAuthenticatedUser } from '../../app/routes/data';
 
@@ -21,7 +23,7 @@ jest.mock('../../app/data', () => ({
 }));
 
 const mockEnterpriseId = 'test-enterprise-uuid';
-extractEnterpriseCustomer.mockResolvedValue({ uuid: mockEnterpriseId });
+const mockEnterpriseSlug = 'test-enterprise-slug';
 
 const mockQueryClient = {
   ensureQueryData: jest.fn().mockResolvedValue({}),
@@ -30,40 +32,136 @@ const mockQueryClient = {
 describe('dashboardLoader', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    localStorage.clear();
     ensureAuthenticatedUser.mockResolvedValue({ userId: 3 });
+    extractEnterpriseCustomer.mockResolvedValue({ uuid: mockEnterpriseId, slug: mockEnterpriseSlug });
   });
 
   it('does nothing with unauthenticated users', async () => {
     ensureAuthenticatedUser.mockResolvedValue(null);
     renderWithRouterProvider({
       path: '/:enterpriseSlug',
-      element: <div>hello world</div>,
+      element: <div data-testid="dashboard" />,
       loader: makeDashboardLoader(mockQueryClient),
     }, [
       {
-        initialEntries: ['/test-enterprise-slug'],
+        initialEntries: [`/${mockEnterpriseSlug}`],
       },
     ]);
 
-    expect(await screen.findByText('hello world')).toBeInTheDocument();
-
+    expect(await screen.findByTestId('dashboard')).toBeInTheDocument();
     expect(mockQueryClient.ensureQueryData).not.toHaveBeenCalled();
   });
 
-  it('ensures the requisite dashboard data is resolved', async () => {
-    renderWithRouterProvider({
-      path: '/:enterpriseSlug',
-      element: <div>hello world</div>,
-      loader: makeDashboardLoader(mockQueryClient),
-    }, [
-      {
-        initialEntries: ['/test-enterprise-slug'],
+  it.each([
+    {
+      hasAssignmentsForDisplay: false,
+      hasEnterpriseCourseEnrollments: false,
+      currentPageRoute: `/${mockEnterpriseSlug}`,
+      hasVisitedDashboardBefore: false,
+      shouldRedirectToSearch: true,
+    },
+    {
+      hasAssignmentsForDisplay: false,
+      hasEnterpriseCourseEnrollments: false,
+      currentPageRoute: `/${mockEnterpriseSlug}`,
+      hasVisitedDashboardBefore: true,
+      shouldRedirectToSearch: false,
+    },
+    {
+      hasAssignmentsForDisplay: false,
+      hasEnterpriseCourseEnrollments: false,
+      currentPageRoute: `/${mockEnterpriseSlug}/search`,
+      hasVisitedDashboardBefore: false,
+      shouldRedirectToSearch: false,
+    },
+    {
+      hasAssignmentsForDisplay: true,
+      hasEnterpriseCourseEnrollments: false,
+      currentPageRoute: `/${mockEnterpriseSlug}`,
+      hasVisitedDashboardBefore: false,
+      shouldRedirectToSearch: false,
+    },
+    {
+      hasAssignmentsForDisplay: false,
+      hasEnterpriseCourseEnrollments: true,
+      currentPageRoute: `/${mockEnterpriseSlug}`,
+      hasVisitedDashboardBefore: false,
+      shouldRedirectToSearch: false,
+    },
+    {
+      hasAssignmentsForDisplay: true,
+      hasEnterpriseCourseEnrollments: true,
+      currentPageRoute: `/${mockEnterpriseSlug}`,
+      hasVisitedDashboardBefore: false,
+      shouldRedirectToSearch: false,
+    },
+  ])('ensures the requisite dashboard data is resolved (%s)', async ({
+    hasAssignmentsForDisplay,
+    hasEnterpriseCourseEnrollments,
+    currentPageRoute,
+    hasVisitedDashboardBefore,
+    shouldRedirectToSearch,
+  }) => {
+    // Mock global.location.pathname
+    const mockLocation = {
+      pathname: currentPageRoute,
+    };
+    jest.spyOn(global, 'location', 'get').mockReturnValue(mockLocation);
+
+    // Mock localStorage, if necessary
+    if (hasVisitedDashboardBefore) {
+      localStorage.setItem('has-user-visited-learner-dashboard', true);
+    }
+
+    // Mock redeemable policies query
+    const mockRedeemablePolicies = {
+      learnerContentAssignments: {
+        hasAssignmentsForDisplay,
       },
-    ]);
+    };
+    const redeemablePoliciesQuery = queryRedeemablePolicies({ enterpriseUuid: mockEnterpriseId, lmsUserId: 3 });
+    when(mockQueryClient.ensureQueryData).calledWith(
+      expect.objectContaining({
+        queryKey: redeemablePoliciesQuery.queryKey,
+      }),
+    ).mockResolvedValue(mockRedeemablePolicies);
 
-    expect(await screen.findByText('hello world')).toBeInTheDocument();
+    // Mock enterprise course enrollments query
+    const mockEnterpriseCourseEnrollments = [];
+    if (hasEnterpriseCourseEnrollments) {
+      mockEnterpriseCourseEnrollments.push({ courseId: 'test-course-id' });
+    }
+    when(mockQueryClient.ensureQueryData).calledWith(
+      expect.objectContaining({
+        queryKey: queryEnterpriseCourseEnrollments(mockEnterpriseId).queryKey,
+      }),
+    ).mockResolvedValue(mockEnterpriseCourseEnrollments);
 
-    expect(mockQueryClient.ensureQueryData).toHaveBeenCalledTimes(3);
+    renderWithRouterProvider(
+      {
+        path: '/:enterpriseSlug',
+        element: <div data-testid="dashboard" />,
+        loader: makeDashboardLoader(mockQueryClient),
+      },
+      {
+        initialEntries: [`/${mockEnterpriseSlug}`],
+        routes: [
+          {
+            path: '/:enterpriseSlug/search',
+            element: <div data-testid="search" />,
+          },
+        ],
+      },
+    );
+
+    if (shouldRedirectToSearch) {
+      expect(await screen.findByTestId('search')).toBeInTheDocument();
+    } else {
+      expect(await screen.findByTestId('dashboard')).toBeInTheDocument();
+    }
+
+    expect(mockQueryClient.ensureQueryData).toHaveBeenCalledTimes(4);
     expect(mockQueryClient.ensureQueryData).toHaveBeenCalledWith(
       expect.objectContaining({
         queryKey: queryEnterpriseCourseEnrollments(mockEnterpriseId).queryKey,
@@ -73,6 +171,12 @@ describe('dashboardLoader', () => {
     expect(mockQueryClient.ensureQueryData).toHaveBeenCalledWith(
       expect.objectContaining({
         queryKey: queryEnterpriseProgramsList(mockEnterpriseId).queryKey,
+        queryFn: expect.any(Function),
+      }),
+    );
+    expect(mockQueryClient.ensureQueryData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: queryRedeemablePolicies({ enterpriseUuid: mockEnterpriseId, lmsUserId: 3 }).queryKey,
         queryFn: expect.any(Function),
       }),
     );


### PR DESCRIPTION
### Ticket

[ENT-9583](https://2u-internal.atlassian.net/browse/ENT-9583)

### CHANGELOG

* Moves call to `redirectToSearchPageForNewUser` from `rootLoader` to `dashboardLoader`.
  * Requires bringing in `queryClient.ensureQueryData(queryRedeemablePolicies(...))` alongside the query to fetch enrollments to determine whether the dashboard -> search redirect is applicable based on both the enrollments but also assignments from `credits_available`.
* Refactors `redirectToSearchPageForNewUser` to accept `enterpriseCourseEnrollments`, and only trigger redirect from the dashboard route to search route for learners with no enrollments to display on their dashboard, in addition to the existing check on the displayed assignments.
  * Returns early if navigating from a different route (e.g., search) to the dashboard route, as this navigation was triggered by an explicit user action (e.g., clicking "Dashboard" in the header menu navigation). Otherwise, it's possible to click "Dashboard" from search route and have no change in the UI since the `dashboardLoader` redirects you right back to the search route you're already on).

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
