### PR TITLE
fix: set static titles for upcoming courseware

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 
 import {
   Badge,
+  Card,
   Col,
   Dropdown,
   Hyperlink,
@@ -160,7 +161,18 @@ const BaseCourseCard = ({
 
   const isExecutiveEducation2UCourse = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
 
-  const CourseTitleComponent = externalCourseLink ? Hyperlink : Link;
+  const renderCourseTitle = () => {
+    const courseTitleComponentProps = {
+      className: classNames('h3 mb-0', { 'text-white': isExecutiveEducation2UCourse }),
+    };
+    if (type === COURSE_STATUSES.upcoming) {
+      return <Card.Header title={title} {...courseTitleComponentProps} />;
+    }
+    if (externalCourseLink) {
+      return <Hyperlink destination={linkToCourse} {...courseTitleComponentProps}>{title}</Hyperlink>;
+    }
+    return <Link to={linkToCourse} {...courseTitleComponentProps}>{title}</Link>;
+  };
 
   const getCoursePaceHyperlink = (chunks) => (
     <Hyperlink
@@ -583,13 +595,7 @@ const BaseCourseCard = ({
                   >
                     <h4 className="course-title mt-n1 mb-0">
                       {renderMicroMastersTitle()}
-                      <CourseTitleComponent
-                        className={classNames('h3 mb-0', { 'text-white': isExecutiveEducation2UCourse })}
-                        destination={externalCourseLink ? linkToCourse : null}
-                        to={!externalCourseLink ? linkToCourse : null}
-                      >
-                        {title}
-                      </CourseTitleComponent>
+                      {renderCourseTitle()}
                     </h4>
                     {renderBadge()}
                   </Stack>

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom';
 
 import {
   Badge,
-  Card,
   Col,
   Dropdown,
   Hyperlink,
@@ -166,7 +165,7 @@ const BaseCourseCard = ({
       className: classNames('h3 mb-0', { 'text-white': isExecutiveEducation2UCourse }),
     };
     if (type === COURSE_STATUSES.upcoming) {
-      return <Card.Header title={title} {...courseTitleComponentProps} />;
+      return <div {...courseTitleComponentProps}>{title}</div>;
     }
     if (externalCourseLink) {
       return <Hyperlink destination={linkToCourse} {...courseTitleComponentProps}>{title}</Hyperlink>;


### PR DESCRIPTION
https://github.com/user-attachments/assets/15286030-823d-47b9-b829-717d1a5bb327

Updates upcoming course titles on the dashboard to be static `Card.Header` files. Still retains original component styling and behavior for all other course `type` based on existing behavior.
Slight refactor to match current code style of the component. 



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
