### PR TITLE
feat: extend BFF feature flag to take into account Waffle flag

### DIFF
--- a/src/components/NotFoundPage/index.jsx
+++ b/src/components/NotFoundPage/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { Container } from '@openedx/paragon';

--- a/src/components/TagCloud/index.jsx
+++ b/src/components/TagCloud/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Chip } from '@openedx/paragon';
 import { Close } from '@openedx/paragon/icons';

--- a/src/components/Toasts/Toasts.jsx
+++ b/src/components/Toasts/Toasts.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Toast } from '@openedx/paragon';
 
 import { ToastsContext } from './ToastsProvider';

--- a/src/components/Toasts/Toasts.test.jsx
+++ b/src/components/Toasts/Toasts.test.jsx
@@ -1,7 +1,4 @@
-import React from 'react';
-import {
-  render, screen, act,
-} from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import userEvent from '@testing-library/user-event';
 import ToastsProvider, { ToastsContext } from './ToastsProvider';

--- a/src/components/Toasts/ToastsProvider.jsx
+++ b/src/components/Toasts/ToastsProvider.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   createContext,
   useState,
   useMemo,

--- a/src/components/academies/AcademyContentCard.jsx
+++ b/src/components/academies/AcademyContentCard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Button,
   CardGrid,

--- a/src/components/academies/AcademyDetailPage.jsx
+++ b/src/components/academies/AcademyDetailPage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import {
   Container, Breadcrumb,
 } from '@openedx/paragon';

--- a/src/components/academies/GoToAcademy.jsx
+++ b/src/components/academies/GoToAcademy.jsx
@@ -1,9 +1,7 @@
 import { Link } from 'react-router-dom';
 import { Button } from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import React from 'react';
-import useEnterpriseCustomer from '../app/data/hooks/useEnterpriseCustomer';
-import { useAcademies } from '../app/data';
+import { useEnterpriseCustomer, useAcademies } from '../app/data';
 
 const GoToAcademy = () => {
   const { data: academies } = useAcademies();

--- a/src/components/academies/PathwaysSection.jsx
+++ b/src/components/academies/PathwaysSection.jsx
@@ -1,5 +1,4 @@
 import { Button, Container, useToggle } from '@openedx/paragon';
-import React from 'react';
 import PropTypes from 'prop-types';
 import DOMPurify from 'dompurify';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';

--- a/src/components/academies/tests/AcademyDetailPage.test.jsx
+++ b/src/components/academies/tests/AcademyDetailPage.test.jsx
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/academies/tests/PathwaysSection.test.jsx
+++ b/src/components/academies/tests/PathwaysSection.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/app/data/hooks/index.js
+++ b/src/components/app/data/hooks/index.js
@@ -47,3 +47,4 @@ export { default as useVideoDetails } from './useVideoDetails';
 export { default as useVideoCourseMetadata } from './useVideoCourseMetadata';
 export { default as useVideoCourseReviews } from './useVideoCourseReviews';
 export { default as useBFF } from './useBFF';
+export { default as useIsBFFEnabled } from './useIsBFFEnabled';

--- a/src/components/app/data/hooks/useBFF.js
+++ b/src/components/app/data/hooks/useBFF.js
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { logError } from '@edx/frontend-platform/logging';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 import { resolveBFFQuery } from '../queries';
+import useEnterpriseFeatures from './useEnterpriseFeatures';
 
 /**
  * Uses the route to determine which API call to make for the BFF
@@ -19,13 +20,17 @@ export default function useBFF({
   fallbackQueryConfig = null,
 }) {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
+  const enterpriseFeatures = useEnterpriseFeatures();
   const { enterpriseSlug } = useParams();
   const location = useLocation();
 
   // Determine the BFF query to use based on the current location
   const matchedBFFQuery = resolveBFFQuery(
     location.pathname,
-    { enterpriseCustomerUuid: enterpriseCustomer.uuid },
+    {
+      enterpriseCustomerUuid: enterpriseCustomer.uuid,
+      enterpriseFeatures,
+    },
   );
 
   // Determine which query to call, the original hook or the new BFF

--- a/src/components/app/data/hooks/useDefaultSearchFilters.test.js
+++ b/src/components/app/data/hooks/useDefaultSearchFilters.test.js
@@ -1,7 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import * as frontendEnterpriseCatalogSearch from '@edx/frontend-enterprise-catalog-search';
 import { SearchContext, SHOW_ALL_NAME } from '@edx/frontend-enterprise-catalog-search';
-import React from 'react';
 import useDefaultSearchFilters from './useDefaultSearchFilters';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 import useSearchCatalogs from './useSearchCatalogs';

--- a/src/components/app/data/hooks/useEnterpriseFeatures.js
+++ b/src/components/app/data/hooks/useEnterpriseFeatures.js
@@ -4,6 +4,14 @@ export default function useEnterpriseFeatures(queryOptions = {}) {
   const { select, ...queryOptionsRest } = queryOptions;
   return useEnterpriseLearner({
     ...queryOptionsRest,
-    select: (data) => data.enterpriseFeatures,
+    select: (data) => {
+      if (select) {
+        return select({
+          original: data,
+          transformed: data?.enterpriseFeatures,
+        });
+      }
+      return data?.enterpriseFeatures;
+    },
   });
 }

--- a/src/components/app/data/hooks/useEnterpriseFeatures.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseFeatures.test.jsx
@@ -30,13 +30,35 @@ describe('useEnterpriseFeatures', () => {
       </AppContext.Provider>
     </QueryClientProvider>
   );
+
   beforeEach(() => {
     jest.clearAllMocks();
     fetchEnterpriseLearnerData.mockResolvedValue(mockEnterpriseLearnerData);
   });
-  it('should return enterprise features correctly', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useEnterpriseFeatures(), { wrapper: Wrapper });
+
+  it.each([
+    { hasQueryOptions: false },
+    { hasQueryOptions: true },
+  ])('should return enterprise features correctly (%s)', async ({ hasQueryOptions }) => {
+    const mockSelect = jest.fn(data => data.transformed);
+    const { result, waitForNextUpdate } = renderHook(
+      () => {
+        if (hasQueryOptions) {
+          return useEnterpriseFeatures({ select: mockSelect });
+        }
+        return useEnterpriseFeatures();
+      },
+      { wrapper: Wrapper },
+    );
     await waitForNextUpdate();
+
+    if (hasQueryOptions) {
+      expect(mockSelect).toHaveBeenCalledWith({
+        original: mockEnterpriseLearnerData,
+        transformed: mockEnterpriseFeatures,
+      });
+    }
+
     const actualEnterpriseFeatures = result.current.data;
     expect(actualEnterpriseFeatures).toEqual(mockEnterpriseFeatures);
   });

--- a/src/components/app/data/hooks/useIsBFFEnabled.js
+++ b/src/components/app/data/hooks/useIsBFFEnabled.js
@@ -4,6 +4,6 @@ import useEnterpriseFeatures from './useEnterpriseFeatures';
 
 export default function useIsBFFEnabled() {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const { data: enterpriseFeatures } = useEnterpriseFeatures();
+  const enterpriseFeatures = useEnterpriseFeatures();
   return isBFFEnabled(enterpriseCustomer.uuid, enterpriseFeatures);
 }

--- a/src/components/app/data/hooks/useIsBFFEnabled.js
+++ b/src/components/app/data/hooks/useIsBFFEnabled.js
@@ -1,0 +1,9 @@
+import { isBFFEnabled } from '../utils';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import useEnterpriseFeatures from './useEnterpriseFeatures';
+
+export default function useIsBFFEnabled() {
+  const { data: enterpriseCustomer } = useEnterpriseCustomer();
+  const { data: enterpriseFeatures } = useEnterpriseFeatures();
+  return isBFFEnabled(enterpriseCustomer.uuid, enterpriseFeatures);
+}

--- a/src/components/app/data/hooks/useIsBFFEnabled.test.js
+++ b/src/components/app/data/hooks/useIsBFFEnabled.test.js
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useIsBFFEnabled from './useIsBFFEnabled';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import useEnterpriseFeatures from './useEnterpriseFeatures';
+import { isBFFEnabled } from '../utils';
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('./useEnterpriseFeatures');
+jest.mock('../utils', () => ({
+  isBFFEnabled: jest.fn(),
+}));
+
+describe('useIsBFFEnabled', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    { hasBFFEnabled: false },
+    { hasBFFEnabled: true },
+  ])('should return expected value based on whether BFF is enabled (%s)', ({ hasBFFEnabled }) => {
+    const mockEnterpriseCustomer = { uuid: '12345' };
+    const mockEnterpriseFeatures = { featureX: true };
+
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    useEnterpriseFeatures.mockReturnValue(mockEnterpriseFeatures);
+    isBFFEnabled.mockReturnValue(hasBFFEnabled);
+
+    const { result } = renderHook(() => useIsBFFEnabled());
+
+    expect(useEnterpriseCustomer).toHaveBeenCalled();
+    expect(useEnterpriseFeatures).toHaveBeenCalled();
+    expect(isBFFEnabled).toHaveBeenCalledWith(mockEnterpriseCustomer.uuid, mockEnterpriseFeatures);
+    expect(result.current).toBe(hasBFFEnabled);
+  });
+});

--- a/src/components/app/data/hooks/useSubscriptions.test.jsx
+++ b/src/components/app/data/hooks/useSubscriptions.test.jsx
@@ -8,8 +8,10 @@ import useEnterpriseCustomer from './useEnterpriseCustomer';
 import useSubscriptions from './useSubscriptions';
 import { LICENSE_STATUS } from '../../../enterprise-user-subsidy/data/constants';
 import { queryEnterpriseLearnerDashboardBFF, resolveBFFQuery } from '../queries';
+import useEnterpriseFeatures from './useEnterpriseFeatures';
 
 jest.mock('./useEnterpriseCustomer');
+jest.mock('./useEnterpriseFeatures');
 jest.mock('../services', () => ({
   ...jest.requireActual('../services'),
   fetchSubscriptions: jest.fn().mockResolvedValue(null),
@@ -18,6 +20,11 @@ jest.mock('../services', () => ({
 jest.mock('../queries', () => ({
   ...jest.requireActual('../queries'),
   resolveBFFQuery: jest.fn(),
+}));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(),
+  useParams: jest.fn(),
 }));
 
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
@@ -34,10 +41,6 @@ const mockSubscriptionsData = {
   licensesByStatus,
   showExpirationNotifications: false,
 };
-jest.mock('react-router-dom', () => ({
-  useLocation: jest.fn(),
-  useParams: jest.fn(),
-}));
 
 describe('useSubscriptions', () => {
   const Wrapper = ({ children }) => (
@@ -49,6 +52,7 @@ describe('useSubscriptions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    useEnterpriseFeatures.mockReturnValue(null);
     fetchSubscriptions.mockResolvedValue(mockSubscriptionsData);
     useLocation.mockReturnValue({ pathname: '/test-enterprise' });
     useParams.mockReturnValue({ enterpriseSlug: 'test-enterprise' });

--- a/src/components/app/data/queries/utils.js
+++ b/src/components/app/data/queries/utils.js
@@ -1,6 +1,6 @@
 import { matchPath } from 'react-router-dom';
 import { queryEnterpriseLearnerDashboardBFF } from './queries';
-import { isBFFEnabledForEnterpriseCustomer } from '../utils';
+import { isBFFEnabled } from '../utils';
 
 /**
  * Resolves the appropriate BFF query function to use for the current route.
@@ -9,11 +9,10 @@ import { isBFFEnabledForEnterpriseCustomer } from '../utils';
  * @returns {Function|null} The BFF query function to use for the current route, or null if no match is found.
  */
 export function resolveBFFQuery(pathname, options = {}) {
-  const { enterpriseCustomerUuid } = options;
+  const { enterpriseCustomerUuid, enterpriseFeatures } = options;
 
-  // Exit early if BFF is not enabled for the enterprise customer
-  const isBFFEnabledForCustomer = isBFFEnabledForEnterpriseCustomer(enterpriseCustomerUuid);
-  if (!isBFFEnabledForCustomer) {
+  // Exit early if BFF is not enabled for the enterprise customer and/or request user
+  if (!isBFFEnabled(enterpriseCustomerUuid, enterpriseFeatures)) {
     return null;
   }
 

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -907,3 +907,16 @@ export function isBFFEnabledForEnterpriseCustomer(enterpriseCustomerUuid) {
   }
   return FEATURE_ENABLE_BFF_API_FOR_ENTERPRISE_CUSTOMERS.includes(enterpriseCustomerUuid);
 }
+
+export function isBFFEnabled(enterpriseCustomerUuid, enterpriseFeatures) {
+  // Check the following conditions:
+  // 1. BFF is enabled for the enterprise customer.
+  // 2. BFF is enabled for the request user via Waffle flag (supporting percentage-based rollout)
+  const isBFFEnabledForCustomer = isBFFEnabledForEnterpriseCustomer(enterpriseCustomerUuid);
+  if (isBFFEnabledForCustomer || enterpriseFeatures?.enterpriseLearnerBFFEnabled) {
+    return true;
+  }
+
+  // Otherwise, BFF is not enabled.
+  return false;
+}

--- a/src/components/app/routes/RouteErrorBoundary.test.jsx
+++ b/src/components/app/routes/RouteErrorBoundary.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { useAsyncError, useRouteError } from 'react-router-dom';
 import { screen } from '@testing-library/react';

--- a/src/components/app/routes/RouterFallback.test.jsx
+++ b/src/components/app/routes/RouterFallback.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/app/routes/data/utils.js
+++ b/src/components/app/routes/data/utils.js
@@ -47,8 +47,15 @@ export async function ensureEnterpriseAppData({
   userEmail,
   queryClient,
   requestUrl,
+  enterpriseFeatures,
 }) {
-  const matchedBFFQuery = resolveBFFQuery(requestUrl.pathname, { enterpriseCustomerUuid: enterpriseCustomer.uuid });
+  const matchedBFFQuery = resolveBFFQuery(
+    requestUrl.pathname,
+    {
+      enterpriseCustomerUuid: enterpriseCustomer.uuid,
+      enterpriseFeatures,
+    },
+  );
   const enterpriseAppDataQueries = [];
   if (!matchedBFFQuery) {
     const subscriptionsQuery = querySubscriptions(enterpriseCustomer.uuid);

--- a/src/components/app/routes/loaders/rootLoader.ts
+++ b/src/components/app/routes/loaders/rootLoader.ts
@@ -68,6 +68,7 @@ const makeRootLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function ma
       userEmail,
       queryClient,
       requestUrl,
+      enterpriseFeatures: enterpriseCustomer.enterpriseFeatures,
     });
 
     // Redirect to the same URL without a trailing slash, if applicable.

--- a/src/components/budget-expiry-notification/index.jsx
+++ b/src/components/budget-expiry-notification/index.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import {
   ActionRow,
   Alert, AlertModal,

--- a/src/components/budget-expiry-notification/tests/BudgetExpiryNotification.test.jsx
+++ b/src/components/budget-expiry-notification/tests/BudgetExpiryNotification.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/contact-admin-mailto/index.jsx
+++ b/src/components/contact-admin-mailto/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MailtoLink } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { getContactEmail } from '../../utils/common';

--- a/src/components/course/CourseEnrollmentFailedAlert.jsx
+++ b/src/components/course/CourseEnrollmentFailedAlert.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom';
 import { Container, Alert } from '@openedx/paragon';

--- a/src/components/course/CourseRecommendationCard.jsx
+++ b/src/components/course/CourseRecommendationCard.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Card, Truncate } from '@openedx/paragon';

--- a/src/components/course/CourseSidebarListItem.jsx
+++ b/src/components/course/CourseSidebarListItem.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Col, Icon, Row } from '@openedx/paragon';
 

