### PR TITLE
fix: correct usages of useEnterpriseFeatures

### DIFF
--- a/src/components/app/data/hooks/useBFF.js
+++ b/src/components/app/data/hooks/useBFF.js
@@ -20,7 +20,7 @@ export default function useBFF({
   fallbackQueryConfig = null,
 }) {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const enterpriseFeatures = useEnterpriseFeatures();
+  const { data: enterpriseFeatures } = useEnterpriseFeatures();
   const { enterpriseSlug } = useParams();
   const location = useLocation();
 

--- a/src/components/app/data/hooks/useBFF.test.jsx
+++ b/src/components/app/data/hooks/useBFF.test.jsx
@@ -138,9 +138,7 @@ describe('useBFF', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    useEnterpriseFeatures.mockReturnValue({
-      enterpriseLearnerBFFEnabled: false,
-    });
+    useEnterpriseFeatures.mockReturnValue({ data: { enterpriseLearnerBFFEnabled: false } });
     fetchEnterpriseLearnerDashboard.mockResolvedValue(mockBFFDashboardData);
     useLocation.mockReturnValue({ pathname: '/test-enterprise' });
     useParams.mockReturnValue({ enterpriseSlug: 'test-enterprise' });
@@ -209,9 +207,7 @@ describe('useBFF', () => {
       });
     }
     if (isBFFEnabledForUser) {
-      useEnterpriseFeatures.mockReturnValue({
-        enterpriseLearnerBFFEnabled: true,
-      });
+      useEnterpriseFeatures.mockReturnValue({ data: { enterpriseLearnerBFFEnabled: true } });
     }
     const isBFFEnabled = isBFFEnabledForCustomer || isBFFEnabledForUser;
     const mockFallbackData = { fallback: 'data' };

--- a/src/components/app/data/hooks/useIsBFFEnabled.js
+++ b/src/components/app/data/hooks/useIsBFFEnabled.js
@@ -4,6 +4,6 @@ import useEnterpriseFeatures from './useEnterpriseFeatures';
 
 export default function useIsBFFEnabled() {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const enterpriseFeatures = useEnterpriseFeatures();
+  const { data: enterpriseFeatures } = useEnterpriseFeatures();
   return isBFFEnabled(enterpriseCustomer.uuid, enterpriseFeatures);
 }

--- a/src/components/app/data/hooks/useIsBFFEnabled.test.js
+++ b/src/components/app/data/hooks/useIsBFFEnabled.test.js
@@ -23,13 +23,13 @@ describe('useIsBFFEnabled', () => {
     const mockEnterpriseFeatures = { featureX: true };
 
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    useEnterpriseFeatures.mockReturnValue(mockEnterpriseFeatures);
+    useEnterpriseFeatures.mockReturnValue({ data: mockEnterpriseFeatures });
     isBFFEnabled.mockReturnValue(hasBFFEnabled);
 
     const { result } = renderHook(() => useIsBFFEnabled());
 
-    expect(useEnterpriseCustomer).toHaveBeenCalled();
-    expect(useEnterpriseFeatures).toHaveBeenCalled();
+    expect(useEnterpriseCustomer).toHaveBeenCalledTimes(1);
+    expect(useEnterpriseFeatures).toHaveBeenCalledTimes(1);
     expect(isBFFEnabled).toHaveBeenCalledWith(mockEnterpriseCustomer.uuid, mockEnterpriseFeatures);
     expect(result.current).toBe(hasBFFEnabled);
   });

--- a/src/components/app/data/hooks/useSubscriptions.test.jsx
+++ b/src/components/app/data/hooks/useSubscriptions.test.jsx
@@ -52,7 +52,7 @@ describe('useSubscriptions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    useEnterpriseFeatures.mockReturnValue(null);
+    useEnterpriseFeatures.mockReturnValue({ data: undefined });
     fetchSubscriptions.mockResolvedValue(mockSubscriptionsData);
     useLocation.mockReturnValue({ pathname: '/test-enterprise' });
     useParams.mockReturnValue({ enterpriseSlug: 'test-enterprise' });

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -62,7 +62,7 @@ const CourseEnrollments = ({ children }) => {
     },
   } = useEnterpriseCourseEnrollments();
 
-  const enterpriseFeatures = useEnterpriseFeatures();
+  const { data: enterpriseFeatures } = useEnterpriseFeatures();
   const {
     hasCourseEnrollments,
     currentCourseEnrollments,

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollmentsEmptyState.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollmentsEmptyState.jsx
@@ -11,7 +11,7 @@ import NewGroupAssignmentAlert from './NewGroupAssignmentAlert';
 const CourseEnrollmentsEmptyState = () => {
   const { data: canOnlyViewHighlightSets } = useCanOnlyViewHighlights();
   const { data: academies } = useAcademies();
-  const enterpriseFeatures = useEnterpriseFeatures();
+  const { data: enterpriseFeatures } = useEnterpriseFeatures();
   const {
     showNewGroupAssociationAlert,
     dismissGroupAssociationAlert,

--- a/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/tests/CourseEnrollments.test.jsx
@@ -152,7 +152,7 @@ describe('Course enrollments', () => {
 
     updateCourseCompleteStatusRequest.mockImplementation(() => ({ data: {} }));
     sortAssignmentsByAssignmentStatus.mockReturnValue([assignmentData]);
-    useEnterpriseFeatures.mockReturnValue({ enterpriseGroupsV1: false });
+    useEnterpriseFeatures.mockReturnValue({ data: { enterpriseGroupsV1: false } });
     useGroupAssociationsAlert.mockReturnValue({
       showNewGroupAssociationAlert: true,
       dismissGroupAssociationAlert: mockDismissGroupAssociationAlert,
@@ -277,7 +277,7 @@ describe('Course enrollments', () => {
   it(
     'renders NewGroupAssignmentAlert when showNewGroupAssociationAlert is true',
     async () => {
-      useEnterpriseFeatures.mockReturnValue({ enterpriseGroupsV1: true });
+      useEnterpriseFeatures.mockReturnValue({ data: { enterpriseGroupsV1: true } });
       useGroupAssociationsAlert.mockReturnValue({
         showNewGroupAssociationAlert: true,
         dismissGroupAssociationAlert: mockDismissGroupAssociationAlert,

--- a/src/components/search/tests/SearchSections.test.jsx
+++ b/src/components/search/tests/SearchSections.test.jsx
@@ -26,7 +26,7 @@ jest.mock('../../app/data', () => ({
   useContentHighlightsConfiguration: jest.fn(() => ({ data: {} })),
   useCanOnlyViewHighlights: jest.fn(() => ({ data: {} })),
   useIsAssignmentsOnlyLearner: jest.fn().mockReturnValue(false),
-  useEnterpriseFeatures: jest.fn(),
+  useEnterpriseFeatures: jest.fn().mockReturnValue({ data: undefined }),
   useDefaultSearchFilters: jest.fn(),
 }));
 


### PR DESCRIPTION
A previous PR incorrectly changed the expected data structure return value of the `useEnterpriseFeatures` hook. The hook returns a `useQuery` result, not a direct pass-thru of the `enterpriseFeatures` object as is currently assumed in the code per the prior PR.

This PR changes the usages of `useEnterpriseFeatures` back to the expected `const { data: enterpriseFeatures } = useEnterpriseFeatures()` throughout the application.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
