### PR TITLE
fix: typo in BFF feature flag key via `enterpriseFeatures`

### DIFF
--- a/src/components/app/data/hooks/useBFF.test.jsx
+++ b/src/components/app/data/hooks/useBFF.test.jsx
@@ -138,7 +138,7 @@ describe('useBFF', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    useEnterpriseFeatures.mockReturnValue({ data: { enterpriseLearnerBFFEnabled: false } });
+    useEnterpriseFeatures.mockReturnValue({ data: { enterpriseLearnerBffEnabled: false } });
     fetchEnterpriseLearnerDashboard.mockResolvedValue(mockBFFDashboardData);
     useLocation.mockReturnValue({ pathname: '/test-enterprise' });
     useParams.mockReturnValue({ enterpriseSlug: 'test-enterprise' });
@@ -207,7 +207,7 @@ describe('useBFF', () => {
       });
     }
     if (isBFFEnabledForUser) {
-      useEnterpriseFeatures.mockReturnValue({ data: { enterpriseLearnerBFFEnabled: true } });
+      useEnterpriseFeatures.mockReturnValue({ data: { enterpriseLearnerBffEnabled: true } });
     }
     const isBFFEnabled = isBFFEnabledForCustomer || isBFFEnabledForUser;
     const mockFallbackData = { fallback: 'data' };

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -913,7 +913,7 @@ export function isBFFEnabled(enterpriseCustomerUuid, enterpriseFeatures) {
   // 1. BFF is enabled for the enterprise customer.
   // 2. BFF is enabled for the request user via Waffle flag (supporting percentage-based rollout)
   const isBFFEnabledForCustomer = isBFFEnabledForEnterpriseCustomer(enterpriseCustomerUuid);
-  if (isBFFEnabledForCustomer || enterpriseFeatures?.enterpriseLearnerBFFEnabled) {
+  if (isBFFEnabledForCustomer || enterpriseFeatures?.enterpriseLearnerBffEnabled) {
     return true;
   }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -45,7 +45,7 @@ export interface EnterpriseCustomer {
 }
 
 export interface EnterpriseFeatures {
-  enterpriseLearnerBFFEnabled: boolean;
+  enterpriseLearnerBffEnabled: boolean;
   [key: string]: boolean;
 }
 


### PR DESCRIPTION
Current code assumes `enterpriseFeatures.enterpriseLearnerBFFEnabled` vs. the actual `enterpriseFeatures.enterpriseLearnerBffEnabled`...

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
