### PR TITLE
fix: check length on empty array for list price

### DIFF
--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -522,7 +522,7 @@ export function useUserHasSubsidyRequestForCourse(courseKey) {
 
 export function useCourseListPrice() {
   const { data: { listPrice } } = useCourseRedemptionEligibility();
-  const resolveListPrice = ({ transformed }) => listPrice.length > 0 ? listPrice : getCoursePrice(transformed);
+  const resolveListPrice = ({ transformed }) => (listPrice.length > 0 ? listPrice : getCoursePrice(transformed));
   return useCourseMetadata({
     select: resolveListPrice,
   });

--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -522,7 +522,7 @@ export function useUserHasSubsidyRequestForCourse(courseKey) {
 
 export function useCourseListPrice() {
   const { data: { listPrice } } = useCourseRedemptionEligibility();
-  const resolveListPrice = ({ transformed }) => listPrice || getCoursePrice(transformed);
+  const resolveListPrice = ({ transformed }) => listPrice.length > 0 ? listPrice : getCoursePrice(transformed);
   return useCourseMetadata({
     select: resolveListPrice,
   });

--- a/src/components/course/data/tests/hooks.test.jsx
+++ b/src/components/course/data/tests/hooks.test.jsx
@@ -1667,6 +1667,7 @@ describe('useCourseListPrice', () => {
       },
     ],
   };
+  const mockedListPrice = [mockListPrice];
 
   const Wrapper = ({ children }) => (
     <AppContext.Provider value={mockAuthenticatedUser}>
@@ -1675,25 +1676,29 @@ describe('useCourseListPrice', () => {
   );
   beforeEach(() => {
     jest.clearAllMocks();
-    useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: mockListPrice } });
+    useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: mockedListPrice } });
     // NOTE: `useCourseMetadata`'s mocked return value assumes the returned value
     // from the `select` function passed to the hook.
-    useCourseMetadata.mockReturnValue({ data: mockListPrice || getCoursePrice(baseCourseMetadataValue) });
+    useCourseMetadata.mockReturnValue({
+      data: mockedListPrice.length > 0 ? mockedListPrice : getCoursePrice(baseCourseMetadataValue),
+    });
   });
   it('should return the list price if one exist', () => {
     const { result } = renderHook(
       () => useCourseListPrice(),
       { wrapper: Wrapper },
     );
-    const expectedListPrice = mockListPrice;
+    const expectedListPrice = [mockListPrice];
     const courseMetadataSelectFn = useCourseMetadata.mock.calls[0][0].select;
     expect(expectedListPrice).toEqual(courseMetadataSelectFn({ transformed: baseCourseMetadataValue }));
     expect(result.current).toEqual({ data: expectedListPrice });
   });
   it('should not return the list price if one doesnt exist, fall back to fixed_price_usd from getCoursePrice', () => {
-    const updatedListPrice = undefined;
+    const updatedListPrice = [];
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
-    useCourseMetadata.mockReturnValue({ data: updatedListPrice || getCoursePrice(baseCourseMetadataValue) });
+    useCourseMetadata.mockReturnValue(
+      { data: updatedListPrice.length > 0 ? updatedListPrice : getCoursePrice(baseCourseMetadataValue) },
+    );
     const { result } = renderHook(
       () => useCourseListPrice(),
       { wrapper: Wrapper },
@@ -1704,10 +1709,12 @@ describe('useCourseListPrice', () => {
     expect(result.current).toEqual({ data: expectedListPrice });
   });
   it('should not return the list price if one doesnt exist, fall back to firstEnrollablePaidSeatPrice from getCoursePrice', () => {
-    const updatedListPrice = undefined;
+    const updatedListPrice = [];
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
     delete baseCourseMetadataValue.activeCourseRun.fixedPriceUsd;
-    useCourseMetadata.mockReturnValue({ data: updatedListPrice || getCoursePrice(baseCourseMetadataValue) });
+    useCourseMetadata.mockReturnValue(
+      { data: updatedListPrice.length > 0 ? updatedListPrice : getCoursePrice(baseCourseMetadataValue) },
+    );
     const { result } = renderHook(
       () => useCourseListPrice(),
       { wrapper: Wrapper },
@@ -1718,11 +1725,13 @@ describe('useCourseListPrice', () => {
     expect(result.current).toEqual({ data: expectedListPrice });
   });
   it('should not return the list price if one doesnt exit, fall back to entitlements from getCoursePrice', () => {
-    const updatedListPrice = undefined;
+    const updatedListPrice = [];
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
     delete baseCourseMetadataValue.activeCourseRun.fixedPriceUsd;
     delete baseCourseMetadataValue.activeCourseRun.firstEnrollablePaidSeatPrice;
-    useCourseMetadata.mockReturnValue({ data: updatedListPrice || getCoursePrice(baseCourseMetadataValue) });
+    useCourseMetadata.mockReturnValue(
+      { data: updatedListPrice > 0 ? updatedListPrice : getCoursePrice(baseCourseMetadataValue) },
+    );
     const { result } = renderHook(
       () => useCourseListPrice(),
       { wrapper: Wrapper },
@@ -1733,7 +1742,7 @@ describe('useCourseListPrice', () => {
     expect(result.current).toEqual({ data: expectedListPrice });
   });
   it('should not return the list price if one doesnt exist or the course metadata doesnt include it', () => {
-    const updatedListPrice = undefined;
+    const updatedListPrice = [];
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: updatedListPrice } });
     const updatedCourseMetadata = {
       ...baseCourseMetadataValue,
@@ -1744,7 +1753,9 @@ describe('useCourseListPrice', () => {
       },
       entitlements: [],
     };
-    useCourseMetadata.mockReturnValue({ data: updatedListPrice || getCoursePrice(updatedCourseMetadata) });
+    useCourseMetadata.mockReturnValue(
+      { data: updatedListPrice.length > 0 ? updatedListPrice : getCoursePrice(updatedCourseMetadata) },
+    );
     const { result } = renderHook(
       () => useCourseListPrice(),
       { wrapper: Wrapper },


### PR DESCRIPTION
Update check on returned list price length to correctly go into the fallback check for price.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