--- a/src/components/course/VerifiedCertPitch.jsx
+++ b/src/components/course/VerifiedCertPitch.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Icon } from '@openedx/paragon';
 import { ContentPasteGo, RocketLaunch } from '@openedx/paragon/icons';

--- a/src/components/course/course-header/CoursePreview.jsx
+++ b/src/components/course/course-header/CoursePreview.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import loadable from '@loadable/component';
 

--- a/src/components/course/course-header/CourseRunCardStatus.jsx
+++ b/src/components/course/course-header/CourseRunCardStatus.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Card } from '@openedx/paragon';
 import { Lock } from '@openedx/paragon/icons';

--- a/src/components/course/course-header/RedemptionStatusText.jsx
+++ b/src/components/course/course-header/RedemptionStatusText.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl, defineMessages } from '@edx/frontend-platform/i18n';
 

--- a/src/components/course/course-header/course-run-actions/BasicNavigateToCourseware.jsx
+++ b/src/components/course/course-header/course-run-actions/BasicNavigateToCourseware.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';

--- a/src/components/course/course-header/course-run-actions/NavigateToCourseware.jsx
+++ b/src/components/course/course-header/course-run-actions/NavigateToCourseware.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import BasicNavigateToCourseware from './BasicNavigateToCourseware';

--- a/src/components/course/course-header/course-run-actions/UpgradeAndNavigateToCourseware.jsx
+++ b/src/components/course/course-header/course-run-actions/UpgradeAndNavigateToCourseware.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 

--- a/src/components/course/course-header/tests/CourseHeader.test.jsx
+++ b/src/components/course/course-header/tests/CourseHeader.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/course/course-header/tests/CoursePreview.test.jsx
+++ b/src/components/course/course-header/tests/CoursePreview.test.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import '@testing-library/jest-dom/extend-expect';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/src/components/course/course-header/tests/CourseRunCard.test.jsx
+++ b/src/components/course/course-header/tests/CourseRunCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/course/course-header/tests/CourseRunCardStatus.test.jsx
+++ b/src/components/course/course-header/tests/CourseRunCardStatus.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/course/course-header/tests/DeprecatedCourseRunCard.test.jsx
+++ b/src/components/course/course-header/tests/DeprecatedCourseRunCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import dayjs from 'dayjs';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ensureConfig, getConfig } from '@edx/frontend-platform';
 import { hasFeatureFlagEnabled } from '@edx/frontend-enterprise-utils';
 import { Button, Hyperlink, MailtoLink } from '@openedx/paragon';

--- a/src/components/course/enrollment/EnrollAction.jsx
+++ b/src/components/course/enrollment/EnrollAction.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import ToCoursewarePage from './components/ToCoursewarePage';

--- a/src/components/course/enrollment/common.jsx
+++ b/src/components/course/enrollment/common.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@openedx/paragon';
 

--- a/src/components/course/enrollment/components/DisabledEnroll.jsx
+++ b/src/components/course/enrollment/components/DisabledEnroll.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import { EnrollButtonCta } from '../common';

--- a/src/components/course/enrollment/components/ToCoursewarePage.jsx
+++ b/src/components/course/enrollment/components/ToCoursewarePage.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import { EnrollButtonCta } from '../common';

--- a/src/components/course/enrollment/components/ToExecutiveEducation2UEnrollment.jsx
+++ b/src/components/course/enrollment/components/ToExecutiveEducation2UEnrollment.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@openedx/paragon';
 import { Link } from 'react-router-dom';

