### PR TITLE
Prevent SubscriptionExpirationModal from displaying when custom messages enabled.

### DIFF
--- a/src/components/app/data/services/subsidies/subscriptions.js
+++ b/src/components/app/data/services/subsidies/subscriptions.js
@@ -236,7 +236,9 @@ export async function fetchSubscriptions(enterpriseUUID) {
     if (customerAgreement) {
       subscriptionsData.customerAgreement = customerAgreement;
     }
-    subscriptionsData.showExpirationNotifications = !(customerAgreement?.disableExpirationNotifications);
+    subscriptionsData.showExpirationNotifications = (
+      !customerAgreement?.disableExpirationNotifications && !customerAgreement?.hasCustomLicenseExpirationMessaging
+    );
 
     // Sort licenses within each license status by whether the associated subscription plans
     // are current; current plans should be prioritized over non-current plans.

--- a/src/components/app/data/services/subsidies/subscriptions.test.js
+++ b/src/components/app/data/services/subsidies/subscriptions.test.js
@@ -66,6 +66,9 @@ describe('fetchSubscriptions', () => {
       daysUntilExpiration: 30,
       startDate: dayjs().subtract(15, 'days').toISOString(),
       expirationDate: dayjs().add(30, 'days').toISOString(),
+      disableExpirationNotifications: false,
+      hasCustomLicenseExpirationMessaging: false,
+      expectedShowExpirationNotifications: true,
     },
     {
       licenseStatus: LICENSE_STATUS.ACTIVATED,
@@ -74,6 +77,9 @@ describe('fetchSubscriptions', () => {
       daysUntilExpiration: 30,
       startDate: dayjs().subtract(15, 'days').toISOString(),
       expirationDate: dayjs().add(30, 'days').toISOString(),
+      disableExpirationNotifications: false,
+      hasCustomLicenseExpirationMessaging: false,
+      expectedShowExpirationNotifications: true,
     },
     {
       licenseStatus: LICENSE_STATUS.ACTIVATED,
@@ -82,6 +88,9 @@ describe('fetchSubscriptions', () => {
       daysUntilExpiration: 0,
       startDate: dayjs().subtract(15, 'days').toISOString(),
       expirationDate: dayjs().toISOString(),
+      disableExpirationNotifications: false,
+      hasCustomLicenseExpirationMessaging: false,
+      expectedShowExpirationNotifications: true,
     },
     {
       licenseStatus: LICENSE_STATUS.UNASSIGNED,
@@ -90,6 +99,45 @@ describe('fetchSubscriptions', () => {
       daysUntilExpiration: 30,
       startDate: dayjs().subtract(15, 'days').toISOString(),
       expirationDate: dayjs().add(30, 'days').toISOString(),
+      disableExpirationNotifications: false,
+      hasCustomLicenseExpirationMessaging: false,
+      expectedShowExpirationNotifications: true,
+    },
+    // Custom subs messaging with standard expiration still enabled
+    {
+      licenseStatus: LICENSE_STATUS.ACTIVATED,
+      isSubscriptionPlanActive: true,
+      isSubscriptionPlanCurrent: false,
+      daysUntilExpiration: -10,
+      startDate: dayjs().subtract(15, 'days').toISOString(),
+      expirationDate: dayjs().subtract(10, 'days').toISOString(),
+      disableExpirationNotifications: false,
+      hasCustomLicenseExpirationMessaging: true,
+      expectedShowExpirationNotifications: false,
+    },
+    // Disabled standard expiration, with custom subs expiration enabled
+    {
+      licenseStatus: LICENSE_STATUS.ACTIVATED,
+      isSubscriptionPlanActive: true,
+      isSubscriptionPlanCurrent: false,
+      daysUntilExpiration: -10,
+      startDate: dayjs().subtract(15, 'days').toISOString(),
+      expirationDate: dayjs().subtract(10, 'days').toISOString(),
+      disableExpirationNotifications: true,
+      hasCustomLicenseExpirationMessaging: true,
+      expectedShowExpirationNotifications: false,
+    },
+    // Disabled standard expiration, no custom subs expiration
+    {
+      licenseStatus: LICENSE_STATUS.ACTIVATED,
+      isSubscriptionPlanActive: true,
+      isSubscriptionPlanCurrent: false,
+      daysUntilExpiration: -10,
+      startDate: dayjs().subtract(15, 'days').toISOString(),
+      expirationDate: dayjs().subtract(10, 'days').toISOString(),
+      disableExpirationNotifications: true,
+      hasCustomLicenseExpirationMessaging: false,
+      expectedShowExpirationNotifications: false,
     },
   ])('returns subscriptions (%s)', async ({
     licenseStatus,
@@ -98,6 +146,9 @@ describe('fetchSubscriptions', () => {
     daysUntilExpiration,
     startDate,
     expirationDate,
+    disableExpirationNotifications,
+    hasCustomLicenseExpirationMessaging,
+    expectedShowExpirationNotifications,
   }) => {
     const mockSubscriptionLicense = {
       uuid: 'test-license-uuid',
@@ -114,7 +165,8 @@ describe('fetchSubscriptions', () => {
     const mockResponse = {
       customerAgreement: {
         uuid: 'test-customer-agreement-uuid',
-        disableExpirationNotifications: false,
+        disableExpirationNotifications,
+        hasCustomLicenseExpirationMessaging,
       },
       results: [mockSubscriptionLicense],
     };
@@ -157,7 +209,7 @@ describe('fetchSubscriptions', () => {
       subscriptionLicense: isLicenseApplicable ? updatedMockSubscriptionLicense : null,
       subscriptionLicenses: [updatedMockSubscriptionLicense],
       shouldShowActivationSuccessMessage: false,
-      showExpirationNotifications: true,
+      showExpirationNotifications: expectedShowExpirationNotifications,
     };
     expect(response).toEqual(expectedResult);
   });

--- a/src/components/expired-subscription-modal/index.jsx
+++ b/src/components/expired-subscription-modal/index.jsx
@@ -5,13 +5,17 @@ import DOMPurify from 'dompurify';
 import { useSubscriptions } from '../app/data';
 
 const ExpiredSubscriptionModal = () => {
-  const { data: { customerAgreement, subscriptionLicense } } = useSubscriptions();
+  const { data: { customerAgreement, subscriptionLicense, subscriptionPlan } } = useSubscriptions();
   const [isOpen] = useToggle(true);
-  const displaySubscriptionExpirationModal = customerAgreement?.hasCustomLicenseExpirationMessaging
-      && !subscriptionLicense?.subscriptionPlan.isCurrent;
+  const displaySubscriptionExpirationModal = (
+    customerAgreement?.hasCustomLicenseExpirationMessaging
+    && subscriptionLicense && !subscriptionPlan.isCurrent
+  );
+
   if (!displaySubscriptionExpirationModal) {
     return null;
   }
+
   return (
     <AlertModal
       title={<h3 className="mb-2">{customerAgreement.modalHeaderText}</h3>}

--- a/src/components/expired-subscription-modal/tests/ExpiredSubscriptionModal.test.jsx
+++ b/src/components/expired-subscription-modal/tests/ExpiredSubscriptionModal.test.jsx
@@ -22,9 +22,10 @@ describe('<ExpiredSubscriptionModal />', () => {
           urlForButtonInModal: null,
         },
         subscriptionLicense: {
-          subscriptionPlan: {
-            isCurrent: true,
-          },
+          uuid: '123',
+        },
+        subscriptionPlan: {
+          isCurrent: true,
         },
       },
     });
@@ -46,10 +47,30 @@ describe('<ExpiredSubscriptionModal />', () => {
           urlForButtonInModal: '/renew',
         },
         subscriptionLicense: {
-          subscriptionPlan: {
-            isCurrent: true,
-          },
+          uuid: '123',
         },
+        subscriptionPlan: {
+          isCurrent: true,
+        },
+      },
+    });
+
+    const { container } = renderWithRouter(<ExpiredSubscriptionModal />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('does not renderwithrouter if learner does not have a license', () => {
+    useSubscriptions.mockReturnValue({
+      data: {
+        customerAgreement: {
+          hasCustomLicenseExpirationMessaging: true,
+          modalHeaderText: 'Expired Subscription',
+          buttonLabelInModal: 'Continue Learning',
+          expiredSubscriptionModalMessaging: '<p>Your subscription has expired.</p>',
+          urlForButtonInModal: '/renew',
+        },
+        subscriptionLicense: null,
+        subscriptionPlan: null,
       },
     });
 
@@ -68,9 +89,10 @@ describe('<ExpiredSubscriptionModal />', () => {
           urlForButtonInModal: '/renew',
         },
         subscriptionLicense: {
-          subscriptionPlan: {
-            isCurrent: false,
-          },
+          uuid: '123',
+        },
+        subscriptionPlan: {
+          isCurrent: false,
         },
       },
     });
@@ -97,6 +119,12 @@ describe('<ExpiredSubscriptionModal />', () => {
           expiredSubscriptionModalMessaging: '<p>Your subscription has expired.</p>',
           urlForButtonInModal: '/renew',
         },
+        subscriptionLicense: {
+          uuid: '123',
+        },
+        subscriptionPlan: {
+          isCurrent: false,
+        },
       },
     });
 
@@ -113,6 +141,12 @@ describe('<ExpiredSubscriptionModal />', () => {
           buttonLabelInModal: 'Continue Learning',
           expiredSubscriptionModalMessaging: '<p>Your subscription has expired.</p>',
           urlForButtonInModal: 'https://example.com',
+        },
+        subscriptionLicense: {
+          uuid: '123',
+        },
+        subscriptionPlan: {
+          isCurrent: false,
         },
       },
     });


### PR DESCRIPTION
Prevents original/standard subscriptions expiration modal from renders simultaneously with the custom subs messaging modal.