### PR TITLE
feat: optimistic query update with the BFF inclusion

### DIFF
--- a/src/components/app/data/services/subsidies/index.js
+++ b/src/components/app/data/services/subsidies/index.js
@@ -65,7 +65,7 @@ export async function fetchEnterpriseOffers(enterpriseId, options = {}) {
 // Redeemable Policies
 
 /**
- * TODO
+ * Fetches the redeemable policies for the specified enterprise and user.
  * @param {*} enterpriseUUID
  * @param {*} userID
  * @returns

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
@@ -85,7 +85,7 @@ export const InProgressCourseCard = ({
   const [isMarkCompleteModalOpen, setIsMarkCompleteModalOpen] = useState(false);
   const { courseCards } = useContext(AppContext);
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const updateCourseEnrollmentStatus = useUpdateCourseEnrollmentStatus({ enterpriseCustomer });
+  const updateCourseEnrollmentStatus = useUpdateCourseEnrollmentStatus();
   const isExecutiveEducation = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
   const coursewareOrUpgradeLink = useLinkToCourse({
     linkToCourse,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
@@ -87,7 +87,6 @@ export const InProgressCourseCard = ({
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const updateCourseEnrollmentStatus = useUpdateCourseEnrollmentStatus({ enterpriseCustomer });
   const isExecutiveEducation = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
-
   const coursewareOrUpgradeLink = useLinkToCourse({
     linkToCourse,
     subsidyForCourse,
@@ -196,7 +195,6 @@ export const InProgressCourseCard = ({
     updateCourseEnrollmentStatus({
       courseRunId: response.courseRunId,
       newStatus: response.courseRunStatus,
-      savedForLater: response.savedForLater,
     });
     navigate('.', {
       replace: true,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/SavedForLaterCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/SavedForLaterCourseCard.jsx
@@ -35,7 +35,7 @@ const SavedForLaterCourseCard = (props) => {
 
   const navigate = useNavigate();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const updateCourseEnrollmentStatus = useUpdateCourseEnrollmentStatus({ enterpriseCustomer });
+  const updateCourseEnrollmentStatus = useUpdateCourseEnrollmentStatus();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleMoveToInProgressOnClose = () => {

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/SavedForLaterCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/SavedForLaterCourseCard.jsx
@@ -36,7 +36,6 @@ const SavedForLaterCourseCard = (props) => {
   const navigate = useNavigate();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const updateCourseEnrollmentStatus = useUpdateCourseEnrollmentStatus({ enterpriseCustomer });
-
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleMoveToInProgressOnClose = () => {
@@ -63,7 +62,6 @@ const SavedForLaterCourseCard = (props) => {
     updateCourseEnrollmentStatus({
       courseRunId: response.courseRunId,
       newStatus: response.courseRunStatus,
-      savedForLater: response.savedForLater,
     });
     navigate('.', {
       replace: true,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useQueryClient } from '@tanstack/react-query';
 import {
@@ -6,7 +6,6 @@ import {
 } from '@openedx/paragon';
 import { logError, logInfo } from '@edx/frontend-platform/logging';
 
-import { useParams } from 'react-router-dom';
 import { ToastsContext } from '../../../../../Toasts';
 import { unenrollFromCourse } from './data';
 import {
@@ -28,7 +27,6 @@ const UnenrollModal = ({
   onSuccess,
 }) => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const params = useParams();
   const { addToast } = useContext(ToastsContext);
   const queryClient = useQueryClient();
   const [btnState, setBtnState] = useState('default');
@@ -47,7 +45,7 @@ const UnenrollModal = ({
     if (isBFFEnabled) {
       // Determine which BFF queries need to be updated after unenrolling.
       const dashboardBFFQueryKey = queryEnterpriseLearnerDashboardBFF({
-        enterpriseSlug: params.enterpriseSlug,
+        enterpriseSlug: enterpriseCustomer.slug,
       }).queryKey;
       const bffQueryKeysToUpdate = [dashboardBFFQueryKey];
       // Update the enterpriseCourseEnrollments data in the cache for each BFF query.

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.test.jsx
@@ -237,24 +237,30 @@ describe('<UnenrollModal />', () => {
         updatedEnrollments = mockQueryClient.getQueryData(
           queryEnterpriseLearnerDashboardBFF({ enterpriseSlug: 'test-enterprise-slug' }).queryKey,
         );
-        if (bffEnterpriseCourseEnrollmentsData) {
+        if (bffEnterpriseCourseEnrollmentsData && !enterpriseCourseEnrollmentsData) {
           expect(updatedEnrollments).toEqual(learnerDashboardBFFResponse);
           expect(logInfo).toHaveBeenCalledTimes(0);
-        } else {
+        } else if (!bffEnterpriseCourseEnrollmentsData) {
           expect(updatedEnrollments).toEqual(undefined);
           expect(logInfo).toHaveBeenCalledTimes(1);
+        } else {
+          expect(updatedEnrollments).toEqual(learnerDashboardBFFResponse);
+          expect(logInfo).toHaveBeenCalledTimes(0);
         }
       }
       if (!isBFFEnabled) {
         updatedEnrollments = mockQueryClient.getQueryData(
           queryEnterpriseCourseEnrollments(mockEnterpriseCustomer.uuid).queryKey,
         );
-        if (enterpriseCourseEnrollmentsData) {
+        if (enterpriseCourseEnrollmentsData && !bffEnterpriseCourseEnrollmentsData) {
           expect(updatedEnrollments).toEqual([]);
           expect(logInfo).toHaveBeenCalledTimes(0);
-        } else {
+        } else if (!enterpriseCourseEnrollmentsData) {
           expect(updatedEnrollments).toEqual(undefined);
           expect(logInfo).toHaveBeenCalledTimes(1);
+        } else {
+          expect(updatedEnrollments).toEqual([]);
+          expect(logInfo).toHaveBeenCalledTimes(0);
         }
       }
     });

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.test.jsx
@@ -237,30 +237,24 @@ describe('<UnenrollModal />', () => {
         updatedEnrollments = mockQueryClient.getQueryData(
           queryEnterpriseLearnerDashboardBFF({ enterpriseSlug: 'test-enterprise-slug' }).queryKey,
         );
-        if (bffEnterpriseCourseEnrollmentsData && !enterpriseCourseEnrollmentsData) {
+        if (bffEnterpriseCourseEnrollmentsData) {
           expect(updatedEnrollments).toEqual(learnerDashboardBFFResponse);
           expect(logInfo).toHaveBeenCalledTimes(0);
-        } else if (!bffEnterpriseCourseEnrollmentsData) {
+        } else {
           expect(updatedEnrollments).toEqual(undefined);
           expect(logInfo).toHaveBeenCalledTimes(1);
-        } else {
-          expect(updatedEnrollments).toEqual(learnerDashboardBFFResponse);
-          expect(logInfo).toHaveBeenCalledTimes(0);
         }
       }
       if (!isBFFEnabled) {
         updatedEnrollments = mockQueryClient.getQueryData(
           queryEnterpriseCourseEnrollments(mockEnterpriseCustomer.uuid).queryKey,
         );
-        if (enterpriseCourseEnrollmentsData && !bffEnterpriseCourseEnrollmentsData) {
+        if (enterpriseCourseEnrollmentsData) {
           expect(updatedEnrollments).toEqual([]);
           expect(logInfo).toHaveBeenCalledTimes(0);
-        } else if (!enterpriseCourseEnrollmentsData) {
+        } else {
           expect(updatedEnrollments).toEqual(undefined);
           expect(logInfo).toHaveBeenCalledTimes(1);
-        } else {
-          expect(updatedEnrollments).toEqual([]);
-          expect(logInfo).toHaveBeenCalledTimes(0);
         }
       }
     });

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.test.jsx
@@ -35,11 +35,6 @@ jest.mock('../../../../../app/data', () => ({
   fetchEnterpriseLearnerDashboard: jest.fn(),
 }));
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => ({ enterpriseSlug: 'test-enterprise-slug' }),
-}));
-
 jest.mock('@edx/frontend-platform/logging', () => ({
   logInfo: jest.fn(),
 }));
@@ -80,7 +75,7 @@ const UnenrollModalWrapper = ({
   }
   if (existingBFFDashboardQueryData) {
     mockQueryClient.setQueryData(
-      queryEnterpriseLearnerDashboardBFF({ enterpriseSlug: 'test-enterprise-slug' }).queryKey,
+      queryEnterpriseLearnerDashboardBFF({ enterpriseSlug: mockEnterpriseCustomer.slug }).queryKey,
       existingBFFDashboardQueryData,
     );
   }
@@ -191,7 +186,7 @@ describe('<UnenrollModal />', () => {
 
     await waitFor(() => {
       const bffDashboardData = mockQueryClient.getQueryData(
-        queryEnterpriseLearnerDashboardBFF({ enterpriseSlug: 'test-enterprise-slug' }).queryKey,
+        queryEnterpriseLearnerDashboardBFF({ enterpriseSlug: mockEnterpriseCustomer.slug }).queryKey,
       );
       let expectedLogInfoCalls = 0;
       if (isBFFEnabled) {

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -528,7 +528,7 @@ export function useCourseEnrollmentsBySection(courseEnrollmentsByStatus) {
 }
 
 // TODO: There is opportunity to generalize this approach into a helper function
-function handleQueriesForUpdatedCourseEnrollmentStatus({
+export function handleQueriesForUpdatedCourseEnrollmentStatus({
   queryClient,
   enterpriseSlug,
   enterpriseCustomer,
@@ -582,18 +582,16 @@ function handleQueriesForUpdatedCourseEnrollmentStatus({
 export const useUpdateCourseEnrollmentStatus = ({ enterpriseCustomer }) => {
   const queryClient = useQueryClient();
   const params = useParams();
-  const location = useLocation();
 
   return useCallback(({ courseRunId, newStatus }) => {
     handleQueriesForUpdatedCourseEnrollmentStatus({
       queryClient,
-      location,
       enterpriseSlug: params.enterpriseSlug,
       enterpriseCustomer,
       courseRunId,
       newEnrollmentStatus: newStatus,
     });
-  }, [queryClient, location, params.enterpriseSlug, enterpriseCustomer]);
+  }, [queryClient, params.enterpriseSlug, enterpriseCustomer]);
 };
 
 /**

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
@@ -1099,10 +1099,6 @@ describe('useUpdateCourseEnrollmentStatus', () => {
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
   });
 
-  afterEach(() => {
-    mockQueryClient = undefined;
-  });
-
   it.each([
     // BFF enabled && course run id matches
     {

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
@@ -1069,122 +1069,61 @@ describe('handleQueriesForUpdatedCourseEnrollmentStatus', () => {
     jest.resetAllMocks();
   });
   it.each([
-    // BFF enabled && courseRunIdMatch == true
+    // BFF enabled
     {
       bffEnterpriseCourseEnrollmentsData: mockBFFEnterpriseCourseEnrollments,
       enterpriseCourseEnrollmentsData: mockEnterpriseCourseEnrollment,
       isBFFEnabled: true,
-      doesCourseRunIdMatch: true,
-    },
-    {
-      bffEnterpriseCourseEnrollmentsData: mockBFFEnterpriseCourseEnrollments,
-      enterpriseCourseEnrollmentsData: null,
-      isBFFEnabled: true,
-      doesCourseRunIdMatch: true,
-    },
-    {
-      bffEnterpriseCourseEnrollmentsData: null,
-      enterpriseCourseEnrollmentsData: mockEnterpriseCourseEnrollment,
-      isBFFEnabled: true,
-      doesCourseRunIdMatch: true,
-    },
-    {
-      bffEnterpriseCourseEnrollmentsData: null,
-      enterpriseCourseEnrollmentsData: null,
-      isBFFEnabled: true,
-      doesCourseRunIdMatch: true,
-    },
-    // BFF disabled && courseRunIdMatch == true
-    {
-      bffEnterpriseCourseEnrollmentsData: mockBFFEnterpriseCourseEnrollments,
-      enterpriseCourseEnrollmentsData: mockEnterpriseCourseEnrollment,
-      isBFFEnabled: false,
-      doesCourseRunIdMatch: true,
-    },
-    {
-      bffEnterpriseCourseEnrollmentsData: mockBFFEnterpriseCourseEnrollments,
-      enterpriseCourseEnrollmentsData: null,
-      isBFFEnabled: false,
-      doesCourseRunIdMatch: true,
-    },
-    {
-      bffEnterpriseCourseEnrollmentsData: null,
-      enterpriseCourseEnrollmentsData: mockEnterpriseCourseEnrollment,
-      isBFFEnabled: false,
-      doesCourseRunIdMatch: true,
-    },
-    {
-      bffEnterpriseCourseEnrollmentsData: null,
-      enterpriseCourseEnrollmentsData: null,
-      isBFFEnabled: false,
-      doesCourseRunIdMatch: true,
-    },
-    // BFF enabled && courseRunIdMatch == false
-    {
-      bffEnterpriseCourseEnrollmentsData: mockBFFEnterpriseCourseEnrollments,
-      enterpriseCourseEnrollmentsData: mockEnterpriseCourseEnrollment,
-      isBFFEnabled: true,
-      doesCourseRunIdMatch: false,
     },
     {
       bffEnterpriseCourseEnrollmentsData: mockBFFEnterpriseCourseEnrollments,
       enterpriseCourseEnrollmentsData: null,
       isBFFEnabled: true,
-      doesCourseRunIdMatch: false,
     },
     {
       bffEnterpriseCourseEnrollmentsData: null,
       enterpriseCourseEnrollmentsData: mockEnterpriseCourseEnrollment,
       isBFFEnabled: true,
-      doesCourseRunIdMatch: false,
     },
     {
       bffEnterpriseCourseEnrollmentsData: null,
       enterpriseCourseEnrollmentsData: null,
       isBFFEnabled: true,
-      doesCourseRunIdMatch: false,
     },
-    // BFF disabled && courseRunIdMatch == false
+    // BFF disabled
     {
       bffEnterpriseCourseEnrollmentsData: mockBFFEnterpriseCourseEnrollments,
       enterpriseCourseEnrollmentsData: mockEnterpriseCourseEnrollment,
       isBFFEnabled: false,
-      doesCourseRunIdMatch: true,
     },
     {
       bffEnterpriseCourseEnrollmentsData: mockBFFEnterpriseCourseEnrollments,
       enterpriseCourseEnrollmentsData: null,
       isBFFEnabled: false,
-      doesCourseRunIdMatch: false,
     },
     {
       bffEnterpriseCourseEnrollmentsData: null,
       enterpriseCourseEnrollmentsData: mockEnterpriseCourseEnrollment,
       isBFFEnabled: false,
-      doesCourseRunIdMatch: false,
     },
     {
       bffEnterpriseCourseEnrollmentsData: null,
       enterpriseCourseEnrollmentsData: null,
       isBFFEnabled: false,
-      doesCourseRunIdMatch: false,
     },
   ])('updates the status, (%s)', (
     {
       bffEnterpriseCourseEnrollmentsData,
       enterpriseCourseEnrollmentsData,
       isBFFEnabled,
-      doesCourseRunIdMatch,
     },
   ) => {
     // Define parameters
     let mockQueryClient;
     isBFFEnabledForEnterpriseCustomer.mockReturnValue(isBFFEnabled);
     const mockParams = { enterpriseSlug: 'test-enterprise-slug' };
-    const mockCorrectCourseRunId = mockEnterpriseCourseEnrollment.courseRunId;
-    const mockIncorrectCourseRunId = 'course-v1:edX+DemoY+Demo';
+    const mockCourseRunId = mockEnterpriseCourseEnrollment.courseRunId;
     const newEnrollmentStatus = 'saved_for_later';
-    const originalEnrollmentStatus = 'in_progress';
 
     // Create a mock hook to utilize queryClient
     const useMockHook = () => {
@@ -1205,13 +1144,13 @@ describe('handleQueriesForUpdatedCourseEnrollmentStatus', () => {
         queryClient: mockQueryClient,
         enterpriseSlug: mockParams.enterpriseSlug,
         enterpriseCustomer: mockEnterpriseCustomer,
-        courseRunId: doesCourseRunIdMatch ? mockCorrectCourseRunId : mockIncorrectCourseRunId,
+        courseRunId: mockCourseRunId,
         newEnrollmentStatus,
       });
     };
 
     // Validate initial courseRunStatus as `in_progress`
-    expect(mockEnterpriseCourseEnrollment.courseRunStatus).toEqual(originalEnrollmentStatus);
+    expect(mockEnterpriseCourseEnrollment.courseRunStatus).toEqual('in_progress');
 
     // Render hook
     renderHook(
@@ -1222,37 +1161,38 @@ describe('handleQueriesForUpdatedCourseEnrollmentStatus', () => {
     // Determine if course run status gets modified based on parameters
     let updatedEnrollments;
     let updatedMockedEnrollment;
-    const expectedCourseRunStatus = doesCourseRunIdMatch
-      ? newEnrollmentStatus
-      : originalEnrollmentStatus;
     if (isBFFEnabled) {
       updatedEnrollments = mockQueryClient.getQueryData(
         queryEnterpriseLearnerDashboardBFF({ enterpriseSlug: 'test-enterprise-slug' }).queryKey,
       );
       updatedMockedEnrollment = updatedEnrollments?.enterpriseCourseEnrollments.find(
-        enrollment => enrollment.courseRunId === mockCorrectCourseRunId,
+        enrollment => enrollment.courseRunId === mockCourseRunId,
       );
-      if (bffEnterpriseCourseEnrollmentsData) {
-        expect(updatedMockedEnrollment.courseRunStatus).toEqual(expectedCourseRunStatus);
+      if (bffEnterpriseCourseEnrollmentsData && !enterpriseCourseEnrollmentsData) {
+        expect(updatedMockedEnrollment.courseRunStatus).toEqual(newEnrollmentStatus);
         expect(logInfo).toHaveBeenCalledTimes(0);
-      } else {
+      } else if (!bffEnterpriseCourseEnrollmentsData) {
         expect(updatedMockedEnrollment).toEqual(undefined);
         expect(logInfo).toHaveBeenCalledTimes(1);
+      } else {
+        expect(updatedMockedEnrollment.courseRunStatus).toEqual(newEnrollmentStatus);
+        expect(logInfo).toHaveBeenCalledTimes(0);
       }
     }
     if (!isBFFEnabled) {
       updatedEnrollments = mockQueryClient.getQueryData(
         queryEnterpriseCourseEnrollments(mockEnterpriseCustomer.uuid).queryKey,
       );
-      updatedMockedEnrollment = updatedEnrollments?.find(
-        enrollment => enrollment.courseRunId === mockCorrectCourseRunId,
-      );
-      if (enterpriseCourseEnrollmentsData) {
-        expect(updatedMockedEnrollment.courseRunStatus).toEqual(expectedCourseRunStatus);
+      updatedMockedEnrollment = updatedEnrollments?.find(enrollment => enrollment.courseRunId === mockCourseRunId);
+      if (enterpriseCourseEnrollmentsData && !bffEnterpriseCourseEnrollmentsData) {
+        expect(updatedMockedEnrollment.courseRunStatus).toEqual(newEnrollmentStatus);
         expect(logInfo).toHaveBeenCalledTimes(0);
-      } else {
+      } else if (!enterpriseCourseEnrollmentsData) {
         expect(updatedMockedEnrollment).toEqual(undefined);
         expect(logInfo).toHaveBeenCalledTimes(1);
+      } else {
+        expect(updatedMockedEnrollment.courseRunStatus).toEqual(newEnrollmentStatus);
+        expect(logInfo).toHaveBeenCalledTimes(0);
       }
     }
   });

--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -36,7 +36,6 @@ const UserEnrollmentForm = ({ className }) => {
   const navigate = useNavigate();
   const config = getConfig();
   const queryClient = useQueryClient();
-  const params = useParams();
   const intl = useIntl();
   const {
     authenticatedUser: { userId, email: userEmail },
@@ -62,13 +61,15 @@ const UserEnrollmentForm = ({ className }) => {
       lmsUserId: userId,
     }).queryKey;
     const enterpriseCourseEnrollmentsQueryKey = queryEnterpriseCourseEnrollments(enterpriseCustomer.uuid).queryKey;
+
+    // List of queries to invalidate after successfully enrolling in the course.
     const queriesToInvalidate = [canRedeemQueryKey, redeemablePoliciesQueryKey, enterpriseCourseEnrollmentsQueryKey];
 
     if (isBFFEnabled) {
       // Determine which BFF queries need to be updated after successfully enrolling.
-      const dashboardBFFQueryKey = queryEnterpriseLearnerDashboardBFF(
-        { enterpriseSlug: params.enterpriseSlug },
-      ).queryKey;
+      const dashboardBFFQueryKey = queryEnterpriseLearnerDashboardBFF({
+        enterpriseSlug: enterpriseCustomer.slug,
+      }).queryKey;
       queriesToInvalidate.push(dashboardBFFQueryKey);
     }
 

--- a/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
@@ -1,6 +1,4 @@
-import {
-  act, screen, waitFor,
-} from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';
@@ -10,7 +8,7 @@ import { logError, logInfo } from '@edx/frontend-platform/logging';
 import dayjs from 'dayjs';
 import MockDate from 'mockdate';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 import UserEnrollmentForm from './UserEnrollmentForm';
 import { checkoutExecutiveEducation2U, toISOStringWithoutMilliseconds } from './data';
@@ -23,7 +21,7 @@ import {
   useEnterpriseCustomer,
 } from '../app/data';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../app/data/services/data/__factories__';
-import { renderWithRouter } from '../../utils/tests';
+import { queryClient, renderWithRouter } from '../../utils/tests';
 import { useUserSubsidyApplicableToCourse } from '../course/data';
 
 const termsLabelText = "I agree to GetSmarter's Terms and Conditions for Students";
@@ -97,8 +95,7 @@ const initialAppContextValue = {
   authenticatedUser: mockAuthenticatedUser,
 };
 
-const queryClient = new QueryClient();
-
+let mockQueryClient;
 const UserEnrollmentFormWrapper = ({
   appContextValue = initialAppContextValue,
   courseContextValue = {
@@ -108,17 +105,20 @@ const UserEnrollmentFormWrapper = ({
     setExternalFormSubmissionError: jest.fn(),
     formSubmissionError: {},
   },
-}) => (
-  <IntlProvider locale="en">
-    <QueryClientProvider client={queryClient}>
-      <AppContext.Provider value={appContextValue}>
-        <CourseContext.Provider value={courseContextValue}>
-          <UserEnrollmentForm />
-        </CourseContext.Provider>
-      </AppContext.Provider>
-    </QueryClientProvider>
-  </IntlProvider>
-);
+}) => {
+  mockQueryClient = queryClient();
+  return (
+    <IntlProvider locale="en">
+      <QueryClientProvider client={mockQueryClient}>
+        <AppContext.Provider value={appContextValue}>
+          <CourseContext.Provider value={courseContextValue}>
+            <UserEnrollmentForm />
+          </CourseContext.Provider>
+        </AppContext.Provider>
+      </QueryClientProvider>
+    </IntlProvider>
+  );
+};
 
 describe('UserEnrollmentForm', () => {
   beforeEach(() => {

--- a/src/components/stateful-enroll/data/hooks/useStatefulEnroll.js
+++ b/src/components/stateful-enroll/data/hooks/useStatefulEnroll.js
@@ -30,7 +30,6 @@ const useStatefulEnroll = ({
 }) => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const [transaction, setTransaction] = useState();
-  // TODO: What is the href/enrollmentURL for a statefulEnroll?
   const optimizelyHandler = useOptimizelyEnrollmentClickHandler({
     courseRunKey: contentKey,
     userEnrollments,

--- a/src/components/stateful-enroll/data/hooks/useStatefulEnroll.js
+++ b/src/components/stateful-enroll/data/hooks/useStatefulEnroll.js
@@ -30,10 +30,11 @@ const useStatefulEnroll = ({
 }) => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const [transaction, setTransaction] = useState();
-  const optimizelyHandler = useOptimizelyEnrollmentClickHandler(
-    contentKey,
+  // TODO: What is the href/enrollmentURL for a statefulEnroll?
+  const optimizelyHandler = useOptimizelyEnrollmentClickHandler({
+    courseRunKey: contentKey,
     userEnrollments,
-  );
+  });
   const searchHandler = useTrackSearchConversionClickHandler({
     eventName: EVENT_NAMES.sucessfulEnrollment,
   });

--- a/src/components/stateful-enroll/data/hooks/useStatefulEnroll.test.jsx
+++ b/src/components/stateful-enroll/data/hooks/useStatefulEnroll.test.jsx
@@ -111,7 +111,7 @@ describe('useStatefulEnroll', () => {
 
     if (isSuccess) {
       expect(trackSearchSpy).toHaveBeenCalledWith({ eventName: EVENT_NAMES.sucessfulEnrollment });
-      expect(optimizelySpy).toHaveBeenCalledWith('content_key', []);
+      expect(optimizelySpy).toHaveBeenCalledWith({ courseRunKey: 'content_key', userEnrollments: [] });
       expect(onSuccess).toHaveBeenCalledTimes(1);
       expect(onSuccess).toHaveBeenCalledWith({ state: mockState });
     } else {


### PR DESCRIPTION
Where existing query invalidations and optimistic updates exist for cached query data related to metadata also retrieved from the BFF layer, we add identical logic to invalidate/optimistic update the BFF query cache.

Fixes bug related to passed in args into optimizely within `useStatefulEnroll`.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
