### PR TITLE
fix: replace `structuredClone` with `_cloneDeep`

### DIFF
--- a/src/components/app/data/constants.js
+++ b/src/components/app/data/constants.js
@@ -1,3 +1,4 @@
+import _cloneDeep from 'lodash.clonedeep';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 
 export const emptyRedeemableLearnerCreditPolicies = {
@@ -84,7 +85,7 @@ export const getBaseSubscriptionsData = () => {
     customerAgreement: null,
     subscriptionLicense: null,
     subscriptionPlan: null,
-    licensesByStatus: structuredClone(baseLicensesByStatus),
+    licensesByStatus: _cloneDeep(baseLicensesByStatus),
     showExpirationNotifications: false,
   };
   return {

--- a/src/components/app/data/services/programs.js
+++ b/src/components/app/data/services/programs.js
@@ -2,6 +2,8 @@ import { getConfig } from '@edx/frontend-platform/config';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { logError } from '@edx/frontend-platform/logging';
+
+import _cloneDeep from 'lodash.clonedeep';
 import { fetchEnterpriseCustomerContainsContent } from './content';
 import { getAvailableCourseRuns } from '../utils';
 
@@ -52,7 +54,7 @@ export async function fetchProgramDetails(enterpriseUuid, programUuid) {
     if (!programDetails) {
       return null;
     }
-    const programDetailsCopy = structuredClone(programDetails);
+    const programDetailsCopy = _cloneDeep(programDetails);
     const { courses } = programDetailsCopy;
     // Retrieve course keys
     const courseKeys = courses.map(({ key }) => key);


### PR DESCRIPTION
Replaces instances of `structuredClone` with `_cloneDeep`. This is done to increase overall access to the learner portal for browsers that do not support `structuredClone`

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
