### PR TITLE
feat: add query key and hooks for BFF layer

### DIFF
--- a/src/components/app/data/hooks/useBFF.js
+++ b/src/components/app/data/hooks/useBFF.js
@@ -1,0 +1,32 @@
+import { useLocation } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { resolveBFFQuery } from '../../routes/data/utils';
+import { useEnterpriseCustomer } from './index';
+
+/**
+ * Switch from UUID to SLUG todo
+ * @param queryOptions
+ * @returns {UseQueryResult<unknown, unknown>}
+ */
+export function useBFF(queryOptions = {}) {
+  const { data: enterpriseCustomer } = useEnterpriseCustomer();
+  const queryClient = useQueryClient();
+  const location = useLocation();
+
+  // Determine the BFF query to use based on the current location
+  const matchedBFFQuery = resolveBFFQuery(location.pathname);
+  return useQuery({
+    ...matchedBFFQuery,
+    ...queryOptions,
+    select: (data) => {
+      if (data) {
+        const oldKey = matchedBFFQuery.queryKey;
+        // To be replaced eventually with the LMS enterprise customer uuid from the response
+        const newKey = oldKey.map((key) => key || enterpriseCustomer.uuid);
+        queryClient.setQueryData(newKey, data);
+        return data;
+      }
+      return data;
+    },
+  });
+}