--- a/src/components/course/enrollment/tests/EnrollAction.test.jsx
+++ b/src/components/course/enrollment/tests/EnrollAction.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/course/enrollment/tests/ToEcomBasketPage.test.jsx
+++ b/src/components/course/enrollment/tests/ToEcomBasketPage.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/course/tests/CourseAssociatedPrograms.test.jsx
+++ b/src/components/course/tests/CourseAssociatedPrograms.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/course/tests/CourseEnrollmentFailedAlert.test.jsx
+++ b/src/components/course/tests/CourseEnrollmentFailedAlert.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useLocation } from 'react-router-dom';
 import {
   screen, render,

--- a/src/components/course/tests/CoursePage.test.jsx
+++ b/src/components/course/tests/CoursePage.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/course/tests/CourseRecommendationCard.test.jsx
+++ b/src/components/course/tests/CourseRecommendationCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/course/tests/CourseRecommendations.test.jsx
+++ b/src/components/course/tests/CourseRecommendations.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/course/tests/CourseSidebarListItem.test.jsx
+++ b/src/components/course/tests/CourseSidebarListItem.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import '@testing-library/jest-dom/extend-expect';
 import { Person } from '@openedx/paragon/icons';

--- a/src/components/course/tests/CourseSidebarPrice.test.jsx
+++ b/src/components/course/tests/CourseSidebarPrice.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/course/tests/CourseSkills.test.jsx
+++ b/src/components/course/tests/CourseSkills.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/course/tests/CreatedBy.test.jsx
+++ b/src/components/course/tests/CreatedBy.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/course/tests/EnrollModal.test.jsx
+++ b/src/components/course/tests/EnrollModal.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import '@testing-library/jest-dom/extend-expect';
 import { screen, render } from '@testing-library/react';

--- a/src/components/course/tests/SubsidyRequestButton.test.jsx
+++ b/src/components/course/tests/SubsidyRequestButton.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, render, waitFor } from '@testing-library/react';
 import { useQueryClient } from '@tanstack/react-query';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/course/tests/VerifiedCertPitch.test.jsx
