### PR TITLE
fix: use correct enterpriseFeatures in loaders

### DIFF
--- a/src/components/app/data/queries/extractEnterpriseFeatures.test.js
+++ b/src/components/app/data/queries/extractEnterpriseFeatures.test.js
@@ -1,0 +1,90 @@
+import { when, resetAllWhenMocks } from 'jest-when';
+import { authenticatedUserFactory, enterpriseCustomerFactory } from '../services/data/__factories__';
+import extractEnterpriseFeatures from './extractEnterpriseFeatures';
+import { queryEnterpriseLearner } from './queries';
+
+const mockEnsureQueryData = jest.fn();
+const mockQueryClient = {
+  ensureQueryData: mockEnsureQueryData,
+};
+const mockAuthenticatedUser = authenticatedUserFactory();
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+
+const getQueryEnterpriseLearner = ({ hasEnterpriseSlug = true } = {}) => queryEnterpriseLearner(
+  mockAuthenticatedUser.username,
+  hasEnterpriseSlug ? mockEnterpriseCustomer.slug : undefined,
+);
+
+describe('extractEnterpriseFeatures', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetAllWhenMocks();
+  });
+
+  it.each([
+    {
+      routeEnterpriseSlug: mockEnterpriseCustomer.slug,
+      enterpriseFeatures: { featureA: true, featureB: false },
+    },
+    {
+      routeEnterpriseSlug: undefined,
+      enterpriseFeatures: { featureA: true, featureB: false },
+    },
+    {
+      routeEnterpriseSlug: mockEnterpriseCustomer.slug,
+      enterpriseFeatures: { featureA: true, featureB: false },
+    },
+  ])('should return the correct enterprise features (%s)', async ({
+    routeEnterpriseSlug,
+    enterpriseFeatures,
+  }) => {
+    const args = {
+      queryClient: mockQueryClient,
+      authenticatedUser: mockAuthenticatedUser,
+      enterpriseSlug: routeEnterpriseSlug,
+    };
+
+    const queryEnterpriseLearnerResult = {
+      enterpriseFeatures,
+    };
+    const queryEnterpriseLearnerQueryKey = getQueryEnterpriseLearner({
+      hasEnterpriseSlug: !!routeEnterpriseSlug,
+    }).queryKey;
+
+    when(mockEnsureQueryData)
+      .calledWith(
+        expect.objectContaining({
+          queryKey: queryEnterpriseLearnerQueryKey,
+        }),
+      )
+      .mockResolvedValue(queryEnterpriseLearnerResult);
+
+    const features = await extractEnterpriseFeatures(args);
+    expect(features).toEqual(enterpriseFeatures);
+  });
+
+  it('should throw an error if enterprise features cannot be found', async () => {
+    const routeEnterpriseSlug = mockEnterpriseCustomer.slug;
+    const args = {
+      queryClient: mockQueryClient,
+      authenticatedUser: mockAuthenticatedUser,
+      enterpriseSlug: routeEnterpriseSlug,
+    };
+
+    const queryEnterpriseLearnerQueryKey = getQueryEnterpriseLearner({
+      hasEnterpriseSlug: !!routeEnterpriseSlug,
+    }).queryKey;
+
+    when(mockEnsureQueryData)
+      .calledWith(
+        expect.objectContaining({
+          queryKey: queryEnterpriseLearnerQueryKey,
+        }),
+      )
+      .mockRejectedValue(new Error('Could not retrieve enterprise features'));
+
+    await expect(extractEnterpriseFeatures(args)).rejects.toThrow(
+      'Could not retrieve enterprise features',
+    );
+  });
+});

--- a/src/components/app/data/queries/extractEnterpriseFeatures.ts
+++ b/src/components/app/data/queries/extractEnterpriseFeatures.ts
@@ -7,7 +7,7 @@ interface ExtractEnterpriseCustomerArgs {
 }
 
 /**
- * Extracts the appropriate enterprise ID for the current user and enterprise slug.
+ * Extracts the enterpriseFeatures from the enterpriseLearnerData for the current user and enterprise slug.
  */
 async function extractEnterpriseFeatures({
   queryClient,

--- a/src/components/app/data/queries/extractEnterpriseFeatures.ts
+++ b/src/components/app/data/queries/extractEnterpriseFeatures.ts
@@ -1,0 +1,27 @@
+import { queryEnterpriseLearner } from './queries';
+
+interface ExtractEnterpriseCustomerArgs {
+  queryClient: Types.QueryClient;
+  authenticatedUser: Types.AuthenticatedUser;
+  enterpriseSlug?: string;
+}
+
+/**
+ * Extracts the appropriate enterprise ID for the current user and enterprise slug.
+ */
+async function extractEnterpriseFeatures({
+  queryClient,
+  authenticatedUser,
+  enterpriseSlug,
+} : ExtractEnterpriseCustomerArgs) : Promise<Types.EnterpriseFeatures> {
+  // Retrieve linked enterprise customers for the current user from query cache, or
+  // fetch from the server if not available.
+  const linkedEnterpriseCustomersQuery = queryEnterpriseLearner(authenticatedUser.username, enterpriseSlug);
+  const enterpriseLearnerData = await queryClient.ensureQueryData<Types.EnterpriseLearnerData>(
+    linkedEnterpriseCustomersQuery,
+  );
+  const { enterpriseFeatures } = enterpriseLearnerData;
+  return enterpriseFeatures;
+}
+
+export default extractEnterpriseFeatures;

--- a/src/components/app/data/queries/index.js
+++ b/src/components/app/data/queries/index.js
@@ -1,4 +1,5 @@
 export { default as extractEnterpriseCustomer } from './extractEnterpriseCustomer';
+export { default as extractEnterpriseFeatures } from './extractEnterpriseFeatures';
 export { default as queries } from './queryKeyFactory';
 
 export * from './queries';

--- a/src/components/app/routes/loaders/rootLoader.ts
+++ b/src/components/app/routes/loaders/rootLoader.ts
@@ -31,7 +31,7 @@ const makeRootLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function ma
       activeEnterpriseCustomer,
       allLinkedEnterpriseCustomerUsers,
     } = enterpriseLearnerData;
-    const { staffEnterpriseCustomer } = enterpriseLearnerData;
+    const { staffEnterpriseCustomer, enterpriseFeatures } = enterpriseLearnerData;
 
     // User has no active, linked enterprise customer and no staff-only customer metadata exists; return early.
     if (!enterpriseCustomer) {
@@ -68,7 +68,7 @@ const makeRootLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function ma
       userEmail,
       queryClient,
       requestUrl,
-      enterpriseFeatures: enterpriseCustomer.enterpriseFeatures,
+      enterpriseFeatures,
     });
 
     // Redirect to the same URL without a trailing slash, if applicable.

