### PR TITLE
feat: fixed bug that prevents learner from seeing custom 404

### DIFF
--- a/src/components/app/Layout.jsx
+++ b/src/components/app/Layout.jsx
@@ -1,5 +1,5 @@
 import { Helmet } from 'react-helmet';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useMatch } from 'react-router-dom';
 import FooterSlot from '@openedx/frontend-slot-footer';
 import { getConfig } from '@edx/frontend-platform/config';
 
@@ -17,12 +17,17 @@ export const DEFAULT_TITLE = 'edX';
 const Layout = () => {
   const config = getConfig();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
+  const licenseActivationRouteMatch = useMatch('/:enterpriseSlug/licenses/:activationKey/activate');
 
   const brandStyles = useStylesForCustomBrandColors(enterpriseCustomer);
 
-  // Authenticated user is NOT linked an enterprise customer, so
-  // render the not found page.
+  // Authenticated user is NOT linked to an enterprise customer.
   if (!enterpriseCustomer) {
+    if (licenseActivationRouteMatch) {
+      // If the user is trying to activate a license, render the license activation route.
+      return <Outlet />;
+    }
+    // Otherwise, render the not found page.
     return <NotFoundPage />;
   }
 

--- a/src/components/app/Layout.test.jsx
+++ b/src/components/app/Layout.test.jsx
@@ -75,6 +75,28 @@ describe('Layout', () => {
     expect(screen.getByText('404', { selector: 'h1' })).toBeInTheDocument();
   });
 
+  it('renders the license activation route when user is not linked to enterprise customer but accessing license activation', () => {
+    useEnterpriseCustomer.mockReturnValue({ data: null });
+
+    renderWithRouterProvider({
+      path: '/:enterpriseSlug/*',
+      element: <LayoutWrapper />,
+      children: [
+        {
+          path: 'licenses/:activationKey/activate',
+          element: <div data-testid="license-activation-page" />,
+        },
+      ],
+    }, {
+      initialEntries: ['/enterprise-slug/licenses/12345678-1234-5678-1234-567812345678/activate'],
+    });
+
+    // Verify license activation page is rendered
+    expect(screen.getByTestId('license-activation-page')).toBeInTheDocument();
+    // Verify 404 is not rendered
+    expect(screen.queryByRole('heading', { name: '404' })).not.toBeInTheDocument();
+  });
+
   it.each([
     {
       isSystemMaintenanceAlertOpen: false,


### PR DESCRIPTION
Learners signed in with their personel accounts were not able to see the custom 404 which tells to change account (when they click on the assigned license email link)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots

## Before:
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/3e1be442-541f-4451-88b6-40bd3eafca4e">

## After:
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/c521f46d-698b-4af8-8345-a4fde0087bb9">