+++ b/src/components/course/tests/VerifiedCertPitch.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { cloneElement, useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import {
   Alert, Container, Tabs, useToggle,
@@ -83,7 +83,7 @@ const DashboardPage = () => {
         activeKey={activeTab}
         onSelect={onSelectHandler}
       >
-        {tabs.map((tab) => React.cloneElement(tab, { key: tab.props.eventKey }))}
+        {tabs.map((tab) => cloneElement(tab, { key: tab.props.eventKey }))}
       </Tabs>
       <IntegrationWarningModal isEnabled={enterpriseCustomer.showIntegrationWarning} />
       {/* ExpiredSubscriptionModal is specifically tailored for learners with an expired license and is

--- a/src/components/dashboard/DashboardPage.jsx
+++ b/src/components/dashboard/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import {
   Alert, Container, Tabs, useToggle,

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import {
   ActionRow, AlertModal, Button, MailtoLink, useToggle,
 } from '@openedx/paragon';

--- a/src/components/dashboard/data/dashboardLoader.ts
+++ b/src/components/dashboard/data/dashboardLoader.ts
@@ -37,7 +37,13 @@ const makeDashboardLoader: Types.MakeRouteLoaderFunctionWithQueryClient = functi
       enterpriseSlug,
     });
 
-    const dashboardBFFQuery = resolveBFFQuery(requestUrl.pathname, { enterpriseCustomerUuid: enterpriseCustomer.uuid });
+    const dashboardBFFQuery = resolveBFFQuery(
+      requestUrl.pathname,
+      {
+        enterpriseCustomerUuid: enterpriseCustomer.uuid,
+        enterpriseFeatures: enterpriseCustomer.enterpriseFeatures,
+      },
+    );
     const loadEnrollmentsPoliciesAndRedirectForNewUsers = Promise.all([
       queryClient.ensureQueryData(
         dashboardBFFQuery

--- a/src/components/dashboard/main-content/CoursesTabComponent.jsx
+++ b/src/components/dashboard/main-content/CoursesTabComponent.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Row,
   MediaQuery,

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -62,7 +62,7 @@ const CourseEnrollments = ({ children }) => {
     },
   } = useEnterpriseCourseEnrollments();
 
-  const { data: enterpriseFeatures } = useEnterpriseFeatures();
+  const enterpriseFeatures = useEnterpriseFeatures();
   const {
     hasCourseEnrollments,
     currentCourseEnrollments,

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollmentsEmptyState.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollmentsEmptyState.jsx
@@ -11,7 +11,7 @@ import NewGroupAssignmentAlert from './NewGroupAssignmentAlert';
 const CourseEnrollmentsEmptyState = () => {
   const { data: canOnlyViewHighlightSets } = useCanOnlyViewHighlights();
   const { data: academies } = useAcademies();
-  const { data: enterpriseFeatures } = useEnterpriseFeatures();
+  const enterpriseFeatures = useEnterpriseFeatures();
   const {
     showNewGroupAssociationAlert,
     dismissGroupAssociationAlert,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/CompletedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/CompletedCourseCard.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform/config';

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/Notification.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/Notification.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/RequestedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/RequestedCourseCard.jsx
@@ -1,8 +1,6 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import BaseCourseCard from './BaseCourseCard';
-
 import { COURSE_STATUSES } from '../data/constants';
 
 const RequestedCourseCard = (props) => (

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/SavedForLaterCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/SavedForLaterCourseCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   Form, Alert, StatefulButton, ActionRow, Button, StandardModal,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/tests/EmailSettingsModal.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/tests/EmailSettingsModal.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mount } from 'enzyme';
 import { StatefulButton } from '@openedx/paragon';
 

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   ActionRow, Button, StandardModal, StatefulButton,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/ModalBody.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/ModalBody.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 
 import ModalError from './ModalError';
 import MarkCompleteModalContext from './MarkCompleteModalContext';

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/ModalError.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/ModalError.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Alert } from '@openedx/paragon';
 import { Error } from '@openedx/paragon/icons';
 

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/tests/MarkCompleteModal.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/tests/MarkCompleteModal.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/ModalBody.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/ModalBody.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 
 import ModalError from './ModalError';
 import MoveToInProgressModalContext from './MoveToInProgressModalContext';

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/ModalError.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/ModalError.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Alert } from '@openedx/paragon';
 import { Error } from '@openedx/paragon/icons';
 

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/MoveToInProgressModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/MoveToInProgressModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   ActionRow, Button, StandardModal, StatefulButton,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/AssignedCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/AssignedCourseCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
@@ -11,7 +10,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import dayjs from '../../../../../../utils/dayjs';
 import BaseCourseCard from '../BaseCourseCard';
 import { ToastsContext } from '../../../../../Toasts';
-import { useEnterpriseCustomer } from '../../../../../app/data';
+import { useEnterpriseCustomer, useIsBFFEnabled } from '../../../../../app/data';
 
 import { queryClient } from '../../../../../../utils/tests';
 import {
@@ -30,6 +29,7 @@ jest.mock('@edx/frontend-enterprise-utils', () => ({
 jest.mock('../../../../../app/data', () => ({
   ...jest.requireActual('../../../../../app/data'),
   useEnterpriseCustomer: jest.fn(),
+  useIsBFFEnabled: jest.fn(),
 }));
 
 const mockAddToast = jest.fn();
@@ -53,6 +53,7 @@ describe('<BaseCourseCard />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    useIsBFFEnabled.mockReturnValue(false);
   });
 
   afterEach(() => {

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/InProgressCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/InProgressCourseCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
@@ -15,6 +14,7 @@ import {
   LICENSE_SUBSIDY_TYPE,
   useCouponCodes,
   useEnterpriseCustomer,
+  useIsBFFEnabled,
 } from '../../../../../app/data';
 import { queryClient } from '../../../../../../utils/tests';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../../../../app/data/services/data/__factories__';
@@ -49,6 +49,7 @@ jest.mock('../../../../../app/data', () => ({
   ...jest.requireActual('../../../../../app/data'),
   useEnterpriseCustomer: jest.fn(),
   useCouponCodes: jest.fn(),
+  useIsBFFEnabled: jest.fn(),
 }));
 
 const InProgressCourseCardWrapper = ({
@@ -78,6 +79,7 @@ describe('<InProgressCourseCard />', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    useIsBFFEnabled.mockReturnValue(false);
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     useCourseUpgradeData.mockReturnValue({
       subsidyForCourse: null,

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.jsx
@@ -9,10 +9,10 @@ import { logError, logInfo } from '@edx/frontend-platform/logging';
 import { ToastsContext } from '../../../../../Toasts';
 import { unenrollFromCourse } from './data';
 import {
-  isBFFEnabledForEnterpriseCustomer,
   queryEnterpriseCourseEnrollments,
   queryEnterpriseLearnerDashboardBFF,
   useEnterpriseCustomer,
+  useIsBFFEnabled,
 } from '../../../../../app/data';
 
 const btnLabels = {
@@ -32,6 +32,8 @@ const UnenrollModal = ({
   const [btnState, setBtnState] = useState('default');
   const [error, setError] = useState(null);
 
+  const isBFFEnabled = useIsBFFEnabled();
+
   const handleClose = () => {
     setBtnState('default');
     setError(null);
@@ -41,7 +43,6 @@ const UnenrollModal = ({
   const updateQueriesAfterUnenrollment = () => {
     const enrollmentForCourseFilter = (enrollment) => enrollment.courseRunId !== courseRunId;
 
-    const isBFFEnabled = isBFFEnabledForEnterpriseCustomer(enterpriseCustomer.uuid);
     if (isBFFEnabled) {
       // Determine which BFF queries need to be updated after unenrolling.
       const dashboardBFFQueryKey = queryEnterpriseLearnerDashboardBFF({

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.test.jsx
@@ -8,11 +8,11 @@ import { unenrollFromCourse } from './data';
 import UnenrollModal from './UnenrollModal';
 import { ToastsContext } from '../../../../../Toasts';
 import {
-  isBFFEnabledForEnterpriseCustomer,
   learnerDashboardBFFResponse,
   queryEnterpriseCourseEnrollments,
   queryEnterpriseLearnerDashboardBFF,
   useEnterpriseCustomer,
+  useIsBFFEnabled,
 } from '../../../../../app/data';
 import { queryClient } from '../../../../../../utils/tests';
 import {
@@ -31,7 +31,7 @@ jest.mock('@edx/frontend-platform/logging', () => ({
 jest.mock('../../../../../app/data', () => ({
   ...jest.requireActual('../../../../../app/data'),
   useEnterpriseCustomer: jest.fn(),
-  isBFFEnabledForEnterpriseCustomer: jest.fn(),
+  useIsBFFEnabled: jest.fn(),
   fetchEnterpriseLearnerDashboard: jest.fn(),
 }));
 
@@ -92,7 +92,7 @@ describe('<UnenrollModal />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    isBFFEnabledForEnterpriseCustomer.mockReturnValue(false);
+    useIsBFFEnabled.mockReturnValue(false);
   });
 
   test('should remain closed when `isOpen` is false', () => {
@@ -173,7 +173,7 @@ describe('<UnenrollModal />', () => {
     existingBFFDashboardQueryData,
     existingEnrollmentsQueryData,
   }) => {
-    isBFFEnabledForEnterpriseCustomer.mockReturnValue(isBFFEnabled);
+    useIsBFFEnabled.mockReturnValue(isBFFEnabled);
     unenrollFromCourse.mockResolvedValueOnce();
     const props = {
       ...baseUnenrollModalProps,

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -24,7 +24,6 @@ import {
   COUPON_CODE_SUBSIDY_TYPE,
   getSubsidyToApplyForCourse,
   groupCourseEnrollmentsByStatus,
-  isBFFEnabledForEnterpriseCustomer,
   isEnrollmentUpgradeable,
   LEARNER_CREDIT_SUBSIDY_TYPE,
   LICENSE_SUBSIDY_TYPE,
@@ -40,6 +39,7 @@ import {
   useEnterpriseCustomerContainsContent,
   useRedeemablePolicies,
   useSubscriptions,
+  useIsBFFEnabled,
 } from '../../../../app/data';
 import { sortAssignmentsByAssignmentStatus, sortedEnrollmentsByEnrollmentDate } from './utils';
 import { ASSIGNMENTS_EXPIRING_WARNING_LOCALSTORAGE_KEY } from '../../../data/constants';
@@ -546,6 +546,9 @@ export function useCourseEnrollmentsBySection(courseEnrollmentsByStatus) {
 export function useUpdateCourseEnrollmentStatus() {
   const queryClient = useQueryClient();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
+
+  const isBFFEnabled = useIsBFFEnabled();
+
   return useCallback(({ courseRunId, newStatus }) => {
     // Transformation to update the course enrollment status.
     const transformUpdatedEnrollment = (enrollment) => {
@@ -558,7 +561,6 @@ export function useUpdateCourseEnrollmentStatus() {
       };
     };
 
-    const isBFFEnabled = isBFFEnabledForEnterpriseCustomer(enterpriseCustomer.uuid);
     if (isBFFEnabled) {
       // Determine which BFF queries need to be updated after updating enrollment status.
       const dashboardBFFQueryKey = queryEnterpriseLearnerDashboardBFF({
@@ -590,7 +592,7 @@ export function useUpdateCourseEnrollmentStatus() {
     }
     const updatedCourseEnrollmentsData = existingCourseEnrollmentsData.map(transformUpdatedEnrollment);
     queryClient.setQueryData(enterpriseCourseEnrollmentsQueryKey, updatedCourseEnrollmentsData);
-  }, [queryClient, enterpriseCustomer]);
+  }, [queryClient, enterpriseCustomer, isBFFEnabled]);
 }
 
 /**

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
@@ -30,7 +30,6 @@ import {
   COURSE_MODES_MAP,
   emptyRedeemableLearnerCreditPolicies,
   ENROLL_BY_DATE_WARNING_THRESHOLD_DAYS,
-  isBFFEnabledForEnterpriseCustomer,
   learnerDashboardBFFResponse,
   queryEnterpriseCourseEnrollments,
   queryEnterpriseLearnerDashboardBFF,
@@ -42,6 +41,7 @@ import {
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
   useEnterpriseCustomerContainsContent,
+  useIsBFFEnabled,
   useRedeemablePolicies,
   useSubscriptions,
 } from '../../../../../app/data';
@@ -77,7 +77,7 @@ jest.mock('../../../../../app/data', () => ({
   useCanUpgradeWithLearnerCredit: jest.fn(),
   useEnterpriseCustomerContainsContent: jest.fn(),
   useCourseRunMetadata: jest.fn(),
-  isBFFEnabledForEnterpriseCustomer: jest.fn(),
+  useIsBFFEnabled: jest.fn(),
 }));
 jest.mock('../../../../../course/data/hooks', () => ({
   ...jest.requireActual('../../../../../course/data/hooks'),
@@ -1213,7 +1213,7 @@ describe('useUpdateCourseEnrollmentStatus', () => {
     existingBFFDashboardQueryData,
     existingEnrollmentsQueryData,
   }) => {
-    isBFFEnabledForEnterpriseCustomer.mockReturnValue(isBFFEnabled);
+    useIsBFFEnabled.mockReturnValue(isBFFEnabled);
     const mockCorrectCourseRunId = mockEnterpriseCourseEnrollment.courseRunId;
     const mockIncorrectCourseRunId = 'course-v1:edX+DemoY+Demo';
     const mockCourseRunId = doesCourseRunIdMatch ? mockCorrectCourseRunId : mockIncorrectCourseRunId;

--- a/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
@@ -25,6 +24,7 @@ import {
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
   useEnterpriseFeatures,
+  useIsBFFEnabled,
 } from '../../../../app/data';
 import { sortAssignmentsByAssignmentStatus } from '../data/utils';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../../../app/data/services/data/__factories__';
@@ -60,10 +60,16 @@ jest.mock('../../../../../config', () => ({
     FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT: true,
   },
 }));
-
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: jest.fn(),
+}));
+jest.mock('../../../../app/data', () => ({
+  ...jest.requireActual('../../../../app/data'),
+  useEnterpriseCourseEnrollments: jest.fn(),
+  useEnterpriseCustomer: jest.fn(),
+  useEnterpriseFeatures: jest.fn(),
+  useIsBFFEnabled: jest.fn(),
 }));
 
 const inProgCourseRun = createCourseEnrollmentWithStatus({ status: COURSE_STATUSES.inProgress });
@@ -103,13 +109,6 @@ const assignmentData = {
   state: 'cancelled',
 };
 
-jest.mock('../../../../app/data', () => ({
-  ...jest.requireActual('../../../../app/data'),
-  useEnterpriseCourseEnrollments: jest.fn(),
-  useEnterpriseCustomer: jest.fn(),
-  useEnterpriseFeatures: jest.fn(),
-}));
-
 const mockAuthenticatedUser = authenticatedUserFactory();
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
 
@@ -136,6 +135,7 @@ describe('Course enrollments', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useLocation.mockReturnValue({});
+    useIsBFFEnabled.mockReturnValue(false);
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     useEnterpriseCourseEnrollments.mockReturnValue({
       data: {

--- a/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
@@ -152,7 +152,7 @@ describe('Course enrollments', () => {
 
     updateCourseCompleteStatusRequest.mockImplementation(() => ({ data: {} }));
     sortAssignmentsByAssignmentStatus.mockReturnValue([assignmentData]);
-    useEnterpriseFeatures.mockReturnValue({ data: { enterpriseGroupsV1: false } });
+    useEnterpriseFeatures.mockReturnValue({ enterpriseGroupsV1: false });
     useGroupAssociationsAlert.mockReturnValue({
       showNewGroupAssociationAlert: true,
       dismissGroupAssociationAlert: mockDismissGroupAssociationAlert,
@@ -277,7 +277,7 @@ describe('Course enrollments', () => {
   it(
     'renders NewGroupAssignmentAlert when showNewGroupAssociationAlert is true',
     async () => {
-      useEnterpriseFeatures.mockReturnValue({ data: { enterpriseGroupsV1: true } });
+      useEnterpriseFeatures.mockReturnValue({ enterpriseGroupsV1: true });
       useGroupAssociationsAlert.mockReturnValue({
         showNewGroupAssociationAlert: true,
         dismissGroupAssociationAlert: mockDismissGroupAssociationAlert,

--- a/src/components/dashboard/sidebar/CouponCodesSummaryCard.jsx
+++ b/src/components/dashboard/sidebar/CouponCodesSummaryCard.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   Badge, Card, Stack, useToggle,

--- a/src/components/dashboard/sidebar/DashboardSidebar.jsx
+++ b/src/components/dashboard/sidebar/DashboardSidebar.jsx
@@ -1,6 +1,5 @@
-import React from 'react';
-
 import { Card } from '@openedx/paragon';
+
 import SupportInformation from './SupportInformation';
 import SubsidiesSummary from './SubsidiesSummary';
 

--- a/src/components/dashboard/sidebar/LearnerCreditSummaryCard.jsx
+++ b/src/components/dashboard/sidebar/LearnerCreditSummaryCard.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Badge, Card, Stack } from '@openedx/paragon';
 import dayjs from 'dayjs';

--- a/src/components/dashboard/sidebar/SubscriptionSummaryCard.jsx
+++ b/src/components/dashboard/sidebar/SubscriptionSummaryCard.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Badge, Card, Stack } from '@openedx/paragon';
 import { defineMessages, FormattedMessage } from '@edx/frontend-platform/i18n';

--- a/src/components/dashboard/sidebar/data/hooks/useSubscriptionSummaryCard.jsx
+++ b/src/components/dashboard/sidebar/data/hooks/useSubscriptionSummaryCard.jsx
@@ -1,5 +1,4 @@
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
-import React from 'react';
 import { Card, useToggle } from '@openedx/paragon';
 import { WarningFilled } from '@openedx/paragon/icons';
 import { useBrowseAndRequest, useSubscriptions } from '../../../../app/data';

--- a/src/components/dashboard/sidebar/tests/CouponCodesSummaryCard.test.jsx
+++ b/src/components/dashboard/sidebar/tests/CouponCodesSummaryCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen, render } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
+++ b/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import dayjs from 'dayjs';
 import '@testing-library/jest-dom/extend-expect';
 import { screen } from '@testing-library/react';

--- a/src/components/dashboard/sidebar/tests/LearnerCreditSummaryCard.test.jsx
+++ b/src/components/dashboard/sidebar/tests/LearnerCreditSummaryCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/dashboard/sidebar/tests/SubscriptionSummaryCard.test.jsx
+++ b/src/components/dashboard/sidebar/tests/SubscriptionSummaryCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/dashboard/tests/CourseRecommendations.test.jsx
+++ b/src/components/dashboard/tests/CourseRecommendations.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/dashboard/tests/DashboardPage.test.jsx
+++ b/src/components/dashboard/tests/DashboardPage.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen, waitFor } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/enterprise-banner/tests/EnterpriseBanner.test.jsx
+++ b/src/components/enterprise-banner/tests/EnterpriseBanner.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform/config';
@@ -7,7 +7,7 @@ import { getLoggingService } from '@edx/frontend-platform/logging';
 import { isDefinedAndNotNull } from '../../utils/common';
 import { useAlgoliaSearch } from '../../utils/hooks';
 import { pushUserCustomerAttributes } from '../../utils/optimizely';
-import { isBFFEnabledForEnterpriseCustomer, useEnterpriseCustomer } from '../app/data';
+import { useEnterpriseCustomer, useIsBFFEnabled } from '../app/data';
 
 /**
  * Custom hook to set custom attributes for logging service:
@@ -16,6 +16,8 @@ import { isBFFEnabledForEnterpriseCustomer, useEnterpriseCustomer } from '../app
  */
 function useLoggingCustomAttributes() {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
+  const isBFFEnabled = useIsBFFEnabled();
+
   useEffect(() => {
     if (isDefinedAndNotNull(enterpriseCustomer)) {
       pushUserCustomerAttributes(enterpriseCustomer);
@@ -23,12 +25,9 @@ function useLoggingCustomAttributes() {
       // Set custom attributes via logging service
       const loggingService = getLoggingService();
       loggingService.setCustomAttribute('enterprise_customer_uuid', enterpriseCustomer.uuid);
-      loggingService.setCustomAttribute(
-        'is_bff_enabled',
-        isBFFEnabledForEnterpriseCustomer(enterpriseCustomer.uuid),
-      );
+      loggingService.setCustomAttribute('is_bff_enabled', isBFFEnabled);
     }
-  }, [enterpriseCustomer]);
+  }, [enterpriseCustomer, isBFFEnabled]);
 }
 
 const EnterprisePage = ({ children }) => {

--- a/src/components/enterprise-page/EnterprisePage.test.jsx
+++ b/src/components/enterprise-page/EnterprisePage.test.jsx
@@ -4,13 +4,13 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { getLoggingService } from '@edx/frontend-platform/logging';
 
 import EnterprisePage from './EnterprisePage';
-import { isBFFEnabledForEnterpriseCustomer, useEnterpriseCustomer } from '../app/data';
+import { useEnterpriseCustomer, useIsBFFEnabled } from '../app/data';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../app/data/services/data/__factories__';
 
 jest.mock('../app/data', () => ({
   ...jest.requireActual('../app/data'),
   useEnterpriseCustomer: jest.fn(),
-  isBFFEnabledForEnterpriseCustomer: jest.fn().mockReturnValue(false),
+  useIsBFFEnabled: jest.fn().mockReturnValue(false),
 }));
 
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
@@ -82,7 +82,7 @@ describe('<EnterprisePage />', () => {
     { isBFFEnabled: true },
   ])('sets custom attributes via logging service (%s)', ({ isBFFEnabled }) => {
     // Mock the BFF feature flag
-    isBFFEnabledForEnterpriseCustomer.mockReturnValue(isBFFEnabled);
+    useIsBFFEnabled.mockReturnValue(isBFFEnabled);
 
     // Mount the component
     const wrapper = mount(

--- a/src/components/enterprise-user-subsidy/enterprise-offers/EnterpriseOffersBalanceAlert.jsx
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/EnterpriseOffersBalanceAlert.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 

--- a/src/components/enterprise-user-subsidy/enterprise-offers/tests/EnterpriseOffersBalanceAlert.test.jsx
+++ b/src/components/enterprise-user-subsidy/enterprise-offers/tests/EnterpriseOffersBalanceAlert.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/error-page/ErrorPage.test.jsx
+++ b/src/components/error-page/ErrorPage.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { AppContext } from '@edx/frontend-platform/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/error-page/ErrorPageContent.jsx
+++ b/src/components/error-page/ErrorPageContent.jsx
@@ -1,8 +1,5 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Container,
-} from '@openedx/paragon';
+import { Container } from '@openedx/paragon';
 import classNames from 'classnames';
 
 /**

--- a/src/components/error-page/ErrorPageHeader.jsx
+++ b/src/components/error-page/ErrorPageHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import {
   AvatarButton,
   Container,

--- a/src/components/executive-education-2u/EnrollmentCompletedSummaryCard.test.jsx
+++ b/src/components/executive-education-2u/EnrollmentCompletedSummaryCard.test.jsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import React from 'react';
 import EnrollmentCompletedSummaryCard from './components/EnrollmentCompletedSummaryCard';
 import { renderWithRouterProvider } from '../../utils/tests';
 

--- a/src/components/executive-education-2u/ExecutiveEducation2UError.jsx
+++ b/src/components/executive-education-2u/ExecutiveEducation2UError.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 

--- a/src/components/executive-education-2u/UserEnrollmentForm.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import {
@@ -20,7 +20,6 @@ import { checkoutExecutiveEducation2U, isDuplicateExternalCourseOrder, toISOStri
 import { useStatefulEnroll } from '../stateful-enroll/data';
 import { CourseContext } from '../course/CourseContextProvider';
 import {
-  isBFFEnabledForEnterpriseCustomer,
   LEARNER_CREDIT_SUBSIDY_TYPE,
   queryCanRedeemContextQueryKey,
   queryEnterpriseCourseEnrollments,
@@ -29,6 +28,7 @@ import {
   useCourseMetadata,
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
+  useIsBFFEnabled,
 } from '../app/data';
 import { useUserSubsidyApplicableToCourse } from '../course/data';
 
@@ -49,13 +49,14 @@ const UserEnrollmentForm = ({ className }) => {
     setExternalCourseFormSubmissionError,
   } = useContext(CourseContext);
 
+  const isBFFEnabled = useIsBFFEnabled();
+
   const { data: { courseEntitlementProductSku } } = useCourseMetadata();
 
   const [isFormSubmitted, setIsFormSubmitted] = useState(false);
   const [enrollButtonState, setEnrollButtonState] = useState('default');
 
   const handleQueryInvalidationForEnrollSuccess = () => {
-    const isBFFEnabled = isBFFEnabledForEnterpriseCustomer(enterpriseCustomer.uuid);
     const canRedeemQueryKey = queryCanRedeemContextQueryKey(enterpriseCustomer.uuid, courseKey);
     const redeemablePoliciesQueryKey = queryRedeemablePolicies({
       enterpriseUuid: enterpriseCustomer.uuid,

--- a/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
+++ b/src/components/executive-education-2u/UserEnrollmentForm.test.jsx
@@ -21,8 +21,8 @@ import {
   useCourseMetadata,
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
-  isBFFEnabledForEnterpriseCustomer,
   queryEnterpriseLearnerDashboardBFF,
+  useIsBFFEnabled,
 } from '../app/data';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../app/data/services/data/__factories__';
 import { queryClient, renderWithRouter, renderWithRouterProvider } from '../../utils/tests';
@@ -61,7 +61,7 @@ jest.mock('../app/data', () => ({
   useEnterpriseCustomer: jest.fn(),
   useEnterpriseCourseEnrollments: jest.fn(),
   useCourseMetadata: jest.fn(),
-  isBFFEnabledForEnterpriseCustomer: jest.fn(),
+  useIsBFFEnabled: jest.fn(),
 }));
 
 jest.mock('../course/data', () => ({
@@ -135,7 +135,7 @@ describe('UserEnrollmentForm', () => {
       missingUserSubsidyReason: undefined,
     });
     useCourseMetadata.mockReturnValue({ data: {} });
-    isBFFEnabledForEnterpriseCustomer.mockReturnValue(false);
+    useIsBFFEnabled.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -253,7 +253,7 @@ describe('UserEnrollmentForm', () => {
   }) => {
     const mockTermsAcceptedAt = '2022-09-28T13:35:06Z';
     MockDate.set(mockTermsAcceptedAt);
-    isBFFEnabledForEnterpriseCustomer.mockReturnValue(isBFFEnabled);
+    useIsBFFEnabled.mockReturnValue(isBFFEnabled);
     useUserSubsidyApplicableToCourse.mockReturnValue({
       userSubsidyApplicableToCourse: {
         subsidyType: LEARNER_CREDIT_SUBSIDY_TYPE,

--- a/src/components/executive-education-2u/components/RegistrationSummaryCard.jsx
+++ b/src/components/executive-education-2u/components/RegistrationSummaryCard.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Card, Col, Row } from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';

--- a/src/components/integration-warning-modal/IntegrationWarningModal.jsx
+++ b/src/components/integration-warning-modal/IntegrationWarningModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import Cookies from 'universal-cookie';
 import { Button, AlertModal } from '@openedx/paragon';

--- a/src/components/integration-warning-modal/ModalBody.jsx
+++ b/src/components/integration-warning-modal/ModalBody.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const ModalBody = () => (
   <div>
     <p className="m-0">

--- a/src/components/layout/MainContent.jsx
+++ b/src/components/layout/MainContent.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const MainContent = props => (

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const Sidebar = props => (

--- a/src/components/layout/SidebarBlock.jsx
+++ b/src/components/layout/SidebarBlock.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/components/loading-spinner/LoadingSpinner.jsx
+++ b/src/components/loading-spinner/LoadingSpinner.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import './styles/LoadingSpinner.scss';

--- a/src/components/microlearning/VideoCourseReview.jsx
+++ b/src/components/microlearning/VideoCourseReview.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Icon, OverlayTrigger, Tooltip } from '@openedx/paragon';
 import { StarFilled, StarOutline } from '@openedx/paragon/icons';
 import PropTypes from 'prop-types';

--- a/src/components/microlearning/VideoDetailPage.jsx
+++ b/src/components/microlearning/VideoDetailPage.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import {
@@ -39,7 +39,7 @@ const VideoDetailPage = () => {
   const coursePrice = getCoursePrice(courseMetadata);
   const [pacingType, pacingTypeContent] = useCoursePacingType(courseMetadata?.activeCourseRun);
   const { data: { subscriptionLicense } } = useSubscriptions();
-  const playerRef = React.useRef(null);
+  const playerRef = useRef(null);
   const intl = useIntl();
 
   const customOptions = {

--- a/src/components/microlearning/VideoDetailPage.jsx
+++ b/src/components/microlearning/VideoDetailPage.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import React, { useContext, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import {

--- a/src/components/microlearning/VideoFeedbackCard.jsx
+++ b/src/components/microlearning/VideoFeedbackCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
   Card, Icon, IconButton, ActionRow, Form, Input, Button,

--- a/src/components/microlearning/__mocks__/@loadable/component.jsx
+++ b/src/components/microlearning/__mocks__/@loadable/component.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 // mock the loadable function to load the module eagarly and expose a preload() function
 function loadable(load) {
   let Component;

--- a/src/components/my-career/CategoryCard.jsx
+++ b/src/components/my-career/CategoryCard.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useEffect, useMemo, useState,
 } from 'react';
 import PropTypes from 'prop-types';

--- a/src/components/my-career/LevelBars.jsx
+++ b/src/components/my-career/LevelBars.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Chip } from '@openedx/paragon';
 

--- a/src/components/my-career/MyCareerTabSkeleton.jsx
+++ b/src/components/my-career/MyCareerTabSkeleton.jsx
@@ -4,7 +4,6 @@ import {
   Row,
   Skeleton,
 } from '@openedx/paragon';
-import React from 'react';
 
 const MyCareerTabSkeleton = () => (
   <div className="py-4.5">

--- a/src/components/my-career/SearchJobRole.jsx
+++ b/src/components/my-career/SearchJobRole.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform/config';
 import { logError } from '@edx/frontend-platform/logging';

--- a/src/components/my-career/SkillsRecommendationCourses.jsx
+++ b/src/components/my-career/SkillsRecommendationCourses.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useMemo, useState, useEffect,
 } from 'react';
 import { Link } from 'react-router-dom';

--- a/src/components/my-career/VisualizeCareer.jsx
+++ b/src/components/my-career/VisualizeCareer.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   ActionRow, Button, Icon, Row, TransitionReplace, useToggle,

--- a/src/components/my-career/tests/AddJobRole.test.jsx
+++ b/src/components/my-career/tests/AddJobRole.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/my-career/tests/CategoryCard.test.jsx
+++ b/src/components/my-career/tests/CategoryCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/my-career/tests/LevelBars.test.jsx
+++ b/src/components/my-career/tests/LevelBars.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/my-career/tests/SearchJobRole.test.jsx
+++ b/src/components/my-career/tests/SearchJobRole.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { mount } from 'enzyme';

--- a/src/components/my-career/tests/SkillsRecommendationCourses.test.jsx
+++ b/src/components/my-career/tests/SkillsRecommendationCourses.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/my-career/tests/SpiderChart.test.jsx
+++ b/src/components/my-career/tests/SpiderChart.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/my-career/tests/VisualizeCareer.test.jsx
+++ b/src/components/my-career/tests/VisualizeCareer.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/pathway-progress/PathwayNode.jsx
+++ b/src/components/pathway-progress/PathwayNode.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Badge, Card } from '@openedx/paragon';
 import { useParams } from 'react-router-dom';

--- a/src/components/pathway-progress/PathwayStep.jsx
+++ b/src/components/pathway-progress/PathwayStep.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import { Collapsible, Icon } from '@openedx/paragon';

--- a/src/components/pathway-progress/tests/PathwayNode.test.jsx
+++ b/src/components/pathway-progress/tests/PathwayNode.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/pathway-progress/tests/PathwayProgressListingCard.test.jsx
+++ b/src/components/pathway-progress/tests/PathwayProgressListingCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/pathway-progress/tests/PathwayProgressListingPage.test.jsx
+++ b/src/components/pathway-progress/tests/PathwayProgressListingPage.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { screen } from '@testing-library/react';

--- a/src/components/pathway-progress/tests/PathwayRequirements.test.jsx
+++ b/src/components/pathway-progress/tests/PathwayRequirements.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import PathwayRequirements from '../PathwayRequirements';

--- a/src/components/pathway-progress/tests/PathwayStep.test.jsx
+++ b/src/components/pathway-progress/tests/PathwayStep.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import PathwayStep from '../PathwayStep';

--- a/src/components/pathway-progress/tests/SubscriptionStatusCard.test.jsx
+++ b/src/components/pathway-progress/tests/SubscriptionStatusCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/pathway/PathwayModal.jsx
+++ b/src/components/pathway/PathwayModal.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';

--- a/src/components/pathway/SearchPathwayCard.jsx
+++ b/src/components/pathway/SearchPathwayCard.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { Link } from 'react-router-dom';

--- a/src/components/pathway/tests/PathwayModal.test.jsx
+++ b/src/components/pathway/tests/PathwayModal.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/pathway/tests/SearchPathwayCard.test.jsx
+++ b/src/components/pathway/tests/SearchPathwayCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/preview-expand/PreviewExpand.jsx
+++ b/src/components/preview-expand/PreviewExpand.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Button, Icon } from '@openedx/paragon';

--- a/src/components/program-progress/tests/ProgramListingCard.test.jsx
+++ b/src/components/program-progress/tests/ProgramListingCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { screen } from '@testing-library/react';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';

--- a/src/components/program-progress/tests/ProgramListingPage.test.jsx
+++ b/src/components/program-progress/tests/ProgramListingPage.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/program-progress/tests/ProgramPathwayOpportunity.test.jsx
+++ b/src/components/program-progress/tests/ProgramPathwayOpportunity.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { FormattedMessage, IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/program-progress/tests/ProgramProgressCircle.test.jsx
+++ b/src/components/program-progress/tests/ProgramProgressCircle.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
+++ b/src/components/program-progress/tests/ProgramProgressCourses.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen, render } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/program-progress/tests/ProgramProgressHeader.test.jsx
+++ b/src/components/program-progress/tests/ProgramProgressHeader.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/program-progress/tests/ProgramProgressPage.test.jsx
+++ b/src/components/program-progress/tests/ProgramProgressPage.test.jsx
@@ -2,7 +2,6 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 import { screen } from '@testing-library/react';
-import React from 'react';
 import { ProgramProgressPage } from '../index';
 import { authenticatedUserFactory, enterpriseCustomerFactory, academiesFactory } from '../../app/data/services/data/__factories__';
 import {

--- a/src/components/program-progress/tests/ProgramProgressSidebar.test.jsx
+++ b/src/components/program-progress/tests/ProgramProgressSidebar.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/program/tests/ProgramCTA.test.jsx
+++ b/src/components/program/tests/ProgramCTA.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { screen, render, fireEvent } from '@testing-library/react';

--- a/src/components/program/tests/ProgramCourses.test.jsx
+++ b/src/components/program/tests/ProgramCourses.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/program/tests/ProgramDataBar.test.jsx
+++ b/src/components/program/tests/ProgramDataBar.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import {
   screen, render, fireEvent,

--- a/src/components/program/tests/ProgramEndorsements.test.jsx
+++ b/src/components/program/tests/ProgramEndorsements.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { screen, render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/program/tests/ProgramFAQ.test.jsx
+++ b/src/components/program/tests/ProgramFAQ.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import {
   screen, render, waitFor,

--- a/src/components/program/tests/ProgramHeader.test.jsx
+++ b/src/components/program/tests/ProgramHeader.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/program/tests/ProgramSidebar.test.jsx
+++ b/src/components/program/tests/ProgramSidebar.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/progress-category-bubbles/ProgressCategoryBubbles.jsx
+++ b/src/components/progress-category-bubbles/ProgressCategoryBubbles.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Bubble, Stack } from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';

--- a/src/components/search/ContentTypeSearchResultsContainer.jsx
+++ b/src/components/search/ContentTypeSearchResultsContainer.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import {

--- a/src/components/search/SearchCourse.jsx
+++ b/src/components/search/SearchCourse.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Configure, Index } from 'react-instantsearch-dom';
 import { getConfig } from '@edx/frontend-platform/config';

--- a/src/components/search/SearchCourseCard.jsx
+++ b/src/components/search/SearchCourseCard.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { Link } from 'react-router-dom';

--- a/src/components/search/SearchError.jsx
+++ b/src/components/search/SearchError.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert } from '@openedx/paragon';
 import { Warning } from '@openedx/paragon/icons';

--- a/src/components/search/SearchNoResults.jsx
+++ b/src/components/search/SearchNoResults.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert } from '@openedx/paragon';
 import { ZoomOut } from '@openedx/paragon/icons';

--- a/src/components/search/SearchPage.jsx
+++ b/src/components/search/SearchPage.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SearchData } from '@edx/frontend-enterprise-catalog-search';
 import { useIntl } from '@edx/frontend-platform/i18n';
 

--- a/src/components/search/SearchPathway.jsx
+++ b/src/components/search/SearchPathway.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Configure, Index } from 'react-instantsearch-dom';
 import { getConfig } from '@edx/frontend-platform/config';

--- a/src/components/search/SearchProgram.jsx
+++ b/src/components/search/SearchProgram.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Configure, Index } from 'react-instantsearch-dom';
 import { getConfig } from '@edx/frontend-platform/config';

--- a/src/components/search/SearchProgramCard.jsx
+++ b/src/components/search/SearchProgramCard.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { Link } from 'react-router-dom';

--- a/src/components/search/SearchResults.jsx
+++ b/src/components/search/SearchResults.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connectStateResults } from 'react-instantsearch-dom';

--- a/src/components/search/SearchVideo.jsx
+++ b/src/components/search/SearchVideo.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Configure, Index } from 'react-instantsearch-dom';
 import { getConfig } from '@edx/frontend-platform/config';

--- a/src/components/search/SearchVideoCard.jsx
+++ b/src/components/search/SearchVideoCard.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import { Link } from 'react-router-dom';

--- a/src/components/search/content-highlights/ContentHighlights.jsx
+++ b/src/components/search/content-highlights/ContentHighlights.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Container, Stack } from '@openedx/paragon';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/components/search/content-highlights/HighlightedContentCard.jsx
+++ b/src/components/search/content-highlights/HighlightedContentCard.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Card, Icon, Truncate } from '@openedx/paragon';

--- a/src/components/search/popular-results/PopularResults.jsx
+++ b/src/components/search/popular-results/PopularResults.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { connectStateResults } from 'react-instantsearch-dom';
 import { useNbHitsFromSearchResults } from '@edx/frontend-enterprise-catalog-search';

--- a/src/components/search/popular-results/PopularResultsIndex.jsx
+++ b/src/components/search/popular-results/PopularResultsIndex.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Index, Configure } from 'react-instantsearch-dom';
 import { getConfig } from '@edx/frontend-platform/';

--- a/src/components/search/tests/Search.test.jsx
+++ b/src/components/search/tests/Search.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';

--- a/src/components/search/tests/SearchCourseCard.test.jsx
+++ b/src/components/search/tests/SearchCourseCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/search/tests/SearchPage.test.jsx
+++ b/src/components/search/tests/SearchPage.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/search/tests/SearchProgramCard.test.jsx
+++ b/src/components/search/tests/SearchProgramCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/search/tests/SearchResults.test.jsx
+++ b/src/components/search/tests/SearchResults.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/search/tests/SearchSections.test.jsx
+++ b/src/components/search/tests/SearchSections.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';

--- a/src/components/search/tests/SearchVideoCard.test.jsx
+++ b/src/components/search/tests/SearchVideoCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/site-header/AvatarDropdown.jsx
+++ b/src/components/site-header/AvatarDropdown.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { NavLink, generatePath, useLocation } from 'react-router-dom';
 import { getConfig } from '@edx/frontend-platform/config';

--- a/src/components/site-header/SiteHeaderLogos.jsx
+++ b/src/components/site-header/SiteHeaderLogos.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link, useParams } from 'react-router-dom';
 import edXLogo from '@edx/brand/logo.svg';
 import { Stack } from '@openedx/paragon';

--- a/src/components/site-header/menu/Menu.jsx
+++ b/src/components/site-header/menu/Menu.jsx
@@ -1,8 +1,14 @@
-import React from 'react';
+import {
+  createElement,
+  Component,
+  createRef,
+  Children,
+  cloneElement,
+} from 'react';
 import { CSSTransition } from 'react-transition-group';
 import PropTypes from 'prop-types';
 
-const MenuTrigger = ({ tag, className, ...attributes }) => React.createElement(tag, {
+const MenuTrigger = ({ tag, className, ...attributes }) => createElement(tag, {
   className: `menu-trigger ${className}`,
   ...attributes,
 });
@@ -17,7 +23,7 @@ MenuTrigger.defaultProps = {
 };
 const MenuTriggerType = (<MenuTrigger />).type;
 
-const MenuContent = ({ tag, className, ...attributes }) => React.createElement(tag, {
+const MenuContent = ({ tag, className, ...attributes }) => createElement(tag, {
   className: ['menu-content', className].join(' '),
   ...attributes,
 });
@@ -31,11 +37,11 @@ MenuContent.defaultProps = {
   className: null,
 };
 
-class Menu extends React.Component {
+class Menu extends Component {
   constructor(props) {
     super(props);
 
-    this.menu = React.createRef();
+    this.menu = createRef();
     this.state = {
       expanded: false,
     };
@@ -208,7 +214,7 @@ class Menu extends React.Component {
   }
 
   renderTrigger(node) {
-    return React.cloneElement(node, {
+    return cloneElement(node, {
       onClick: this.onTriggerClick,
       'aria-haspopup': 'menu',
       'aria-expanded': this.state.expanded,
@@ -231,7 +237,7 @@ class Menu extends React.Component {
   render() {
     const { className } = this.props;
 
-    const wrappedChildren = React.Children.map(this.props.children, (child) => {
+    const wrappedChildren = Children.map(this.props.children, (child) => {
       if (child.type === MenuTriggerType) {
         return this.renderTrigger(child);
       }
@@ -240,7 +246,7 @@ class Menu extends React.Component {
 
     const rootClassName = this.state.expanded ? 'menu expanded' : 'menu';
 
-    return React.createElement(this.props.tag, {
+    return createElement(this.props.tag, {
       className: `${rootClassName} ${className}`,
       ref: this.menu,
       onKeyDown: this.onKeyDown,

--- a/src/components/site-header/tests/SiteHeader.test.jsx
+++ b/src/components/site-header/tests/SiteHeader.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { breakpoints } from '@openedx/paragon';

--- a/src/components/skills-quiz-v2/JobCardComponent.jsx
+++ b/src/components/skills-quiz-v2/JobCardComponent.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from 'react';
+import { useContext, useState, useEffect } from 'react';
 import {
   SelectableBox, Chip, Spinner, Stack, Button,
 } from '@openedx/paragon';

--- a/src/components/skills-quiz-v2/SkillsQuizHeader.jsx
+++ b/src/components/skills-quiz-v2/SkillsQuizHeader.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import edxLogo from '../skills-quiz/images/edx-logo.svg';
 

--- a/src/components/skills-quiz-v2/tests/SkillsQuiz.test.jsx
+++ b/src/components/skills-quiz-v2/tests/SkillsQuiz.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/skills-quiz-v2/tests/SkillsQuizForm.test.jsx
+++ b/src/components/skills-quiz-v2/tests/SkillsQuizForm.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import algoliasearch from 'algoliasearch/lite';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/src/components/skills-quiz-v2/tests/SkillsQuizHeader.test.jsx
+++ b/src/components/skills-quiz-v2/tests/SkillsQuizHeader.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/skills-quiz/CardLoadingSkeleton.jsx
+++ b/src/components/skills-quiz/CardLoadingSkeleton.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Card, CardGrid } from '@openedx/paragon';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/src/components/skills-quiz/CourseCard.jsx
+++ b/src/components/skills-quiz/CourseCard.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import {
   Badge, Card, Stack, Truncate,
 } from '@openedx/paragon';

--- a/src/components/skills-quiz/CurrentJobDropdown.jsx
+++ b/src/components/skills-quiz/CurrentJobDropdown.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import FacetListRefinement from '@edx/frontend-enterprise-catalog-search/FacetListRefinement';
 import PropTypes from 'prop-types';

--- a/src/components/skills-quiz/GoalDropdown.jsx
+++ b/src/components/skills-quiz/GoalDropdown.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Dropdown } from '@openedx/paragon';
 import {
   DROPDOWN_OPTION_CHANGE_CAREERS, DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE, DROPDOWN_OPTION_GET_PROMOTED,

--- a/src/components/skills-quiz/IndustryDropdown.jsx
+++ b/src/components/skills-quiz/IndustryDropdown.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import FacetListRefinement from '@edx/frontend-enterprise-catalog-search/FacetListRefinement';
 import PropTypes from 'prop-types';

--- a/src/components/skills-quiz/SearchCourseCard.jsx
+++ b/src/components/skills-quiz/SearchCourseCard.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useContext, useMemo, useState, useEffect,
 } from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';

--- a/src/components/skills-quiz/SearchCurrentJobCard.jsx
+++ b/src/components/skills-quiz/SearchCurrentJobCard.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useContext, useState, useEffect, useMemo,
 } from 'react';
 import PropTypes from 'prop-types';

--- a/src/components/skills-quiz/SearchJobCard.jsx
+++ b/src/components/skills-quiz/SearchJobCard.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useContext, useState, useEffect, useMemo,
 } from 'react';
 import PropTypes from 'prop-types';

--- a/src/components/skills-quiz/SearchJobDropdown.jsx
+++ b/src/components/skills-quiz/SearchJobDropdown.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import FacetListRefinement from '@edx/frontend-enterprise-catalog-search/FacetListRefinement';
 import PropTypes from 'prop-types';

--- a/src/components/skills-quiz/SearchPathways.jsx
+++ b/src/components/skills-quiz/SearchPathways.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useContext, useMemo, useState, useEffect,
 } from 'react';
 import PropTypes from 'prop-types';

--- a/src/components/skills-quiz/SearchProgramCard.jsx
+++ b/src/components/skills-quiz/SearchProgramCard.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useContext, useMemo, useState, useEffect,
 } from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';

--- a/src/components/skills-quiz/SelectJobCard.jsx
+++ b/src/components/skills-quiz/SelectJobCard.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { SelectableBox } from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { SkillsContext } from './SkillsContextProvider';

--- a/src/components/skills-quiz/SelectedJobSkills.jsx
+++ b/src/components/skills-quiz/SelectedJobSkills.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Badge } from '@openedx/paragon';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';

--- a/src/components/skills-quiz/SimilarJobs.jsx
+++ b/src/components/skills-quiz/SimilarJobs.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Hyperlink } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { SearchContext, setRefinementAction } from '@edx/frontend-enterprise-catalog-search';

--- a/src/components/skills-quiz/SkillsContextProvider.jsx
+++ b/src/components/skills-quiz/SkillsContextProvider.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useReducer, useMemo } from 'react';
+import { createContext, useReducer, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   SET_KEY_VALUE,

--- a/src/components/skills-quiz/SkillsCourses.jsx
+++ b/src/components/skills-quiz/SkillsCourses.jsx
@@ -1,5 +1,5 @@
 import {
-  useEffect, useState, useContext, useMemo,
+  useEffect, useState, useContext, useMemo, Fragment,
 } from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import {
@@ -121,7 +121,7 @@ const SkillsCourses = ({ index }) => {
       {isLoading ? (
         <CardLoadingSkeleton />
       ) : coursesWithSkills?.map((coursesWithSkill) => (
-        <React.Fragment key={uuidv4()}>
+        <Fragment key={uuidv4()}>
           <div className="my-4 d-flex align-items-center justify-content-between">
             <h3 className="mb-0">
               <FormattedMessage
@@ -155,7 +155,7 @@ const SkillsCourses = ({ index }) => {
               />
             ))}
           </CardGrid>
-        </React.Fragment>
+        </Fragment>
       ))}
       <div>
         { hitCount === 0 && (

--- a/src/components/skills-quiz/SkillsCourses.jsx
+++ b/src/components/skills-quiz/SkillsCourses.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useEffect, useState, useContext, useMemo,
 } from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';

--- a/src/components/skills-quiz/SkillsQuiz.jsx
+++ b/src/components/skills-quiz/SkillsQuiz.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Helmet } from 'react-helmet';
 import { SearchData } from '@edx/frontend-enterprise-catalog-search';
 

--- a/src/components/skills-quiz/SkillsQuizHeader.jsx
+++ b/src/components/skills-quiz/SkillsQuizHeader.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import edxLogo from './images/edx-logo.svg';
 

--- a/src/components/skills-quiz/SkillsQuizPage.jsx
+++ b/src/components/skills-quiz/SkillsQuizPage.jsx
@@ -1,7 +1,5 @@
-import React from 'react';
-
-import { getConfig } from '@edx/frontend-platform/config';
 import { Navigate } from 'react-router-dom';
+import { getConfig } from '@edx/frontend-platform/config';
 
 import SkillsQuiz from './SkillsQuiz';
 

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useEffect, useState, useContext, useMemo,
 } from 'react';
 import PropTypes from 'prop-types';

--- a/src/components/skills-quiz/TopSkillsOverview.jsx
+++ b/src/components/skills-quiz/TopSkillsOverview.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useContext, useEffect, useState, useMemo,
 } from 'react';
 import PropTypes from 'prop-types';

--- a/src/components/skills-quiz/data/tests/hooks.test.jsx
+++ b/src/components/skills-quiz/data/tests/hooks.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import '@testing-library/jest-dom/extend-expect';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';

--- a/src/components/skills-quiz/tests/GoalsDropdown.test.jsx
+++ b/src/components/skills-quiz/tests/GoalsDropdown.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen } from '@testing-library/react';
 import { GOAL_DROPDOWN_DEFAULT_OPTION } from '../constants';

--- a/src/components/skills-quiz/tests/JobDescriptions.test.jsx
+++ b/src/components/skills-quiz/tests/JobDescriptions.test.jsx
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { act, screen, render } from '@testing-library/react';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';

--- a/src/components/skills-quiz/tests/SearchCourseCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchCourseCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';

--- a/src/components/skills-quiz/tests/SearchCurrentJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchCurrentJobCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';

--- a/src/components/skills-quiz/tests/SearchFilters.test.jsx
+++ b/src/components/skills-quiz/tests/SearchFilters.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';

--- a/src/components/skills-quiz/tests/SearchJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchJobCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';

--- a/src/components/skills-quiz/tests/SearchPathways.test.jsx
+++ b/src/components/skills-quiz/tests/SearchPathways.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/skills-quiz/tests/SearchProgramCard.test.jsx
+++ b/src/components/skills-quiz/tests/SearchProgramCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';

--- a/src/components/skills-quiz/tests/SelectJobCard.test.jsx
+++ b/src/components/skills-quiz/tests/SelectJobCard.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/skills-quiz/tests/SelectedJobSkills.test.jsx
+++ b/src/components/skills-quiz/tests/SelectedJobSkills.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppContext } from '@edx/frontend-platform/react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/skills-quiz/tests/SkillsCourses.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsCourses.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';

--- a/src/components/skills-quiz/tests/SkillsQuiz.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsQuiz.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/skills-quiz/tests/SkillsQuizHeader.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsQuizHeader.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/skills-quiz/tests/SkillsQuizPage.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsQuizPage.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { screen } from '@testing-library/react';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/skills-quiz/tests/SkillsQuizStepper.test.jsx
+++ b/src/components/skills-quiz/tests/SkillsQuizStepper.test.jsx
@@ -2,7 +2,6 @@
 // "Cannot log after tests are done. Did you forget to wait
 // for something async in your test" and Algolia.
 
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, screen } from '@testing-library/react';

--- a/src/components/skills-quiz/tests/utils.jsx
+++ b/src/components/skills-quiz/tests/utils.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 
 import { SearchData } from '@edx/frontend-enterprise-catalog-search';

--- a/src/components/skills-quiz/tests/utils.test.jsx
+++ b/src/components/skills-quiz/tests/utils.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithSearchContext } from './utils';
 

--- a/src/components/stateful-enroll/StatefulEnroll.jsx
+++ b/src/components/stateful-enroll/StatefulEnroll.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { StatefulButton } from '@openedx/paragon';
 import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';

--- a/src/components/system-wide-banner/SystemWideWarningBanner.jsx
+++ b/src/components/system-wide-banner/SystemWideWarningBanner.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { PageBanner, Icon } from '@openedx/paragon';
 import { WarningFilled } from '@openedx/paragon/icons';

--- a/src/components/video/VideoPlayer.jsx
+++ b/src/components/video/VideoPlayer.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import VideoJS from './VideoJS';
 

--- a/src/components/video/tests/VideoJS.test.jsx
+++ b/src/components/video/tests/VideoJS.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { waitFor } from '@testing-library/react';
 import { renderWithRouter } from '../../../utils/tests';
 import VideoJS from '../VideoJS';

--- a/src/components/video/tests/VideoPlayer.test.jsx
+++ b/src/components/video/tests/VideoPlayer.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { waitFor } from '@testing-library/react';
 import VideoPlayer from '../VideoPlayer';
 import { renderWithRouter } from '../../../utils/tests';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,7 +2,6 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 
-import React from 'react';
 import ReactDOM from 'react-dom';
 import {
   APP_INIT_ERROR, APP_READY, initialize, subscribe,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,6 +42,10 @@ export interface EnterpriseCustomer {
   slug: string;
   name: string;
   enableOneAcademy: boolean;
+  enterpriseFeatures: {
+    enterpriseLearnerBFFEnabled: boolean;
+    [key: string]: boolean;
+  };
 }
 
 export interface EnterpriseLearnerData {

--- a/src/utils/hooks.jsx
+++ b/src/utils/hooks.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import algoliasearch from 'algoliasearch';
 
 export const useRenderContactHelpText = (enterpriseCustomer) => {

--- a/src/utils/tests.jsx
+++ b/src/utils/tests.jsx
@@ -1,4 +1,4 @@
-import React, { isValidElement } from 'react';
+import { isValidElement } from 'react';
 import { BrowserRouter as Router, RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import dayjs from 'dayjs';


### PR DESCRIPTION
# CHANGELOG


* Extends the checks for whether the BFF is enabled for the customer/user to take into account the new `enterprise.learner_bff_enabled` Waffle flag exposed via the `enterprise-learner` REST API from the LMS in its serialized `enterprise_features` object.
  * If BFF is enabled for the specific enterprise customer, use the BFF.
  * If the `enterprise.learner_bff_enabled` Waffle flag is `true` for the user, use the BFF. This addition enables an incremental percentage based rollout to other enterprise learners beyond the learners explicitly opted in via the enterprise customer's configuration.
  * Otherwise, don't use the BFF in favor of the legacy/granular API calls.
* Updates tests to account for Waffle-based feature flag.
* Removes `import React` throughout codebase.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
