### PR TITLE
[ENT-9791] chore: upgrade @edx/frontend-enterprise-catalog-search to 10.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@1.2.3",
         "@edx/frontend-component-footer": "14.0.1",
-        "@edx/frontend-enterprise-catalog-search": "10.7.1",
+        "@edx/frontend-enterprise-catalog-search": "10.8.0",
         "@edx/frontend-enterprise-hotjar": "7.1.0",
         "@edx/frontend-enterprise-logistration": "9.1.0",
         "@edx/frontend-enterprise-utils": "9.1.0",
@@ -2240,9 +2240,9 @@
       }
     },
     "node_modules/@edx/frontend-enterprise-catalog-search": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-10.7.1.tgz",
-      "integrity": "sha512-/IoBD+PsBvct5GHugwjsamkzUHbbuTyzvVQ7n5/qtZvci/aHOQayXjVVI8e9aFlMU826YWofWuxGGEAEb6uxzg==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-10.8.0.tgz",
+      "integrity": "sha512-iMfH7MhuuBBhmlyQdpkVRICk8J1b3fy9rs0jqZDlrYiGl4SMggo5t+dP6DCseX2QqqmvDXWb/ds5wCH5mMz/+w==",
       "dependencies": {
         "@edx/frontend-enterprise-utils": "^9.1.0",
         "classnames": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@1.2.3",
     "@edx/frontend-component-footer": "14.0.1",
-    "@edx/frontend-enterprise-catalog-search": "10.7.1",
+    "@edx/frontend-enterprise-catalog-search": "10.8.0",
     "@edx/frontend-enterprise-hotjar": "7.1.0",
     "@edx/frontend-enterprise-logistration": "9.1.0",
     "@edx/frontend-enterprise-utils": "9.1.0",


### PR DESCRIPTION
**Ticket:**
https://2u-internal.atlassian.net/browse/ENT-9791

**Description:**
Bumped the version of catalog search to [10.8.0](https://github.com/openedx/frontend-enterprise/releases/tag/%40edx%2Ffrontend-enterprise-catalog-search%4010.8.0) in order to log segment event to track the selected value for "Learning Type" dropdown

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