--- a/src/components/app/data/hooks/useBFF.js
+++ b/src/components/app/data/hooks/useBFF.js
@@ -1,7 +1,6 @@
-import { useLocation } from 'react-router-dom';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useLocation, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { resolveBFFQuery } from '../../routes/data/utils';
-import { useEnterpriseCustomer } from './index';
 
 /**
  * Uses the route to determine which API call to make for the BFF
@@ -11,24 +10,17 @@ import { useEnterpriseCustomer } from './index';
  */
 export function useBFF(queryOptions = {}) {
   const { select, ...queryOptionsRest } = queryOptions;
-  const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const queryClient = useQueryClient();
   const location = useLocation();
-
+  const params = useParams();
   // Determine the BFF query to use based on the current location
   const matchedBFFQuery = resolveBFFQuery(location.pathname);
   return useQuery({
-    ...matchedBFFQuery,
+    ...matchedBFFQuery(params),
     ...queryOptionsRest,
     select: (data) => {
       if (!data) {
         return data;
       }
-      // TODO: To be extracted into helper function once BFF exposes enterpriseCustomer.uuid
-      const originalQueryKey = matchedBFFQuery.queryKey;
-      // To be replaced eventually with the LMS enterprise customer uuid from the response
-      const queryKeyWithEnterpriseUuid = originalQueryKey.map((keySegment) => keySegment || enterpriseCustomer.uuid);
-      queryClient.setQueryData(queryKeyWithEnterpriseUuid, data);
 
       // TODO: Determine if returned data needs further transformations
       const transformedData = structuredClone(data);

--- a/src/components/app/data/hooks/useBFF.test.jsx
+++ b/src/components/app/data/hooks/useBFF.test.jsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { v4 as uuidv4 } from 'uuid';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { enterpriseCustomerFactory } from '../services/data/__factories__';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 import { queryClient } from '../../../../utils/tests';
@@ -22,6 +22,7 @@ jest.mock('../services', () => ({
 jest.mock('react-router-dom', () => ({
   useLocation: jest.fn(),
   matchPath: jest.fn(),
+  useParams: jest.fn(),
 }));
 
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
@@ -134,10 +135,11 @@ describe('useBFF', () => {
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     fetchEnterpriseLearnerDashboard.mockResolvedValue(mockBFFDashboardData);
     useLocation.mockReturnValue({ pathname: '/test-enterprise' });
+    useParams.mockReturnValue({ enterpriseSlug: 'test-enterprise' });
     resolveBFFQuery.mockReturnValue(null);
   });
   it('should handle resolved value correctly for the dashboard route', async () => {
-    resolveBFFQuery.mockReturnValue(queryEnterpriseLearnerDashboardBFF(null, 'test-enterprise'));
+    resolveBFFQuery.mockReturnValue(queryEnterpriseLearnerDashboardBFF);
     const { result, waitForNextUpdate } = renderHook(() => useBFF(), { wrapper: Wrapper });
     await waitForNextUpdate();
 

--- a/src/components/app/data/hooks/useBFF.test.jsx
+++ b/src/components/app/data/hooks/useBFF.test.jsx
@@ -1,0 +1,152 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
+import { useLocation } from 'react-router-dom';
+import { enterpriseCustomerFactory } from '../services/data/__factories__';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { queryClient } from '../../../../utils/tests';
+import { fetchEnterpriseLearnerDashboard } from '../services';
+import { useBFF } from './useBFF';
+import { resolveBFFQuery } from '../../routes/data/utils';
+import { queryEnterpriseLearnerDashboardBFF } from '../queries';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('../../routes/data/utils', () => ({
+  ...jest.requireActual('../services'),
+  resolveBFFQuery: jest.fn(),
+}));
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchEnterpriseLearnerDashboard: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn(),
+  matchPath: jest.fn(),
+}));
+
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockCustomerAgreementUuid = uuidv4();
+const mockSubscriptionCatalogUuid = uuidv4();
+const mockSubscriptionLicenseUuid = uuidv4();
+const mockSubscriptionPlanUuid = uuidv4();
+const mockActivationKey = uuidv4();
+const mockBFFDashboardData = {
+  enterpriseCustomerUserSubsidies: {
+    subscriptions: {
+      customerAgreement: {
+        uuid: mockCustomerAgreementUuid,
+        availableSubscriptionCatalogs: [
+          mockSubscriptionCatalogUuid,
+        ],
+        defaultEnterpriseCatalogUuid: null,
+        netDaysUntilExpiration: 328,
+        disableExpirationNotifications: false,
+        enableAutoAppliedSubscriptionsWithUniversalLink: true,
+        subscriptionForAutoAppliedLicenses: null,
+      },
+      subscriptionLicenses: [
+        {
+          uuid: mockSubscriptionLicenseUuid,
+          status: 'activated',
+          userEmail: 'fake_user@test-email.com',
+          activationDate: '2024-04-08T20:49:57.593412Z',
+          lastRemindDate: '2024-04-08T20:49:57.593412Z',
+          revokedDate: null,
+          activationKey: mockActivationKey,
+          subscriptionPlan: {
+            uuid: mockSubscriptionPlanUuid,
+            title: 'Another Subscription Plan',
+            enterpriseCatalogUuid: mockSubscriptionCatalogUuid,
+            isActive: true,
+            isCurrent: true,
+            startDate: '2024-01-18T15:09:41Z',
+            expirationDate: '2025-03-31T15:09:47Z',
+            daysUntilExpiration: 131,
+            daysUntilExpirationIncludingRenewals: 131,
+            shouldAutoApplyLicenses: false,
+          },
+        },
+      ],
+      subscriptionLicensesByStatus: {
+        activated: [
+          {
+            uuid: mockSubscriptionLicenseUuid,
+            status: 'activated',
+            userEmail: 'fake_user@test-email.com',
+            activationDate: '2024-04-08T20:49:57.593412Z',
+            lastRemindDate: '2024-04-08T20:49:57.593412Z',
+            revokedDate: null,
+            activationKey: mockActivationKey,
+            subscriptionPlan: {
+              uuid: '6e5debf9-a407-4655-98c1-d510880f5fa6',
+              title: 'Another Subscription Plan',
+              enterpriseCatalogUuid: mockSubscriptionCatalogUuid,
+              isActive: true,
+              isCurrent: true,
+              startDate: '2024-01-18T15:09:41Z',
+              expirationDate: '2025-03-31T15:09:47Z',
+              daysUntilExpiration: 131,
+              daysUntilExpirationIncludingRenewals: 131,
+              shouldAutoApplyLicenses: false,
+            },
+          },
+        ],
+        assigned: [],
+        expired: [],
+        revoked: [],
+      },
+    },
+  },
+  enterpriseCourseEnrollments: [
+    {
+      courseRunId: 'course-v1:edX+DemoX+3T2022',
+      courseKey: 'edX+DemoX',
+      courseType: 'executive-education-2u',
+      orgName: 'edX',
+      courseRunStatus: 'completed',
+      displayName: 'Really original course name',
+      emailsEnabled: true,
+      certificateDownloadUrl: null,
+      created: '2023-06-14T15:48:31.672317Z',
+      startDate: '2022-10-26T00:00:00Z',
+      endDate: '2022-12-04T23:59:59Z',
+      mode: 'unpaid-executive-education',
+      isEnrollmentActive: true,
+      productSource: '2u',
+      enrollBy: null,
+      pacing: 'instructor',
+      courseRunUrl: 'https://fake-url.com/account?org_id=n0tr3a1',
+      resumeCourseRunUrl: null,
+      isRevoked: false,
+    },
+  ],
+  errors: [],
+  warnings: [],
+};
+describe('useBFF', () => {
+  const Wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchEnterpriseLearnerDashboard.mockResolvedValue(mockBFFDashboardData);
+    useLocation.mockReturnValue({ pathname: '/test-enterprise' });
+    resolveBFFQuery.mockReturnValue(null);
+  });
+  it('should handle resolved value correctly for the dashboard route', async () => {
+    resolveBFFQuery.mockReturnValue(queryEnterpriseLearnerDashboardBFF(null, 'test-enterprise'));
+    const { result, waitForNextUpdate } = renderHook(() => useBFF(), { wrapper: Wrapper });
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        data: mockBFFDashboardData,
+        isLoading: false,
+        isFetching: false,
+      }),
+    );
+  });
+});

--- a/src/components/app/data/queries/queries.ts
+++ b/src/components/app/data/queries/queries.ts
@@ -267,11 +267,10 @@ export function queryVideoDetail(videoUUID: string, enterpriseUUID: string) {
 }
 
 // BFF queries
-export function queryEnterpriseLearnerDashboardBFF(enterpriseUuid: string, enterpriseSlug: string) {
+export function queryEnterpriseLearnerDashboardBFF({ enterpriseSlug }) {
   return queries
-    .enterprise
-    .enterpriseCustomer(enterpriseUuid)
-    ._ctx.enterpriseSlug(enterpriseSlug)
-    ._ctx.bffs
+    .bff
+    .enterpriseSlug(enterpriseSlug)
+    ._ctx.route
     ._ctx.dashboard;
 }

--- a/src/components/app/data/queries/queries.ts
+++ b/src/components/app/data/queries/queries.ts
@@ -265,3 +265,13 @@ export function queryVideoDetail(videoUUID: string, enterpriseUUID: string) {
     ._ctx.video
     ._ctx.detail(videoUUID);
 }
+
+// BFF queries
+export function queryEnterpriseLearnerDashboardBFF(enterpriseUuid: string, enterpriseSlug: string) {
+  return queries
+    .enterprise
+    .enterpriseCustomer(enterpriseUuid)
+    ._ctx.enterpriseSlug(enterpriseSlug)
+    ._ctx.bffs
+    ._ctx.dashboard;
+}

--- a/src/components/app/data/queries/queryKeyFactory.js
+++ b/src/components/app/data/queries/queryKeyFactory.js
@@ -16,6 +16,7 @@ import {
   fetchEnterpriseCourseEnrollments,
   fetchEnterpriseCuration,
   fetchEnterpriseCustomerContainsContent,
+  fetchEnterpriseLearnerDashboard,
   fetchEnterpriseLearnerData,
   fetchEnterpriseOffers,
   fetchInProgressPathways,
@@ -47,6 +48,20 @@ const enterprise = createQueryKeys('enterprise', {
   enterpriseCustomer: (enterpriseUuid) => ({
     queryKey: [enterpriseUuid],
     contextQueries: {
+      enterpriseSlug: (enterpriseSlug) => ({
+        queryKey: [enterpriseSlug],
+        contextQueries: {
+          bffs: {
+            queryKey: null,
+            contextQueries: {
+              dashboard: ({
+                queryKey: null,
+                queryFn: ({ queryKey }) => fetchEnterpriseLearnerDashboard(queryKey[2], queryKey[4]),
+              }),
+            },
+          },
+        },
+      }),
       academies: {
         queryKey: null,
         contextQueries: {
@@ -64,6 +79,15 @@ const enterprise = createQueryKeys('enterprise', {
           detail: (academyUUID) => ({
             queryKey: [academyUUID],
             queryFn: ({ queryKey }) => fetchAcademiesDetail(academyUUID, queryKey[2]),
+          }),
+        },
+      },
+      bffs: {
+        queryKey: null,
+        contextQueries: {
+          dashboard: ({
+            queryKey: null,
+            queryFn: ({ queryKey }) => fetchEnterpriseLearnerDashboard(queryKey[2]),
           }),
         },
       },

--- a/src/components/app/data/queries/queryKeyFactory.js
+++ b/src/components/app/data/queries/queryKeyFactory.js
@@ -82,15 +82,6 @@ const enterprise = createQueryKeys('enterprise', {
           }),
         },
       },
-      bffs: {
-        queryKey: null,
-        contextQueries: {
-          dashboard: ({
-            queryKey: null,
-            queryFn: ({ queryKey }) => fetchEnterpriseLearnerDashboard(queryKey[2]),
-          }),
-        },
-      },
       // queryContentHighlightsConfiguration
       contentHighlights: {
         queryKey: null,

--- a/src/components/app/data/queries/queryKeyFactory.js
+++ b/src/components/app/data/queries/queryKeyFactory.js
@@ -48,20 +48,6 @@ const enterprise = createQueryKeys('enterprise', {
   enterpriseCustomer: (enterpriseUuid) => ({
     queryKey: [enterpriseUuid],
     contextQueries: {
-      enterpriseSlug: (enterpriseSlug) => ({
-        queryKey: [enterpriseSlug],
-        contextQueries: {
-          bffs: {
-            queryKey: null,
-            contextQueries: {
-              dashboard: ({
-                queryKey: null,
-                queryFn: ({ queryKey }) => fetchEnterpriseLearnerDashboard(queryKey[2], queryKey[4]),
-              }),
-            },
-          },
-        },
-      }),
       academies: {
         queryKey: null,
         contextQueries: {
@@ -278,5 +264,22 @@ const content = createQueryKeys('content', {
   }),
 });
 
-const queries = mergeQueryKeys(enterprise, user, content);
+const bff = createQueryKeys('bff', {
+  enterpriseSlug: (enterpriseSlug) => ({
+    queryKey: [enterpriseSlug],
+    contextQueries: {
+      route: {
+        queryKey: null,
+        contextQueries: {
+          dashboard: ({
+            queryKey: null,
+            queryFn: ({ queryKey }) => fetchEnterpriseLearnerDashboard({ enterpriseSlug: queryKey[2] }),
+          }),
+        },
+      },
+    },
+  }),
+});
+
+const queries = mergeQueryKeys(enterprise, user, content, bff);
 export default queries;

--- a/src/components/app/data/services/bffs.js
+++ b/src/components/app/data/services/bffs.js
@@ -3,7 +3,7 @@ import { logError } from '@edx/frontend-platform/logging';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
-export const learnerDashboardBFFResponse = {
+export const baseLearnerBFFResponse = {
   enterpriseCustomerUserSubsidies: {
     subscriptions: {
       customerAgreement: {},
@@ -11,20 +11,24 @@ export const learnerDashboardBFFResponse = {
       subscriptionLicensesByStatus: {},
     },
   },
-  enterpriseCourseEnrollments: [],
   errors: [],
   warnings: [],
 };
 
-export async function fetchEnterpriseLearnerDashboard(enterpriseId, enterpriseSlug, lmsUserId) {
+export const learnerDashboardBFFResponse = {
+  ...baseLearnerBFFResponse,
+  enterpriseCourseEnrollments: [],
+};
+
+export async function fetchEnterpriseLearnerDashboard(customerIdentifiers) {
   const { ENTERPRISE_ACCESS_BASE_URL } = getConfig();
-  const params = {
-    enterprise_customer_uuid: enterpriseId,
-    enterprise_customer_slug: enterpriseSlug,
-    lms_user_id: lmsUserId,
-  };
   const url = `${ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/dashboard/`;
   try {
+    const params = {
+      enterprise_customer_uuid: customerIdentifiers?.enterpriseId,
+      enterprise_customer_slug: customerIdentifiers?.enterpriseSlug,
+    };
+
     const result = await getAuthenticatedHttpClient().post(url, params);
     return camelCaseObject(result.data);
   } catch (error) {

--- a/src/components/app/data/services/bffs.js
+++ b/src/components/app/data/services/bffs.js
@@ -1,0 +1,22 @@
+import { getConfig } from '@edx/frontend-platform/config';
+import { logError } from '@edx/frontend-platform/logging';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
+
+export async function fetchEnterpriseLearnerDashboard(enterpriseId, enterpriseSlug, lmsUserId) {
+  const { ENTERPRISE_ACCESS_BASE_URL } = getConfig();
+  const params = {
+    enterprise_customer_uuid: enterpriseId,
+    enterprise_customer_slug: enterpriseSlug,
+    lms_user_id: lmsUserId,
+  };
+  const url = `${ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/dashboard/`;
+  try {
+    const result = await getAuthenticatedHttpClient().post(url, params);
+    return camelCaseObject(result.data);
+  } catch (error) {
+    logError(error);
+    // TODO: consider returning a sane default API response structure here to mitigate complete failure.
+    return {};
+  }
+}

--- a/src/components/app/data/services/bffs.js
+++ b/src/components/app/data/services/bffs.js
@@ -3,6 +3,19 @@ import { logError } from '@edx/frontend-platform/logging';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
+export const learnerDashboardBFFResponse = {
+  enterpriseCustomerUserSubsidies: {
+    subscriptions: {
+      customerAgreement: {},
+      subscriptionLicenses: [],
+      subscriptionLicensesByStatus: {},
+    },
+  },
+  enterpriseCourseEnrollments: [],
+  errors: [],
+  warnings: [],
+};
+
 export async function fetchEnterpriseLearnerDashboard(enterpriseId, enterpriseSlug, lmsUserId) {
   const { ENTERPRISE_ACCESS_BASE_URL } = getConfig();
   const params = {
@@ -16,7 +29,6 @@ export async function fetchEnterpriseLearnerDashboard(enterpriseId, enterpriseSl
     return camelCaseObject(result.data);
   } catch (error) {
     logError(error);
-    // TODO: consider returning a sane default API response structure here to mitigate complete failure.
-    return {};
+    return learnerDashboardBFFResponse;
   }
 }

--- a/src/components/app/data/services/bffs.test.js
+++ b/src/components/app/data/services/bffs.test.js
@@ -131,13 +131,13 @@ describe('fetchEnterpriseLearnerDashboard', () => {
 
   it('returns learner dashboard metadata', async () => {
     axiosMock.onPost(enterpriseDashboard).reply(200, mockBFFDashboardResponse);
-    const result = await fetchEnterpriseLearnerDashboard(mockEnterpriseCustomer.uuid, null, 1234);
+    const result = await fetchEnterpriseLearnerDashboard({ enterpriseId: mockEnterpriseCustomer.uuid });
     expect(result).toEqual(camelCaseObject(mockBFFDashboardResponse));
   });
 
   it('catches error and returns null', async () => {
     axiosMock.onPost(enterpriseDashboard).reply(404, learnerDashboardBFFResponse);
-    const result = await fetchEnterpriseLearnerDashboard(null, null, null);
+    const result = await fetchEnterpriseLearnerDashboard(null);
     expect(result).toEqual(learnerDashboardBFFResponse);
   });
 });

--- a/src/components/app/data/services/bffs.test.js
+++ b/src/components/app/data/services/bffs.test.js
@@ -1,0 +1,143 @@
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import { v4 as uuidv4 } from 'uuid';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { enterpriseCustomerFactory } from './data/__factories__';
+import { fetchEnterpriseLearnerDashboard, learnerDashboardBFFResponse } from './bffs';
+
+const axiosMock = new MockAdapter(axios);
+getAuthenticatedHttpClient.mockReturnValue(axios);
+
+const APP_CONFIG = {
+  ENTERPRISE_ACCESS_BASE_URL: 'http://localhost:18270',
+};
+jest.mock('@edx/frontend-platform/config', () => ({
+  ...jest.requireActual('@edx/frontend-platform'),
+  getConfig: jest.fn(() => APP_CONFIG),
+}));
+
+jest.mock('@edx/frontend-platform/auth', () => ({
+  ...jest.requireActual('@edx/frontend-platform/auth'),
+  getAuthenticatedHttpClient: jest.fn(),
+}));
+
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockCustomerAgreementUuid = uuidv4();
+const mockSubscriptionCatalogUuid = uuidv4();
+const mockSubscriptionLicenseUuid = uuidv4();
+const mockSubscriptionPlanUuid = uuidv4();
+const mockActivationKey = uuidv4();
+const mockBFFDashboardResponse = {
+  enterprise_customer_user_subsidies: {
+    subscriptions: {
+      customer_agreement: {
+        uuid: mockCustomerAgreementUuid,
+        available_subscription_catalogs: [
+          mockSubscriptionCatalogUuid,
+        ],
+        default_enterprise_catalog_uuid: null,
+        net_days_until_expiration: 328,
+        disable_expiration_notifications: false,
+        enable_auto_applied_subscriptions_with_universal_link: true,
+        subscription_for_auto_applied_licenses: null,
+      },
+      subscription_licenses: [
+        {
+          uuid: mockSubscriptionLicenseUuid,
+          status: 'activated',
+          user_email: 'fake_user@test-email.com',
+          activation_date: '2024-04-08T20:49:57.593412Z',
+          last_remind_date: '2024-04-08T20:49:57.593412Z',
+          revoked_date: null,
+          activation_key: mockActivationKey,
+          subscription_plan: {
+            uuid: mockSubscriptionPlanUuid,
+            title: 'Another Subscription Plan',
+            enterprise_catalog_uuid: mockSubscriptionCatalogUuid,
+            is_active: true,
+            is_current: true,
+            start_date: '2024-01-18T15:09:41Z',
+            expiration_date: '2025-03-31T15:09:47Z',
+            days_until_expiration: 131,
+            days_until_expiration_including_renewals: 131,
+            should_auto_apply_licenses: false,
+          },
+        },
+      ],
+      subscription_licenses_by_status: {
+        activated: [
+          {
+            uuid: mockSubscriptionLicenseUuid,
+            status: 'activated',
+            user_email: 'fake_user@test-email.com',
+            activation_date: '2024-04-08T20:49:57.593412Z',
+            lastRemind_date: '2024-04-08T20:49:57.593412Z',
+            revoked_date: null,
+            activation_key: mockActivationKey,
+            subscription_plan: {
+              uuid: '6e5debf9-a407-4655-98c1-d510880f5fa6',
+              title: 'Another Subscription Plan',
+              enterprise_catalog_uuid: mockSubscriptionCatalogUuid,
+              is_active: true,
+              is_current: true,
+              start_date: '2024-01-18T15:09:41Z',
+              expiration_date: '2025-03-31T15:09:47Z',
+              days_until_expiration: 131,
+              days_until_expiration_including_renewals: 131,
+              should_auto_apply_licenses: false,
+            },
+          },
+        ],
+        assigned: [],
+        expired: [],
+        revoked: [],
+      },
+    },
+  },
+  enterprise_course_enrollments: [
+    {
+      course_run_id: 'course-v1:edX+DemoX+3T2022',
+      course_key: 'edX+DemoX',
+      course_type: 'executive-education-2u',
+      org_name: 'edX',
+      course_run_status: 'completed',
+      display_name: 'Really original course name',
+      emails_enabled: true,
+      certificate_download_url: null,
+      created: '2023-06-14T15:48:31.672317Z',
+      start_date: '2022-10-26T00:00:00Z',
+      end_date: '2022-12-04T23:59:59Z',
+      mode: 'unpaid-executive-education',
+      is_enrollment_active: true,
+      product_source: '2u',
+      enroll_by: null,
+      pacing: 'instructor',
+      course_run_url: 'https://fake-url.com/account?org_id=n0tr3a1',
+      resume_course_run_url: null,
+      is_revoked: false,
+    },
+  ],
+  errors: [],
+  warnings: [],
+};
+describe('fetchEnterpriseLearnerDashboard', () => {
+  const enterpriseDashboard = `${APP_CONFIG.ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/dashboard/`;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axiosMock.reset();
+  });
+
+  it('returns learner dashboard metadata', async () => {
+    axiosMock.onPost(enterpriseDashboard).reply(200, mockBFFDashboardResponse);
+    const result = await fetchEnterpriseLearnerDashboard(mockEnterpriseCustomer.uuid, null, 1234);
+    expect(result).toEqual(camelCaseObject(mockBFFDashboardResponse));
+  });
+
+  it('catches error and returns null', async () => {
+    axiosMock.onPost(enterpriseDashboard).reply(404, learnerDashboardBFFResponse);
+    const result = await fetchEnterpriseLearnerDashboard(null, null, null);
+    expect(result).toEqual(learnerDashboardBFFResponse);
+  });
+});

--- a/src/components/app/data/services/index.js
+++ b/src/components/app/data/services/index.js
@@ -1,4 +1,5 @@
 export * from './academies';
+export * from './bffs';
 export * from './content';
 export * from './contentHighlights';
 export * from './course';

--- a/src/components/app/data/utils.test.js
+++ b/src/components/app/data/utils.test.js
@@ -1006,12 +1006,10 @@ describe('resolveBFFQuery', () => {
     const pathname = '/testEnterpriseSlug';
     const mockParams = { enterpriseSlug: 'testEnterpriseSlug' };
     const expectedQueryKey = [
-      'enterprise',
-      'enterpriseCustomer',
-      null,
+      'bff',
       'enterpriseSlug',
       'testEnterpriseSlug',
-      'bffs',
+      'route',
       'dashboard',
     ];
     matchPath.mockImplementation((pattern, path) => {
@@ -1022,7 +1020,7 @@ describe('resolveBFFQuery', () => {
     });
     const result = resolveBFFQuery(pathname);
     expect(matchPath).toHaveBeenCalledWith('/:enterpriseSlug', pathname);
-    expect(result.queryKey).toEqual(expectedQueryKey);
+    expect(result({ enterpriseSlug: 'testEnterpriseSlug' }).queryKey).toEqual(expectedQueryKey);
   });
   it('returns null from unmatched query key', () => {
     const pathname = '/testEnterpriseSlug/Slugma';

--- a/src/components/app/routes/data/utils.js
+++ b/src/components/app/routes/data/utils.js
@@ -49,9 +49,7 @@ export function resolveBFFQuery(pathname) {
   const matchedRoute = routeToBFFQueryMap.find((route) => matchPath(route.pattern, pathname));
 
   if (matchedRoute) {
-    const match = matchPath(matchedRoute.pattern, pathname);
-    const params = match ? match.params : {};
-    return matchedRoute.query(null, params?.enterpriseSlug);
+    return matchedRoute.query;
   }
 
   // No match found

--- a/src/components/app/routes/data/utils.js
+++ b/src/components/app/routes/data/utils.js
@@ -20,6 +20,7 @@ import {
   queryContentHighlightsConfiguration,
   queryCouponCodeRequests,
   queryCouponCodes,
+  queryEnterpriseLearnerDashboardBFF,
   queryEnterpriseLearnerOffers,
   queryLicenseRequests,
   queryNotices,
@@ -27,6 +28,35 @@ import {
   querySubscriptions,
   updateUserActiveEnterprise,
 } from '../../data';
+
+/**
+ * Resolves the appropriate BFF query function to use for the current route.
+ * @param {string} pathname - The current route pathname.
+ * @returns {Function|null} The BFF query function to use for the current route, or null if no match is found.
+ */
+export function resolveBFFQuery(pathname) {
+  // Define route patterns and their corresponding query functions
+
+  const routeToBFFQueryMap = [
+    {
+      pattern: '/:enterpriseSlug',
+      query: queryEnterpriseLearnerDashboardBFF,
+    },
+    // Add more routes and queries incrementally as needed
+  ];
+
+  // Find the matching route and return the corresponding query function
+  const matchedRoute = routeToBFFQueryMap.find((route) => matchPath(route.pattern, pathname));
+
+  if (matchedRoute) {
+    const match = matchPath(matchedRoute.pattern, pathname);
+    const params = match ? match.params : {};
+    return matchedRoute.query(null, params?.enterpriseSlug);
+  }
+
+  // No match found
+  return null;
+}
 
 /**
  * Ensures all enterprise-related app data is loaded.

--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -1,20 +1,14 @@
 import React, { useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import { useQueryClient } from '@tanstack/react-query';
-import {
-  Alert, Container, Tabs,
-} from '@openedx/paragon';
+import { Alert, Container, Tabs } from '@openedx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 
 import { IntegrationWarningModal } from '../integration-warning-modal';
 import SubscriptionExpirationModal from './SubscriptionExpirationModal';
 import { useDashboardTabs } from './data';
-import {
-  querySubscriptions,
-  useEnterpriseCustomer,
-  useSubscriptions,
-} from '../app/data';
+import { querySubscriptions, useEnterpriseCustomer, useSubscriptions } from '../app/data';
 import BudgetExpiryNotification from '../budget-expiry-notification';
 import ExpiredSubscriptionModal from '../expired-subscription-modal';
 


### PR DESCRIPTION
Adds a query key for the BFF layer.
Adds a custom hook for utilizing the BFF call for the learner dashboard. _Note_: We do not make the BFF call yet.
As part of adding the custom hook which initially utilizes the enterprise slug to make the BFF call, we create a method for copying over the BFF data to a query cache with the updated query key that is populated with the enterprise customer uuid from the API response to avoid duplicate calls in the future. 
Adds related tests, pending 1 test.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
