### PR TITLE
fix: ensure matching reason types and user messages on course page

### DIFF
--- a/src/components/course/data/hooks.jsx
+++ b/src/components/course/data/hooks.jsx
@@ -630,6 +630,7 @@ export const useUserSubsidyApplicableToCourse = () => {
       userSubsidyApplicableToCourse?.availableCourseRuns || onlyUnrestrictedCourseRuns
     );
   }
+
   return useMemo(() => ({
     userSubsidyApplicableToCourse,
     missingUserSubsidyReason,

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -40,6 +40,8 @@ jest.mock('@edx/frontend-platform', () => ({
   }),
 }));
 
+const mockCatalogUuid = 'test-catalog-uuid';
+
 describe('findCouponCodeForCourse', () => {
   const couponCodes = [{
     code: 'bearsRus',
@@ -442,8 +444,6 @@ describe('getMissingSubsidyReasonActions', () => {
 });
 
 describe('getSubscriptionDisabledEnrollmentReasonType', () => {
-  const mockCatalogUuid = 'test-catalog-uuid';
-
   it.each([
     // No subscriptions for customer. Expected: undefined
     {
@@ -819,8 +819,6 @@ describe('isCurrentCoupon', () => {
 });
 
 describe('getCouponCodesDisabledEnrollmentReasonType', () => {
-  const testCatalogUuid = 'test-catalog-uuid';
-
   afterEach(() => {
     MockDate.reset();
   });
@@ -835,9 +833,9 @@ describe('getCouponCodesDisabledEnrollmentReasonType', () => {
     },
     {
       todaysDate: '2023-08-02T12:00:00Z',
-      catalogsWithCourse: [testCatalogUuid],
+      catalogsWithCourse: [mockCatalogUuid],
       couponsOverview: [{
-        enterpriseCatalogUuid: testCatalogUuid,
+        enterpriseCatalogUuid: mockCatalogUuid,
         startDate: '2023-08-01T12:00:00Z',
         endDate: '2024-08-01T12:00:00Z',
         numUnassigned: 100,
@@ -847,9 +845,9 @@ describe('getCouponCodesDisabledEnrollmentReasonType', () => {
     },
     {
       todaysDate: '2023-08-02T12:00:00Z',
-      catalogsWithCourse: [testCatalogUuid],
+      catalogsWithCourse: [mockCatalogUuid],
       couponsOverview: [{
-        enterpriseCatalogUuid: testCatalogUuid,
+        enterpriseCatalogUuid: mockCatalogUuid,
         startDate: '2023-08-01T12:00:00Z',
         endDate: '2024-08-01T12:00:00Z',
         numUnassigned: 0,
@@ -859,9 +857,9 @@ describe('getCouponCodesDisabledEnrollmentReasonType', () => {
     },
     {
       todaysDate: '2023-10-31T12:00:00Z',
-      catalogsWithCourse: [testCatalogUuid],
+      catalogsWithCourse: [mockCatalogUuid],
       couponsOverview: [{
-        enterpriseCatalogUuid: testCatalogUuid,
+        enterpriseCatalogUuid: mockCatalogUuid,
         startDate: '2023-08-01T12:00:00Z',
         endDate: '2023-08-31T12:00:00Z',
         numUnassigned: 100,
@@ -933,12 +931,12 @@ describe('getMissingApplicableSubsidyReason', () => {
     };
     const mockData = {
       ...baseMockData,
-      catalogsWithCourse: ['test-catalog-uuid'],
+      catalogsWithCourse: [mockCatalogUuid],
       couponsOverview:
       {
         data: {
           results: [{
-            enterpriseCatalogUuid: 'test-catalog-uuid',
+            enterpriseCatalogUuid: mockCatalogUuid,
             numUnassigned: 100,
             ...couponProperties,
           }],
@@ -953,17 +951,17 @@ describe('getMissingApplicableSubsidyReason', () => {
     const mockData = {
       ...baseMockData,
       customerAgreement: {
-        availableSubscriptionCatalogs: ['test-catalog-uuid'],
+        availableSubscriptionCatalogs: [mockCatalogUuid],
       },
       subscriptionLicense: {
         // Subscription license is activated, but expired.
         status: LICENSE_STATUS.ACTIVATED,
         subscriptionPlan: {
           isCurrent: false,
-          enterpriseCatalogUuid: 'test-catalog-uuid',
+          enterpriseCatalogUuid: mockCatalogUuid,
         },
       },
-      catalogsWithCourse: ['test-catalog-uuid'],
+      catalogsWithCourse: [mockCatalogUuid],
     };
     const result = getMissingApplicableSubsidyReason(mockData);
     expect(result.reason).toEqual(DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_EXPIRED);
@@ -973,17 +971,17 @@ describe('getMissingApplicableSubsidyReason', () => {
     const mockData = {
       ...baseMockData,
       customerAgreement: {
-        availableSubscriptionCatalogs: ['test-catalog-uuid'],
+        availableSubscriptionCatalogs: [mockCatalogUuid],
       },
       subscriptionLicense: {
         // Subscription license is current but deactivated (revoked).
         status: LICENSE_STATUS.REVOKED,
         subscriptionPlan: {
           isCurrent: true,
-          enterpriseCatalogUuid: 'test-catalog-uuid',
+          enterpriseCatalogUuid: mockCatalogUuid,
         },
       },
-      catalogsWithCourse: ['test-catalog-uuid'],
+      catalogsWithCourse: [mockCatalogUuid],
     };
     const result = getMissingApplicableSubsidyReason(mockData);
     expect(result.reason).toEqual(DISABLED_ENROLL_REASON_TYPES.SUBSCRIPTION_DEACTIVATED);


### PR DESCRIPTION
# Description

[ENT-9729](https://2u-internal.atlassian.net/browse/ENT-9729)

## Before

The displayed message pertains to the "Not in catalog" case, but the button CTA corresponds to revoked subscription license.

<img width="282" alt="image" src="https://github.com/user-attachments/assets/f0bbdaeb-f70b-4a37-a4ec-26355ec92e5d" />

## After

The displayed message corresponds to the revoked subscription license.

<img width="282" alt="image" src="https://github.com/user-attachments/assets/886238ff-570e-4abe-b12a-c73896e9ed6e" />

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
