### PR TITLE
fix: remove duplicative course run card on allocation

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -441,16 +441,21 @@ export function useContentAssignments() {
       expiredAssignments,
     } = allEnrollmentsByStatus.assigned;
 
-    const upgradeableAuditEnrollmentCourseKeys = [...allEnrollmentsByStatus.inProgress]
+    const potentiallyUpgradeableAuditEnrollmentCourses = [...allEnrollmentsByStatus.inProgress]
       .filter(enrollment => isEnrollmentUpgradeable(enrollment))
-      .map((enrollment) => enrollment.courseRunId);
+      .map((enrollment) => ({
+        courseKey: enrollment.courseKey,
+        courseRunId: enrollment.courseRunId,
+      }));
 
     // Filter out any assignments that have a corresponding potentially upgradeable
     // audit enrollment. Note: all enrollment cards currently assume content key is
     // a course run id despite the current assignment's content key referring to a
-    // top-level course key.
+    // top-level course key or a specific course run identifier as assignment.courseRunId.
     const filteredAssignmentsForDisplay = assignmentsForDisplay.filter((assignment) => (
-      !upgradeableAuditEnrollmentCourseKeys.includes(assignment.courseRunId)
+      !potentiallyUpgradeableAuditEnrollmentCourses.some(({ courseKey, courseRunId }) => (
+        [courseKey, courseRunId].includes(assignment.courseRunId)
+      ))
     ));
 
     // Sort and transform the list of assignments for display.
