### PR TITLE
feat: updated the custom expiration model design and truly blocking

### DIFF
--- a/src/components/expired-subscription-modal/index.jsx
+++ b/src/components/expired-subscription-modal/index.jsx
@@ -1,27 +1,46 @@
 import {
-  StandardModal, useToggle,
+  useToggle, AlertModal, Button, ActionRow,
 } from '@openedx/paragon';
-import { Link } from 'react-router-dom';
 import { useSubscriptions } from '../app/data';
 
 const ExpiredSubscriptionModal = () => {
   const { data: { customerAgreement } } = useSubscriptions();
-  const [isOpen, ,close] = useToggle(true);
+  const [isOpen] = useToggle(true);
   if (!customerAgreement?.hasCustomLicenseExpirationMessaging) {
     return null;
   }
+  const onClickHandler = () => {
+    let url = customerAgreement?.urlForButtonInModal;
+
+    if (url) {
+      // Check if the URL starts with 'http://' or 'https://'
+      if (!url.startsWith('http://') && !url.startsWith('https://')) {
+        // Prepend 'https://' if the URL is missing the protocol
+        url = `https://${url}`;
+      }
+
+      // Navigate to the full URL
+      window.open(url, '_blank'); // Opening in a new tab
+    }
+  };
   return (
-    <StandardModal
+    <AlertModal
+      title={customerAgreement?.modalHeaderText}
       isOpen={isOpen}
-      className="d-flex justify-content-center align-items-center text-wrap text-right "
-      hasCloseButton
-      onClose={close}
+      isBlocking
+      footerNode={(
+        <ActionRow>
+          <Button
+            onClick={onClickHandler}
+          >
+            {customerAgreement?.buttonLabelInModal}
+          </Button>
+        </ActionRow>
+      )}
     >
-      <p className="text-center">
-        {customerAgreement?.expiredSubscriptionModalMessaging}
-        <Link className="text-decoration-none" to={customerAgreement?.urlForExpiredModal}> {customerAgreement?.hyperLinkTextForExpiredModal}</Link>
-      </p>
-    </StandardModal>
+      {/* eslint-disable-next-line react/no-danger */}
+      <div dangerouslySetInnerHTML={{ __html: customerAgreement?.expiredSubscriptionModalMessaging }} />
+    </AlertModal>
   );
 };
 


### PR DESCRIPTION
**Description**

- Updated the custom expiration model design
- Make that modal truly blocking

<img width="1411" alt="Screenshot 2024-10-17 at 3 35 51 PM" src="https://github.com/user-attachments/assets/3b85319d-0152-4b84-854b-8209aaf82a23">



JIRA -> [ENT-9616](https://2u-internal.atlassian.net/browse/ENT-9616), [ENT-9618](https://2u-internal.atlassian.net/browse/ENT-9618)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
