### PR TITLE
fix: styles on expiry modal

### DIFF
--- a/src/components/expired-subscription-modal/index.jsx
+++ b/src/components/expired-subscription-modal/index.jsx
@@ -25,7 +25,7 @@ const ExpiredSubscriptionModal = () => {
   };
   return (
     <AlertModal
-      title={customerAgreement?.modalHeaderText}
+      title={<h3 className="mb-2">{customerAgreement?.modalHeaderText}</h3>}
       isOpen={isOpen}
       isBlocking
       footerNode={(


### PR DESCRIPTION
**Description**

Issue:
- Modal title text was showing some unnecessary spaces

Fix:
-  Override base class to fix the issue

<img width="1433" alt="Screenshot 2024-10-21 at 4 36 18 PM" src="https://github.com/user-attachments/assets/ef5d1271-524b-4051-8810-d718970d94fe">



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
