### PR TITLE
fix: ensure useSubscriptions and useEnterpriseCourseEnrollments uses queryOptions.select from args

### DIFF
--- a/src/components/app/data/constants.js
+++ b/src/components/app/data/constants.js
@@ -65,6 +65,7 @@ export const ASSIGNMENT_TYPES = {
   EXPIRED: 'expired',
   ERRORED: 'errored',
   EXPIRING: 'expiring',
+  REVERSED: 'reversed',
 };
 
 // When the start date is before this number of days before today, display the alternate start date (fixed to today).

--- a/src/components/app/data/hooks/useEnterpriseCourseEnrollments.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseCourseEnrollments.test.jsx
@@ -30,7 +30,7 @@ jest.mock('./useBFF');
 
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
 const mockAuthenticatedUser = authenticatedUserFactory();
-const mockCourseEnrollments = {
+const mockCourseEnrollment = {
   displayName: 'Education',
   micromastersTitle: 'Demo in higher education',
   courseRunUrl: 'test-course-url',
@@ -114,6 +114,16 @@ const mockRedeemablePolicies = {
   },
 };
 
+const expectedTransformedRequests = (request) => ({
+  courseRunId: request.courseId,
+  title: request.courseTitle,
+  orgName: request.coursePartners?.map(partner => partner.name).join(', '),
+  courseRunStatus: COURSE_STATUSES.requested,
+  linkToCourse: `${mockEnterpriseCustomer.slug}/course/${request.courseId}`,
+  created: request.created,
+  notifications: [],
+});
+
 describe('useEnterpriseCourseEnrollments', () => {
   const Wrapper = ({ children }) => (
     <QueryClientProvider client={queryClient()}>
@@ -125,35 +135,28 @@ describe('useEnterpriseCourseEnrollments', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    fetchEnterpriseCourseEnrollments.mockResolvedValue([mockCourseEnrollments]);
+    fetchEnterpriseCourseEnrollments.mockResolvedValue([mockCourseEnrollment]);
     fetchBrowseAndRequestConfiguration.mockResolvedValue(mockBrowseAndRequestConfiguration);
     fetchLicenseRequests.mockResolvedValue([mockLicenseRequests]);
     fetchCouponCodeRequests.mockResolvedValue([mockCouponCodeRequests]);
     fetchRedeemablePolicies.mockResolvedValue(mockRedeemablePolicies);
-    useBFF.mockReturnValue({ data: [mockCourseEnrollments].map(transformCourseEnrollment) });
+    useBFF.mockReturnValue({ data: [mockCourseEnrollment].map(transformCourseEnrollment) });
   });
-  it('should return transformed return values from course enrollments API', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useEnterpriseCourseEnrollments(), { wrapper: Wrapper });
-    await waitForNextUpdate();
-    const expectedEnterpriseCourseEnrollments = {
-      title: mockCourseEnrollments.displayName,
-      microMastersTitle: mockCourseEnrollments.micromastersTitle,
-      linkToCourse: mockCourseEnrollments.courseRunUrl,
-      linkToCertificate: mockCourseEnrollments.certificateDownloadUrl,
-      hasEmailsEnabled: mockCourseEnrollments.emailsEnabled,
-      notifications: mockCourseEnrollments.dueDates,
-      canUnenroll: canUnenrollCourseEnrollment(mockCourseEnrollments),
+
+  it.each([
+    { hasQueryOptions: false },
+    { hasQueryOptions: true },
+  ])('should return transformed enrollments data (%s)', async ({ hasQueryOptions }) => {
+    const expectedEnterpriseCourseEnrollments = [{
+      title: mockCourseEnrollment.displayName,
+      microMastersTitle: mockCourseEnrollment.micromastersTitle,
+      linkToCourse: mockCourseEnrollment.courseRunUrl,
+      linkToCertificate: mockCourseEnrollment.certificateDownloadUrl,
+      hasEmailsEnabled: mockCourseEnrollment.emailsEnabled,
+      notifications: mockCourseEnrollment.dueDates,
+      canUnenroll: canUnenrollCourseEnrollment(mockCourseEnrollment),
       isCourseAssigned: false,
-    };
-    const expectedTransformedRequests = (request) => ({
-      courseRunId: request.courseId,
-      title: request.courseTitle,
-      orgName: request.coursePartners?.map(partner => partner.name).join(', '),
-      courseRunStatus: COURSE_STATUSES.requested,
-      linkToCourse: `${mockEnterpriseCustomer.slug}/course/${request.courseId}`,
-      created: request.created,
-      notifications: [],
-    });
+    }];
     const expectedRequests = {
       couponCodes: [expectedTransformedRequests(mockCouponCodeRequests)],
       subscriptionLicenses: [expectedTransformedRequests(mockLicenseRequests)],
@@ -177,7 +180,7 @@ describe('useEnterpriseCourseEnrollments', () => {
       uuid: mockContentAssignment.uuid,
       learnerAcknowledged: mockContentAssignment.learnerAcknowledged,
     };
-    const expectedContentAssignment = {
+    const expectedContentAssignmentData = {
       acceptedAssignments: [],
       allocatedAssignments: [expectedTransformedLearnerContentAssignment],
       assignmentsForDisplay: [expectedTransformedLearnerContentAssignment],
@@ -187,15 +190,64 @@ describe('useEnterpriseCourseEnrollments', () => {
       expiredAssignments: [],
     };
 
+    const mockSelectEnrollment = jest.fn().mockReturnValue(expectedEnterpriseCourseEnrollments);
+    const mockSelectLicenseRequest = jest.fn().mockReturnValue(expectedRequests.subscriptionLicenses);
+    const mockSelectCouponCodeRequest = jest.fn().mockReturnValue(expectedRequests.couponCodes);
+    const mockSelectContentAssignment = jest.fn().mockReturnValue(expectedContentAssignmentData);
+    const mockQueryOptions = {
+      enrollmentQueryOptions: { select: mockSelectEnrollment },
+      licenseRequestQueryOptions: { select: mockSelectLicenseRequest },
+      couponCodeRequestQueryOptions: { select: mockSelectCouponCodeRequest },
+      contentAssignmentQueryOptions: { select: mockSelectContentAssignment },
+    };
+    const queryOptions = hasQueryOptions ? mockQueryOptions : undefined;
+    const { result, waitForNextUpdate } = renderHook(
+      () => {
+        if (hasQueryOptions) {
+          return useEnterpriseCourseEnrollments(queryOptions);
+        }
+        return useEnterpriseCourseEnrollments()
+      },
+      { wrapper: Wrapper }
+    );
+    await waitForNextUpdate();
+
+    // Call the mocked useBFF's input select functions
+    const useBFFArgs = useBFF.mock.calls[0][0];
+    const { select: selectBFFQuery } = useBFFArgs.bffQueryOptions;
+    const { select: selectFallbackBFFQuery } = useBFFArgs.fallbackQueryConfig;
+    selectBFFQuery({ enterpriseCourseEnrollments: [mockCourseEnrollment] });
+    selectFallbackBFFQuery([mockCourseEnrollment]);
+
+    // Assert that passed select fn query options were called with the correct arguments
+    if (hasQueryOptions) {
+      expect(mockSelectLicenseRequest).toHaveBeenCalledWith({
+        original: [mockLicenseRequests],
+        transformed: expectedRequests.subscriptionLicenses,
+      });
+      expect(mockSelectCouponCodeRequest).toHaveBeenCalledWith({
+        original: [mockCouponCodeRequests],
+        transformed: expectedRequests.couponCodes,
+      });
+      expect(mockSelectContentAssignment).toHaveBeenCalledWith({
+        original: mockRedeemablePolicies,
+        transformed: expectedContentAssignmentData,
+      });
+      expect(mockSelectEnrollment).toHaveBeenCalledWith({
+        original: [mockCourseEnrollment],
+        transformed: expectedEnterpriseCourseEnrollments,
+      });
+    }
+
     const expectedTransformedAllEnrollmentsByStatus = transformAllEnrollmentsByStatus({
-      enterpriseCourseEnrollments: [expectedEnterpriseCourseEnrollments],
+      enterpriseCourseEnrollments: expectedEnterpriseCourseEnrollments,
       requests: expectedRequests,
-      contentAssignments: expectedContentAssignment,
+      contentAssignments: expectedContentAssignmentData,
     });
 
     expect(result.current.data.allEnrollmentsByStatus).toEqual(expectedTransformedAllEnrollmentsByStatus);
-    expect(result.current.data.enterpriseCourseEnrollments).toEqual([expectedEnterpriseCourseEnrollments]);
-    expect(result.current.data.contentAssignments).toEqual(expectedContentAssignment);
+    expect(result.current.data.enterpriseCourseEnrollments).toEqual(expectedEnterpriseCourseEnrollments);
+    expect(result.current.data.contentAssignments).toEqual(expectedContentAssignmentData);
     expect(result.current.data.requests).toEqual(expectedRequests);
   });
 });

--- a/src/components/app/data/hooks/useEnterpriseCourseEnrollments.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseCourseEnrollments.test.jsx
@@ -206,9 +206,9 @@ describe('useEnterpriseCourseEnrollments', () => {
         if (hasQueryOptions) {
           return useEnterpriseCourseEnrollments(queryOptions);
         }
-        return useEnterpriseCourseEnrollments()
+        return useEnterpriseCourseEnrollments();
       },
-      { wrapper: Wrapper }
+      { wrapper: Wrapper },
     );
     await waitForNextUpdate();
 

--- a/src/components/app/data/hooks/useSubscriptions.js
+++ b/src/components/app/data/hooks/useSubscriptions.js
@@ -10,12 +10,28 @@ import { transformSubscriptionsData } from '../services';
  */
 export default function useSubscriptions(queryOptions = {}) {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
+  const { select, ...queryOptionsRest } = queryOptions;
+
   return useBFF({
     bffQueryOptions: {
-      select: (data) => transformSubscriptionsData(
-        data?.enterpriseCustomerUserSubsidies?.subscriptions,
-        { isBFFData: true },
-      ),
+      ...queryOptionsRest,
+      select: (data) => {
+        const transformedData = transformSubscriptionsData(
+          data?.enterpriseCustomerUserSubsidies?.subscriptions,
+          { isBFFData: true },
+        );
+
+        // When custom `select` function is provided in `queryOptions`, call it with original and transformed data.
+        if (select) {
+          return select({
+            original: data,
+            transformed: transformedData,
+          });
+        }
+
+        // Otherwise, return the transformed data.
+        return transformedData;
+      },
     },
     fallbackQueryConfig: {
       ...querySubscriptions(enterpriseCustomer.uuid),

--- a/src/components/app/data/hooks/useSubscriptions.test.jsx
+++ b/src/components/app/data/hooks/useSubscriptions.test.jsx
@@ -3,16 +3,17 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { useLocation, useParams } from 'react-router-dom';
 import { enterpriseCustomerFactory } from '../services/data/__factories__';
 import { queryClient } from '../../../../utils/tests';
-import { fetchSubscriptions } from '../services';
+import { fetchSubscriptions, fetchEnterpriseLearnerDashboard } from '../services';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 import useSubscriptions from './useSubscriptions';
 import { LICENSE_STATUS } from '../../../enterprise-user-subsidy/data/constants';
-import { resolveBFFQuery } from '../queries';
+import { queryEnterpriseLearnerDashboardBFF, resolveBFFQuery } from '../queries';
 
 jest.mock('./useEnterpriseCustomer');
 jest.mock('../services', () => ({
   ...jest.requireActual('../services'),
   fetchSubscriptions: jest.fn().mockResolvedValue(null),
+  fetchEnterpriseLearnerDashboard: jest.fn(),
 }));
 jest.mock('../queries', () => ({
   ...jest.requireActual('../queries'),
@@ -44,6 +45,7 @@ describe('useSubscriptions', () => {
       {children}
     </QueryClientProvider>
   );
+
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
@@ -52,14 +54,99 @@ describe('useSubscriptions', () => {
     useParams.mockReturnValue({ enterpriseSlug: 'test-enterprise' });
     resolveBFFQuery.mockReturnValue(null);
   });
-  it('should handle resolved value correctly', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useSubscriptions(), { wrapper: Wrapper });
+
+  it.each([
+    {
+      hasQueryOptions: false,
+      isBFFQueryEnabled: false,
+    },
+    {
+      hasQueryOptions: false,
+      isBFFQueryEnabled: true,
+    },
+    {
+      hasQueryOptions: true,
+      isBFFQueryEnabled: false,
+    },
+    {
+      hasQueryOptions: true,
+      isBFFQueryEnabled: true,
+    },
+  ])('should handle resolved value correctly (%s)', async ({ hasQueryOptions, isBFFQueryEnabled }) => {
+    const mockSubscriptionLicense = {
+      uuid: 'mock-subscription-license-uuid',
+      status: LICENSE_STATUS.ACTIVATED,
+      subscriptionPlan: {
+        uuid: 'mock-subscription-plan-uuid',
+      },
+    };
+    let mockSelect = jest.fn((data) => data);
+    if (isBFFQueryEnabled) {
+      mockSelect = jest.fn(({ original, transformed }) => {
+        return transformed.subscriptionLicense;
+      })
+    }
+    const queryOptions = hasQueryOptions ? { select: mockSelect } : undefined;
+    const mockSubscriptionLicensesByStatus = {
+      ...mockSubscriptionsData.licensesByStatus,
+      [mockSubscriptionLicense.status]: [mockSubscriptionLicense],
+    };
+    const mockSubscriptionsDataWithLicense = {
+      ...mockSubscriptionsData,
+      subscriptionLicenses: [mockSubscriptionLicense],
+      customerAgreement: {
+        uuid: 'mock-customer-agreement-uuid',
+        disableExpirationNotifications: true,
+      },
+      subscriptionLicense: mockSubscriptionLicense,
+      subscriptionPlan: mockSubscriptionLicense.subscriptionPlan,
+      licensesByStatus: mockSubscriptionLicensesByStatus,
+      showExpirationNotifications: false,
+    };
+    if (isBFFQueryEnabled) {
+      mockSubscriptionsDataWithLicense.subscriptionLicensesByStatus = mockSubscriptionLicensesByStatus;
+      delete mockSubscriptionsDataWithLicense.licensesByStatus;
+      resolveBFFQuery.mockReturnValue(queryEnterpriseLearnerDashboardBFF);
+      fetchEnterpriseLearnerDashboard.mockResolvedValue({
+        enterpriseCustomerUserSubsidies: {
+          subscriptions: mockSubscriptionsDataWithLicense,
+        },
+      });
+    }
+    fetchSubscriptions.mockResolvedValue(mockSubscriptionsDataWithLicense);
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => {
+        if (queryOptions) {
+          return useSubscriptions(queryOptions);
+        }
+        return useSubscriptions();
+      },
+      { wrapper: Wrapper }
+    );
 
     await waitForNextUpdate();
 
+    const expectedSubscriptionsdata = {
+      ...mockSubscriptionsDataWithLicense,
+      licensesByStatus: mockSubscriptionLicensesByStatus,
+    };
+    delete expectedSubscriptionsdata.subscriptionLicensesByStatus;
+
+    if (hasQueryOptions && isBFFQueryEnabled) {
+      expect(mockSelect).toHaveBeenCalledWith({
+        original: {
+          enterpriseCustomerUserSubsidies: {
+            subscriptions: mockSubscriptionsDataWithLicense,
+          },
+        },
+        transformed: expectedSubscriptionsdata,
+      });
+    }
+
     expect(result.current).toEqual(
       expect.objectContaining({
-        data: mockSubscriptionsData,
+        data: hasQueryOptions && isBFFQueryEnabled ? mockSubscriptionLicense : expectedSubscriptionsdata,
         isLoading: false,
         isFetching: false,
       }),

--- a/src/components/app/data/hooks/useSubscriptions.test.jsx
+++ b/src/components/app/data/hooks/useSubscriptions.test.jsx
@@ -82,9 +82,7 @@ describe('useSubscriptions', () => {
     };
     let mockSelect = jest.fn((data) => data);
     if (isBFFQueryEnabled) {
-      mockSelect = jest.fn(({ original, transformed }) => {
-        return transformed.subscriptionLicense;
-      })
+      mockSelect = jest.fn(({ transformed }) => transformed.subscriptionLicense);
     }
     const queryOptions = hasQueryOptions ? { select: mockSelect } : undefined;
     const mockSubscriptionLicensesByStatus = {
@@ -122,7 +120,7 @@ describe('useSubscriptions', () => {
         }
         return useSubscriptions();
       },
-      { wrapper: Wrapper }
+      { wrapper: Wrapper },
     );
 
     await waitForNextUpdate();

--- a/src/components/app/data/services/subsidies/index.test.js
+++ b/src/components/app/data/services/subsidies/index.test.js
@@ -127,6 +127,7 @@ describe('fetchRedeemablePolicies', () => {
         canceledAssignments: [],
         erroredAssignments: [],
         expiredAssignments: [],
+        reversedAssignments: [],
         hasAcceptedAssignments: false,
         hasAllocatedAssignments: true,
         hasAssignments: true,
@@ -134,6 +135,7 @@ describe('fetchRedeemablePolicies', () => {
         hasCanceledAssignments: false,
         hasErroredAssignments: false,
         hasExpiredAssignments: false,
+        hasReversedAssignments: false,
       },
     };
     expect(result).toEqual(expectedRedeemablePolicies);

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -173,6 +173,7 @@ export function getAssignmentsByState(assignments = []) {
   const canceledAssignments = [];
   const expiredAssignments = [];
   const erroredAssignments = [];
+  const reversedAssignments = [];
   const assignmentsForDisplay = [];
 
   assignments.forEach((assignment) => {
@@ -191,6 +192,9 @@ export function getAssignmentsByState(assignments = []) {
         break;
       case ASSIGNMENT_TYPES.ERRORED:
         erroredAssignments.push(assignment);
+        break;
+      case ASSIGNMENT_TYPES.REVERSED:
+        reversedAssignments.push(assignment);
         break;
       default:
         logError(`[getAssignmentsByState] Unsupported state ${assignment.state} for assignment ${assignment.uuid}`);

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -165,6 +165,14 @@ export function determineEnterpriseCustomerUserForDisplay({
 *  hasCanceledAssignments: Boolean,
 *  acceptedAssignments: Array,
 *  hasAcceptedAssignments: Boolean,
+*  expiredAssignments: Array,
+*  hasExpiredAssignments: Boolean,
+*  erroredAssignments: Array,
+*  hasErroredAssignments: Boolean,
+*  reversedAssignments: Array,
+*  hasReversedAssignments: Boolean,
+*  assignmentsForDisplay: Array,
+*  hasAssignmentsForDisplay: Boolean
 * }}
 */
 export function getAssignmentsByState(assignments = []) {
@@ -208,6 +216,7 @@ export function getAssignmentsByState(assignments = []) {
   const hasCanceledAssignments = canceledAssignments.length > 0;
   const hasExpiredAssignments = expiredAssignments.length > 0;
   const hasErroredAssignments = erroredAssignments.length > 0;
+  const hasReversedAssignments = reversedAssignments.length > 0;
 
   // Concatenate all assignments for display (includes allocated and canceled assignments)
   assignmentsForDisplay.push(...allocatedAssignments);
@@ -228,6 +237,8 @@ export function getAssignmentsByState(assignments = []) {
     hasExpiredAssignments,
     erroredAssignments,
     hasErroredAssignments,
+    reversedAssignments,
+    hasReversedAssignments,
     assignmentsForDisplay,
     hasAssignmentsForDisplay,
   };

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -150,10 +150,13 @@ export const useCourseUpgradeData = ({
   const location = useLocation();
   const canUpgradeToVerifiedEnrollment = isEnrollmentUpgradeable({ mode, enrollBy });
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
+
+  // Metadata required to determine if the course run is contained in the customer's content catalog(s)
   const { data: customerContainsContent } = useEnterpriseCustomerContainsContent([courseRunKey], {
     enabled: canUpgradeToVerifiedEnrollment,
   });
 
+  // Metadata required to allow upgrade via applicable learner credit subsidy
   const { data: learnerCreditMetadata } = useCanUpgradeWithLearnerCredit(courseRunKey, {
     enabled: canUpgradeToVerifiedEnrollment,
   });
@@ -162,7 +165,8 @@ export const useCourseUpgradeData = ({
   const { data: subscriptionLicense } = useSubscriptions({
     select: (data) => {
       let license;
-      if (data.transformed) {
+      if (data?.transformed) {
+        // If the data has been transformed, use the transformed data.
         license = data.transformed.subscriptionLicense;
       } else {
         license = data?.subscriptionLicense;

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -160,8 +160,13 @@ export const useCourseUpgradeData = ({
 
   // Metadata required to allow upgrade via applicable subscription license
   const { data: subscriptionLicense } = useSubscriptions({
-    select: ({ transformed }) => {
-      const license = transformed?.subscriptionLicense;
+    select: (data) => {
+      let license;
+      if (data.transformed) {
+        license = data.transformed.subscriptionLicense;
+      } else {
+        license = data?.subscriptionLicense;
+      }
       const isLicenseActivated = !!(license?.status === LICENSE_STATUS.ACTIVATED);
       const isSubscriptionPlanCurrent = !!license?.subscriptionPlan.isCurrent;
       if (!isLicenseActivated || !isSubscriptionPlanCurrent) {

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -160,8 +160,8 @@ export const useCourseUpgradeData = ({
 
   // Metadata required to allow upgrade via applicable subscription license
   const { data: subscriptionLicense } = useSubscriptions({
-    select: (data) => {
-      const license = data?.subscriptionLicense;
+    select: ({ transformed }) => {
+      const license = transformed?.subscriptionLicense;
       const isLicenseActivated = !!(license?.status === LICENSE_STATUS.ACTIVATED);
       const isSubscriptionPlanCurrent = !!license?.subscriptionPlan.isCurrent;
       if (!isLicenseActivated || !isSubscriptionPlanCurrent) {

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
@@ -366,11 +366,18 @@ describe('useCourseUpgradeData', () => {
         }),
       );
       const useSubscriptionsSelectFn = useSubscriptions.mock.calls[0][0].select;
-      const selectTransformResult = useSubscriptionsSelectFn({ subscriptionLicense: mockSubscriptionLicense });
+      const selectTransformResultLegacy = useSubscriptionsSelectFn({ subscriptionLicense: mockSubscriptionLicense });
+      const transformedSubscriptionsBFFData = {
+        original: { subscriptionLicense: mockSubscriptionLicense },
+        transformed: { subscriptionLicense: mockSubscriptionLicense },
+      };
+      const selectTransformResultBFF = useSubscriptionsSelectFn(transformedSubscriptionsBFFData);
       if (subscriptionLicenseStatus === LICENSE_STATUS.ACTIVATED && isSubscriptionPlanCurrent) {
-        expect(selectTransformResult).toEqual(mockSubscriptionLicense);
+        expect(selectTransformResultLegacy).toEqual(mockSubscriptionLicense);
+        expect(selectTransformResultBFF).toEqual(mockSubscriptionLicense);
       } else {
-        expect(selectTransformResult).toBeNull();
+        expect(selectTransformResultLegacy).toBeNull();
+        expect(selectTransformResultBFF).toBeNull();
       }
 
       // Assert expected output


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-9857

In both `useSubscriptions` and `useEnterpriseCourseEnrollments`, this PR ensures any optional `queryOptions.select` functions passed in follow the established convention of being called with an object containing the following:

```js
return select({
  original: data, // the original query data, untransformed
  transformed: transformedData, // the transformed query data, as determined by the hook's internal `select` logic.
});
```

This pattern ensures any custom `select` functions passed to the helper query hooks (e.g., `useSubscriptions`) are given a choice of using the original query data or transformed query data from the parent hook.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