--- a/src/components/dashboard/data/dashboardLoader.test.jsx
+++ b/src/components/dashboard/data/dashboardLoader.test.jsx
@@ -249,7 +249,7 @@ describe('dashboardLoader', () => {
       expect(await screen.findByTestId('dashboard')).toBeInTheDocument();
     }
 
-    expect(mockQueryClient.ensureQueryData).toHaveBeenCalledTimes(4);
+    expect(mockQueryClient.ensureQueryData).toHaveBeenCalledTimes(5);
     expect(mockQueryClient.ensureQueryData).toHaveBeenCalledWith(
       expect.objectContaining({
         queryKey: shouldUseBFFQuery

--- a/src/components/dashboard/data/dashboardLoader.ts
+++ b/src/components/dashboard/data/dashboardLoader.ts
@@ -1,13 +1,13 @@
 import { ensureAuthenticatedUser, redirectToSearchPageForNewUser } from '../../app/routes/data';
 import {
   extractEnterpriseCustomer,
+  extractEnterpriseFeatures,
   queryEnterpriseCourseEnrollments,
   queryEnterprisePathwaysList,
   queryEnterpriseProgramsList,
   queryRedeemablePolicies,
   resolveBFFQuery,
 } from '../../app/data';
-import extractEnterpriseFeatures from '../../app/data/queries/extractEnterpriseFeatures';
 
 type DashboardRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
   readonly enterpriseSlug: string;

--- a/src/components/dashboard/data/dashboardLoader.ts
+++ b/src/components/dashboard/data/dashboardLoader.ts
@@ -32,16 +32,13 @@ const makeDashboardLoader: Types.MakeRouteLoaderFunctionWithQueryClient = functi
     }
 
     const { enterpriseSlug } = params;
+
+    // Extract enterprise customer.
     const enterpriseCustomer = await extractEnterpriseCustomer({
       queryClient,
       authenticatedUser,
       enterpriseSlug,
     });
-
-    // User has no active, linked enterprise customer and no staff-only customer metadata exists; return early.
-    if (!enterpriseCustomer) {
-      return null;
-    }
 
     // Extract enterprise features.
     const enterpriseFeatures = await extractEnterpriseFeatures({

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,10 +42,11 @@ export interface EnterpriseCustomer {
   slug: string;
   name: string;
   enableOneAcademy: boolean;
-  enterpriseFeatures: {
-    enterpriseLearnerBFFEnabled: boolean;
-    [key: string]: boolean;
-  };
+}
+
+export interface EnterpriseFeatures {
+  enterpriseLearnerBFFEnabled: boolean;
+  [key: string]: boolean;
 }
 
 export interface EnterpriseLearnerData {
@@ -53,6 +54,7 @@ export interface EnterpriseLearnerData {
   activeEnterpriseCustomer: Types.EnterpriseCustomer;
   allLinkedEnterpriseCustomerUsers: any[];
   staffEnterpriseCustomer: Types.EnterpriseCustomer;
+  enterpriseFeatures: Types.EnterpriseFeatures;
 }
 
 interface EnrollmentDueDate {


### PR DESCRIPTION
# Description

Currently, the loaders are incorrectly assuming `enterpriseFeatures` is a property on the `enterpriseCustomer`; however, this is not actually correct.

The `enterpriseFeatures` actually comes from the `enterpriseLearnerData` data, not as a nested property under the `enterpriseCustomer`.

As such, enabling the BFF via the Waffle-based feature flag is never working properly in the loaders since `undefined` is currently passed into `isBFFEnabled`.

This PR:
1. Implements an `extractEnterpriseFeatures` method similar to `extractEnterpriseCustomer`, used within `dashboardLoader`.
2. Ensures the correct `enterpriseFeatures` is passed to `ensureEnterpriseAppData`.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
