### PR TITLE
fix: invalid date formatting on course route

### DIFF
--- a/src/components/course/course-header/deprecated/CourseRunCard.jsx
+++ b/src/components/course/course-header/deprecated/CourseRunCard.jsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import dayjs from 'dayjs';
 import { useLocation } from 'react-router-dom';
 import { Card } from '@openedx/paragon';
 import { FormattedDate, FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
@@ -15,7 +14,7 @@ import {
   hasCourseStarted,
   findHighestLevelSku,
   pathContainsCourseTypeSlug,
-  getCourseStartDate,
+  getNormalizedStartDate,
 } from '../../data/utils';
 import { formatStringAsNumber } from '../../../../utils/common';
 import {
@@ -31,8 +30,6 @@ import {
   useEnterpriseCustomer,
   useSubscriptions,
 } from '../../../app/data';
-
-const DATE_FORMAT = 'MMM D';
 
 const CourseRunCard = ({
   courseEntitlements,
@@ -62,7 +59,7 @@ const CourseRunCard = ({
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const userCanRequestSubsidyForCourse = useCanUserRequestSubsidyForCourse();
 
-  const courseStartDate = getCourseStartDate({ courseRun });
+  const courseStartDate = getNormalizedStartDate(courseRun);
 
   const isCourseStarted = useMemo(
     () => hasCourseStarted(courseStartDate),
@@ -165,7 +162,7 @@ const CourseRunCard = ({
             values={{
               upcomingCourseStartDate: (
                 <FormattedDate
-                  value={dayjs(courseStartDate).format(DATE_FORMAT)}
+                  value={courseStartDate}
                   month="short"
                   day="numeric"
                 />
@@ -203,7 +200,7 @@ const CourseRunCard = ({
               values={{
                 courseStartDate: (
                   <FormattedDate
-                    value={dayjs(courseStartDate).format(DATE_FORMAT)}
+                    value={courseStartDate}
                     month="short"
                     day="numeric"
                   />
@@ -275,7 +272,7 @@ const CourseRunCard = ({
           values={{
             courseStartedDate: (
               <FormattedDate
-                value={dayjs(courseStartDate).format(DATE_FORMAT)}
+                value={courseStartDate}
                 month="short"
                 day="numeric"
               />
@@ -291,7 +288,7 @@ const CourseRunCard = ({
           values={{
             courseStartsDate: (
               <FormattedDate
-                value={dayjs(courseStartDate).format(DATE_FORMAT)}
+                value={courseStartDate}
                 month="short"
                 day="numeric"
               />
@@ -311,7 +308,7 @@ const CourseRunCard = ({
               values={{
                 courseStartsDate: (
                   <FormattedDate
-                    value={dayjs(courseStartDate).format(DATE_FORMAT)}
+                    value={courseStartDate}
                     month="short"
                     day="numeric"
                   />

--- a/src/components/course/course-header/tests/DeprecatedCourseRunCard.test.jsx
+++ b/src/components/course/course-header/tests/DeprecatedCourseRunCard.test.jsx
@@ -28,7 +28,7 @@ import { useCanUserRequestSubsidyForCourse } from '../../data/hooks';
 import { SUBSIDY_TYPE } from '../../../../constants';
 
 const COURSE_UUID = 'foo';
-const COURSE_RUN_START = dayjs().format();
+const COURSE_RUN_START = dayjs().toISOString();
 const COURSE_WEEKS_TO_COMPLETE = 1;
 const DATE_FORMAT = 'MMM D';
 const COURSE_ID = '123';
@@ -201,9 +201,7 @@ describe('<DeprecatedCourseRunCard />', () => {
   test('Course is self paced and has started', () => {
     // If Browse/Request feature is off, user should always see the enroll button
     const courseRun = generateCourseRun({});
-    renderCard({
-      courseRun,
-    });
+    renderCard({ courseRun });
     const startDate = dayjs(COURSE_RUN_START).format(DATE_FORMAT);
     expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
     expect(screen.getByText('Be the first to enroll!')).toBeInTheDocument();
@@ -213,14 +211,12 @@ describe('<DeprecatedCourseRunCard />', () => {
   test('Course self is paced, has not started, and enrollment count', () => {
     // The user has a mocked subsidy from renderCard default values,
     // so they should see an enroll button.
-    const courseRunStart = dayjs(COURSE_RUN_START).add(1, 'd').format();
+    const courseRunStart = dayjs(COURSE_RUN_START).add(1, 'd').toISOString();
     const courseRun = generateCourseRun({
       start: courseRunStart,
       enrollmentCount: 1000,
     });
-    renderCard({
-      courseRun,
-    });
+    renderCard({ courseRun });
     const startDate = dayjs(courseRunStart).format(DATE_FORMAT);
     expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
     expect(screen.getByText('1,000 recently enrolled!')).toBeInTheDocument();
@@ -240,9 +236,7 @@ describe('<DeprecatedCourseRunCard />', () => {
       },
     });
     const courseRun = generateCourseRun({});
-    renderCard({
-      courseRun,
-    });
+    renderCard({ courseRun });
     const startDate = dayjs(COURSE_RUN_START).format(DATE_FORMAT);
     expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
     expect(screen.getByText('Be the first to enroll!')).toBeInTheDocument();
@@ -254,9 +248,7 @@ describe('<DeprecatedCourseRunCard />', () => {
     // and there is an applicable catalog for the configured subsidy request type.
     const courseRun = generateCourseRun({});
     useCanUserRequestSubsidyForCourse.mockReturnValue(true);
-    renderCard({
-      courseRun,
-    });
+    renderCard({ courseRun });
     const startDate = dayjs(COURSE_RUN_START).format(DATE_FORMAT);
     expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
     expect(screen.getByText('Be the first to enroll!')).toBeInTheDocument();
@@ -268,9 +260,7 @@ describe('<DeprecatedCourseRunCard />', () => {
     // subsidies and there is no applicable catalog for the configured subsidy type.
     // Instead, the CTA should bring the user through the ecommerce basket flow.
     const courseRun = generateCourseRun({});
-    renderCard({
-      courseRun,
-    });
+    renderCard({ courseRun });
     const startDate = dayjs(COURSE_RUN_START).format(DATE_FORMAT);
     expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();
     expect(screen.getByText('Be the first to enroll!')).toBeInTheDocument();
@@ -278,7 +268,7 @@ describe('<DeprecatedCourseRunCard />', () => {
   });
 
   test('User is enrolled, and course not started', () => {
-    const courseRunStart = dayjs(COURSE_RUN_START).add(1, 'd').format();
+    const courseRunStart = dayjs(COURSE_RUN_START).add(1, 'd').toISOString();
     const courseRun = generateCourseRun({
       start: courseRunStart,
     });
@@ -289,7 +279,7 @@ describe('<DeprecatedCourseRunCard />', () => {
         courseRunId: COURSE_ID,
         isEnrollmentActive: true,
         isRevoked: false,
-        mode: COURSE_MODES_MAP.AUDIT,
+        mode: COURSE_MODES_MAP.VERIFIED,
       }],
     });
     expect(screen.getByText(`Starts ${startDate}`)).toBeInTheDocument();

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -95,7 +95,7 @@ export const getNormalizedStartDate = ({
     return todayToIso;
   }
   const startDateIso = dayjs(start).toISOString();
-  if (isCourseSelfPaced(pacingType)) {
+  if (isCourseSelfPaced(pacingType) && dayjs(startDateIso).isBefore(dayjs())) {
     if (hasTimeToComplete({ end, weeksToComplete }) || isWithinMinimumStartDateThreshold({ start })) {
       // always today's date (incentives enrollment)
       return todayToIso;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/UpcomingCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/UpcomingCourseCard.jsx
@@ -1,6 +1,4 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import dayjs from 'dayjs';
 import { FormattedDate, FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import { Button } from '@openedx/paragon';
@@ -15,7 +13,7 @@ const UpcomingCourseCard = (props) => {
         description="Label for the upcoming course card button"
         values={{
           upcomingDate: <FormattedDate
-            value={dayjs(props.startDate).format('MMM D')}
+            value={props.startDate}
             month="short"
             day="numeric"
           />,


### PR DESCRIPTION
# Description

Resolves "Invalid Date" messages on course about page in Learner Portal in Firefox (appears fine in Chrome). The error seems to be due to different browsers' parsing/handling of datetime strings.

<img width="1198" alt="image" src="https://github.com/user-attachments/assets/b1bccd88-d63f-483d-9ada-4b33fb83106f">

Locally, there was a JS error triggers by `react-intl`'s `FormattedDate` component:

```
Error: [@formatjs/intl Error FORMAT_ERROR] Error formatting date.
Locale: en
date value is not finite in DateTimeFormat.format()
```

The solution was to ensure the raw date string was passed to `FormattedDate` vs. passing the already-formatted date via `dayjs(...).format(DATE_FORMAT)`. 

This PR also switches to use `getNormalizedStartDate` within the deprecated `CourseRunCard` component to ensure today's date is used for display, where relevant (i.e., self-paced courses with time-to-complete).

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
