### PR TITLE
fix: update conditionally blocked BFF queries

### DIFF
--- a/src/components/app/routes/data/utils.js
+++ b/src/components/app/routes/data/utils.js
@@ -101,33 +101,35 @@ export async function ensureEnterpriseAppData({
 
         return subscriptionsData;
       }),
-      queryClient.ensureQueryData(
-        queryRedeemablePolicies({
-          enterpriseUuid: enterpriseCustomer.uuid,
-          lmsUserId: userId,
-        }),
-      ),
-      queryClient.ensureQueryData(
-        queryCouponCodes(enterpriseCustomer.uuid),
-      ),
-      queryClient.ensureQueryData(
-        queryEnterpriseLearnerOffers(enterpriseCustomer.uuid),
-      ),
-      queryClient.ensureQueryData(
-        queryBrowseAndRequestConfiguration(enterpriseCustomer.uuid),
-      ),
-      queryClient.ensureQueryData(
-        queryLicenseRequests(enterpriseCustomer.uuid, userEmail),
-      ),
-      queryClient.ensureQueryData(
-        queryCouponCodeRequests(enterpriseCustomer.uuid, userEmail),
-      ),
-      // Content Highlights
-      queryClient.ensureQueryData(
-        queryContentHighlightsConfiguration(enterpriseCustomer.uuid),
-      ),
     );
   }
+  enterpriseAppDataQueries.push(...[
+    queryClient.ensureQueryData(
+      queryRedeemablePolicies({
+        enterpriseUuid: enterpriseCustomer.uuid,
+        lmsUserId: userId,
+      }),
+    ),
+    queryClient.ensureQueryData(
+      queryCouponCodes(enterpriseCustomer.uuid),
+    ),
+    queryClient.ensureQueryData(
+      queryEnterpriseLearnerOffers(enterpriseCustomer.uuid),
+    ),
+    queryClient.ensureQueryData(
+      queryBrowseAndRequestConfiguration(enterpriseCustomer.uuid),
+    ),
+    queryClient.ensureQueryData(
+      queryLicenseRequests(enterpriseCustomer.uuid, userEmail),
+    ),
+    queryClient.ensureQueryData(
+      queryCouponCodeRequests(enterpriseCustomer.uuid, userEmail),
+    ),
+    // Content Highlights
+    queryClient.ensureQueryData(
+      queryContentHighlightsConfiguration(enterpriseCustomer.uuid),
+    ),
+  ]);
 
   if (getConfig().ENABLE_NOTICES) {
     enterpriseAppDataQueries.push(


### PR DESCRIPTION
Upon testing locally, after the nProgressLoader bar completes there was a brief moment a blank was shown. This is not normal. Updates conditionally blocked queries based on whether the BFF is enabled for the customer.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
