### PR TITLE
fix: correctly pass arguments into resolveBFFQuery

### DIFF
--- a/src/components/app/routes/data/utils.js
+++ b/src/components/app/routes/data/utils.js
@@ -48,7 +48,7 @@ export async function ensureEnterpriseAppData({
   queryClient,
   requestUrl,
 }) {
-  const matchedBFFQuery = resolveBFFQuery(requestUrl.pathname);
+  const matchedBFFQuery = resolveBFFQuery(requestUrl.pathname, { enterpriseCustomerUuid: enterpriseCustomer.uuid });
   const enterpriseAppDataQueries = [];
   if (!matchedBFFQuery) {
     const subscriptionsQuery = querySubscriptions(enterpriseCustomer.uuid);

--- a/src/components/dashboard/data/dashboardLoader.ts
+++ b/src/components/dashboard/data/dashboardLoader.ts
@@ -37,7 +37,7 @@ const makeDashboardLoader: Types.MakeRouteLoaderFunctionWithQueryClient = functi
       enterpriseSlug,
     });
 
-    const dashboardBFFQuery = resolveBFFQuery(requestUrl.pathname, enterpriseCustomer.uuid);
+    const dashboardBFFQuery = resolveBFFQuery(requestUrl.pathname, { enterpriseCustomerUuid: enterpriseCustomer.uuid });
     const loadEnrollmentsPoliciesAndRedirectForNewUsers = Promise.all([
       queryClient.ensureQueryData(
         dashboardBFFQuery


### PR DESCRIPTION
Update usages of `resolveBFFQuery` to correctly pass the enterpriseCustomer uuid as an options field.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