@@ -463,14 +468,14 @@ export function useContentAssignments() {
 
     // Determine whether there are unacknowledged canceled assignments. If so, display alert.
     const filteredCanceledAssignments = canceledAssignments.filter((assignment) => (
-      !upgradeableAuditEnrollmentCourseKeys.includes(assignment.courseRunId)
+      !potentiallyUpgradeableAuditEnrollmentCourses.includes(assignment.courseRunId)
     ));
     const hasUnacknowledgedCanceledAssignments = getHasUnacknowledgedAssignments(filteredCanceledAssignments);
     setShowCanceledAssignmentsAlert(hasUnacknowledgedCanceledAssignments);
 
     // Determine whether there are unacknowledged expired assignments. If so, display alert.
     const filteredExpiredAssignments = expiredAssignments.filter((assignment) => (
-      !upgradeableAuditEnrollmentCourseKeys.includes(assignment.courseRunId)
+      !potentiallyUpgradeableAuditEnrollmentCourses.includes(assignment.courseRunId)
     ));
     const hasUnacknowledgedExpiredAssignments = getHasUnacknowledgedAssignments(filteredExpiredAssignments);
     setShowExpiredAssignmentsAlert(hasUnacknowledgedExpiredAssignments);

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -37,9 +37,9 @@ import {
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
   useEnterpriseCustomerContainsContent,
+  useIsBFFEnabled,
   useRedeemablePolicies,
   useSubscriptions,
-  useIsBFFEnabled,
 } from '../../../../app/data';
 import { sortAssignmentsByAssignmentStatus, sortedEnrollmentsByEnrollmentDate } from './utils';
 import { ASSIGNMENTS_EXPIRING_WARNING_LOCALSTORAGE_KEY } from '../../../data/constants';
@@ -443,7 +443,7 @@ export function useContentAssignments() {
 
     const upgradeableAuditEnrollmentCourseKeys = [...allEnrollmentsByStatus.inProgress]
       .filter(enrollment => isEnrollmentUpgradeable(enrollment))
-      .map((enrollment) => enrollment.courseKey);
+      .map((enrollment) => enrollment.courseRunId);
 
     // Filter out any assignments that have a corresponding potentially upgradeable
     // audit enrollment. Note: all enrollment cards currently assume content key is

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
@@ -589,11 +589,15 @@ describe('useCourseUpgradeData', () => {
 });
 
 describe('useContentAssignments', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   const mockRedeemableLearnerCreditPolicies = emptyRedeemableLearnerCreditPolicies;
   const mockSubsidyExpirationDateStr = dayjs().add(ENROLL_BY_DATE_WARNING_THRESHOLD_DAYS + 1, 'days').toISOString();
   const mockAssignmentConfigurationId = 'test-assignment-configuration-id';
   const mockAssignment = {
-    contentKey: 'edX+DemoX',
+    courseKey: 'edX+DemoX',
+    courseRunId: 'course-v1:Best+course+2T2025',
     contentTitle: 'edX Demo Course',
     subsidyExpirationDate: mockSubsidyExpirationDateStr,
     assignmentConfiguration: mockAssignmentConfigurationId,
@@ -929,10 +933,13 @@ describe('useContentAssignments', () => {
       ...mockTransformedMockCourseEnrollment,
       mode,
       enrollBy,
+      isAssignedCourseRun: true,
     };
+
     const mockAssignmentForExistingEnrollment = {
       ...mockAllocatedAssignment,
-      contentKey: mockEnrollment.courseRunKey,
+      contentKey: mockEnrollment.courseRunId,
+      isAssignedCourseRun: true,
     };
     const mockPoliciesWithInProgressEnrollment = {
       ...mockPoliciesWithAssignments,
@@ -949,6 +956,7 @@ describe('useContentAssignments', () => {
       },
     });
     const { result } = renderHook(() => useContentAssignments(), { wrapper });
+
     if (isAssignmentExcluded) {
       expect(result.current.assignments).toHaveLength(0);
     } else {

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/utils.test.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/utils.test.js
@@ -15,6 +15,7 @@ describe('transformCourseEnrollment', () => {
     const originalCourseEnrollment = createRawCourseEnrollment();
 
     const transformedCourseEnrollment = {
+      courseKey: originalCourseEnrollment.courseKey,
       completed: originalCourseEnrollment.completed,
       courseRunId: originalCourseEnrollment.courseRunId,
       courseRunStatus: originalCourseEnrollment.courseRunStatus,
@@ -44,6 +45,7 @@ describe('transformCourseEnrollment', () => {
       certificateDownloadUrl: certificateUrl,
     });
     const transformedCourseEnrollment = {
+      courseKey: originalCourseEnrollment.courseKey,
       completed: originalCourseEnrollment.completed,
       courseRunId: originalCourseEnrollment.courseRunId,
       courseRunStatus: originalCourseEnrollment.courseRunStatus,

--- a/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
+++ b/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
@@ -31,7 +31,7 @@ const createCourseEnrollmentWithStatus = (
 };
 
 const createRawCourseEnrollment = (options) => ({
-  courseRunId: 'course-v1:Best+course',
+  courseRunId: 'course-v1:Best+course+2T2025',
   displayName: 'Best course',
   micromastersTitle: 'Greatest Micromasters',
   resumeCourseRunUrl: 'http://www.resumecourserun.com',

--- a/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
+++ b/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
@@ -15,7 +15,7 @@ const createCourseEnrollmentWithStatus = (
 ) => {
   const randomNumber = Math.random();
   return ({
-    courseKey: 'edX+DemoX',
+    courseKey: 'Best+course',
     courseRunId: `$course-v1:edX+DemoX+Demo_Course-${randomNumber}`,
     courseRunStatus: status,
     linkToCourse: 'https://edx.org/',
@@ -32,7 +32,7 @@ const createCourseEnrollmentWithStatus = (
 };
 
 const createRawCourseEnrollment = (options) => ({
-  courseKey: 'edX+DemoX',
+  courseKey: 'Best+course',
   courseRunId: 'course-v1:Best+course+2T2025',
   displayName: 'Best course',
   micromastersTitle: 'Greatest Micromasters',

--- a/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
+++ b/src/components/dashboard/main-content/course-enrollments/tests/enrollment-testutils.js
@@ -15,6 +15,7 @@ const createCourseEnrollmentWithStatus = (
 ) => {
   const randomNumber = Math.random();
   return ({
+    courseKey: 'edX+DemoX',
     courseRunId: `$course-v1:edX+DemoX+Demo_Course-${randomNumber}`,
     courseRunStatus: status,
     linkToCourse: 'https://edx.org/',
@@ -31,6 +32,7 @@ const createCourseEnrollmentWithStatus = (
 };
 
 const createRawCourseEnrollment = (options) => ({
+  courseKey: 'edX+DemoX',
   courseRunId: 'course-v1:Best+course+2T2025',
   displayName: 'Best course',
   micromastersTitle: 'Greatest Micromasters',


### PR DESCRIPTION
During the transition to run based assignments, a refactor was missed related to filtering out duplicative learner credit allocations on a potentially upgradable audit enrollment on the learner dashboard page. This did **not** affect the user's ability to upgrade their audit enrollment. It presented a confusing UI experience on which course card to proceed on (Upgrade or learner credit enrollment.)

This PR removes duplicative course cards by filtering on the course run vs the content key which may either be a top level course or a course run id.

Prior to fix:
![Screenshot 2025-01-10 at 12 05 15 PM](https://github.com/user-attachments/assets/8f6e68c2-b7ce-4868-bccf-5ef03ce542e2)

After fix:
![Screenshot 2025-01-10 at 12 06 36 PM](https://github.com/user-attachments/assets/4231fbc3-56ce-4a71-af15-e2416d4d888a)



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
