### PR TITLE
refactor: remove BFF transform for subscriptions data

### DIFF
--- a/src/components/app/data/constants.js
+++ b/src/components/app/data/constants.js
@@ -85,7 +85,7 @@ export const getBaseSubscriptionsData = () => {
     customerAgreement: null,
     subscriptionLicense: null,
     subscriptionPlan: null,
-    licensesByStatus: _cloneDeep(baseLicensesByStatus),
+    subscriptionLicensesByStatus: _cloneDeep(baseLicensesByStatus),
     showExpirationNotifications: false,
   };
   return {

--- a/src/components/app/data/hooks/useCatalogsForSubsidyRequests.test.jsx
+++ b/src/components/app/data/hooks/useCatalogsForSubsidyRequests.test.jsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '../../../../utils/tests';
 import useCatalogsForSubsidyRequest from './useCatalogsForSubsidyRequests';
-import { LICENSE_STATUS } from '../../../enterprise-user-subsidy/data/constants';
+import { getBaseSubscriptionsData } from '../constants';
 import useSubscriptions from './useSubscriptions';
 import { useBrowseAndRequestConfiguration } from './useBrowseAndRequest';
 import useCouponCodes from './useCouponCodes';
@@ -17,19 +17,7 @@ jest.mock('../services', () => ({
   fetchSubscriptions: jest.fn().mockResolvedValue(null),
   fetchBrowseAndRequestConfiguration: jest.fn().mockResolvedValue(null),
 }));
-const licensesByStatus = {
-  [LICENSE_STATUS.ACTIVATED]: [],
-  [LICENSE_STATUS.ASSIGNED]: [],
-  [LICENSE_STATUS.REVOKED]: [],
-};
-const mockSubscriptionsData = {
-  subscriptionLicenses: [],
-  customerAgreement: null,
-  subscriptionLicense: null,
-  subscriptionPlan: null,
-  licensesByStatus,
-  showExpirationNotifications: false,
-};
+const { baseSubscriptionsData } = getBaseSubscriptionsData();
 const mockCouponsOverviewResponse = [{ id: 123 }];
 const mockBrowseAndRequestConfiguration = {
   id: 123,
@@ -44,7 +32,7 @@ describe('useCatalogsForSubsidyRequests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useBrowseAndRequestConfiguration.mockReturnValue({ data: mockBrowseAndRequestConfiguration });
-    useSubscriptions.mockReturnValue({ data: mockSubscriptionsData });
+    useSubscriptions.mockReturnValue({ data: baseSubscriptionsData });
     useCouponCodes.mockReturnValue({ data: { couponsOverview: mockCouponsOverviewResponse } });
   });
   it('should handle return when subsidy request not enabled for browseAndRequestConfiguration', () => {
@@ -56,7 +44,7 @@ describe('useCatalogsForSubsidyRequests', () => {
       availableSubscriptionCatalogs: ['test-catalog1', 'test-catalog2'],
     };
     const mockUpdatedSubscriptionsData = {
-      ...mockSubscriptionsData,
+      ...baseSubscriptionsData,
       customerAgreement,
     };
     const mockUpdatedBrowseAndRequestConfiguration = {
@@ -118,7 +106,7 @@ describe('useCatalogsForSubsidyRequests', () => {
       enterpriseCatalogUuid: 'test-catalog6',
     }];
     useBrowseAndRequestConfiguration.mockReturnValue({ data: mockUpdatedBrowseAndRequestConfiguration });
-    useSubscriptions.mockReturnValue({ data: mockSubscriptionsData });
+    useSubscriptions.mockReturnValue({ data: baseSubscriptionsData });
     useCouponCodes.mockReturnValue({ data: { couponsOverview: mockUpdatedCouponsOverviewResponse } });
     const { result } = renderHook(() => useCatalogsForSubsidyRequest(), { wrapper: Wrapper });
 

--- a/src/components/app/data/hooks/useSubscriptions.js
+++ b/src/components/app/data/hooks/useSubscriptions.js
@@ -1,7 +1,6 @@
 import { querySubscriptions } from '../queries';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 import useBFF from './useBFF';
-import { transformSubscriptionsData } from '../services';
 
 /**
  * Custom hook to get subscriptions data for the enterprise.
@@ -16,10 +15,7 @@ export default function useSubscriptions(queryOptions = {}) {
     bffQueryOptions: {
       ...queryOptionsRest,
       select: (data) => {
-        const transformedData = transformSubscriptionsData(
-          data?.enterpriseCustomerUserSubsidies?.subscriptions,
-          { isBFFData: true },
-        );
+        const transformedData = data?.enterpriseCustomerUserSubsidies?.subscriptions;
 
         // When custom `select` function is provided in `queryOptions`, call it with original and transformed data.
         if (select) {

--- a/src/components/app/data/services/subsidies/subscriptions.js
+++ b/src/components/app/data/services/subsidies/subscriptions.js
@@ -7,10 +7,7 @@ import { generatePath, matchPath, redirect } from 'react-router-dom';
 import { features } from '../../../../../config';
 import { LICENSE_STATUS } from '../../../../enterprise-user-subsidy/data/constants';
 import { fetchPaginatedData } from '../utils';
-import {
-  SESSION_STORAGE_KEY_LICENSE_ACTIVATION_MESSAGE,
-  getBaseSubscriptionsData,
-} from '../../constants';
+import { getBaseSubscriptionsData, SESSION_STORAGE_KEY_LICENSE_ACTIVATION_MESSAGE } from '../../constants';
 
 // Subscriptions
 

--- a/src/components/app/data/services/subsidies/subscriptions.js
+++ b/src/components/app/data/services/subsidies/subscriptions.js
@@ -8,6 +8,7 @@ import { features } from '../../../../../config';
 import { LICENSE_STATUS } from '../../../../enterprise-user-subsidy/data/constants';
 import { fetchPaginatedData } from '../utils';
 import { getBaseSubscriptionsData, SESSION_STORAGE_KEY_LICENSE_ACTIVATION_MESSAGE } from '../../constants';
+import { addLicenseToSubscriptionLicensesByStatus } from '../../utils';
 
 // Subscriptions
 
@@ -216,10 +217,11 @@ export function transformSubscriptionsData({ customerAgreement, subscriptionLice
     if (license.status === LICENSE_STATUS.UNASSIGNED) {
       return;
     }
-    if (!subscriptionsData.subscriptionLicensesByStatus[license.status]) {
-      subscriptionsData.subscriptionLicensesByStatus[license.status] = [];
-    }
-    subscriptionsData.subscriptionLicensesByStatus[license.status].push(license);
+    const updatedLicensesByStatus = addLicenseToSubscriptionLicensesByStatus({
+      subscriptionLicensesByStatus: subscriptionsData.subscriptionLicensesByStatus,
+      subscriptionLicense: license,
+    });
+    subscriptionsData.subscriptionLicensesByStatus = updatedLicensesByStatus;
   });
 
   // Extracts a single subscription license for the user, from the ordered licenses by status.

--- a/src/components/app/data/services/subsidies/subscriptions.js
+++ b/src/components/app/data/services/subsidies/subscriptions.js
@@ -216,6 +216,9 @@ export function transformSubscriptionsData({ customerAgreement, subscriptionLice
     if (license.status === LICENSE_STATUS.UNASSIGNED) {
       return;
     }
+    if (!subscriptionsData.subscriptionLicensesByStatus[license.status]) {
+      subscriptionsData.subscriptionLicensesByStatus[license.status] = [];
+    }
     subscriptionsData.subscriptionLicensesByStatus[license.status].push(license);
   });
 

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -920,3 +920,20 @@ export function isBFFEnabled(enterpriseCustomerUuid, enterpriseFeatures) {
   // Otherwise, BFF is not enabled.
   return false;
 }
+
+/**
+ * Adds a subscription license to the subscription licenses grouped by status.
+ * @param {Oject} args
+ * @param {Object} args.subscriptionLicensesByStatus - The subscription licenses grouped by status.
+ * @param {Object} args.subscriptionLicense - The subscription license to add to the subscription licenses by status.
+ * @returns {Object} - Returns the updated subscription licenses grouped by status.
+ */
+export function addLicenseToSubscriptionLicensesByStatus({ subscriptionLicensesByStatus, subscriptionLicense }) {
+  const licenseStatus = subscriptionLicense.status;
+  const updatedLicensesByStatus = { ...subscriptionLicensesByStatus };
+  if (!updatedLicensesByStatus[licenseStatus]) {
+    updatedLicensesByStatus[licenseStatus] = [];
+  }
+  updatedLicensesByStatus[licenseStatus].push(subscriptionLicense);
+  return updatedLicensesByStatus;
+}

--- a/src/components/app/routes/data/utils.js
+++ b/src/components/app/routes/data/utils.js
@@ -60,9 +60,9 @@ export async function ensureEnterpriseAppData({
   if (!matchedBFFQuery) {
     const subscriptionsQuery = querySubscriptions(enterpriseCustomer.uuid);
     enterpriseAppDataQueries.push(
-    // Enterprise Customer User Subsidies
+      // Enterprise Customer User Subsidies
       queryClient.ensureQueryData(subscriptionsQuery).then(async (subscriptionsData) => {
-      // Auto-activate the user's subscription license, if applicable.
+        // Auto-activate the user's subscription license, if applicable.
         const activatedOrAutoAppliedLicense = await activateOrAutoApplySubscriptionLicense({
           enterpriseCustomer,
           allLinkedEnterpriseCustomerUsers,
@@ -78,11 +78,11 @@ export async function ensureEnterpriseAppData({
             );
             const isCurrentStatusMatchingLicenseStatus = status === activatedOrAutoAppliedLicense.status;
             if (licensesIncludesActivatedOrAutoAppliedLicense) {
-              updatedLicensesByStatus[status] = isCurrentStatusMatchingLicenseStatus
-                ? licenses.filter((license) => license.uuid !== activatedOrAutoAppliedLicense.uuid)
-                : [...licenses, activatedOrAutoAppliedLicense];
+              updatedLicensesByStatus[status] = licenses.filter(
+                (license) => license.uuid !== activatedOrAutoAppliedLicense.uuid,
+              );
             } else if (isCurrentStatusMatchingLicenseStatus) {
-              updatedLicensesByStatus[activatedOrAutoAppliedLicense.status].push(activatedOrAutoAppliedLicense);
+              updatedLicensesByStatus[status] = [activatedOrAutoAppliedLicense];
             }
           });
           // Optimistically update the query cache with the auto-activated or auto-applied subscription license.

--- a/src/components/app/routes/data/utils.js
+++ b/src/components/app/routes/data/utils.js
@@ -70,9 +70,9 @@ export async function ensureEnterpriseAppData({
           requestUrl,
         });
         if (activatedOrAutoAppliedLicense) {
-          const { licensesByStatus } = subscriptionsData;
-          const updatedLicensesByStatus = { ...licensesByStatus };
-          Object.entries(licensesByStatus).forEach(([status, licenses]) => {
+          const { subscriptionLicensesByStatus } = subscriptionsData;
+          const updatedLicensesByStatus = { ...subscriptionLicensesByStatus };
+          Object.entries(subscriptionLicensesByStatus).forEach(([status, licenses]) => {
             const licensesIncludesActivatedOrAutoAppliedLicense = licenses.some(
               (license) => license.uuid === activatedOrAutoAppliedLicense.uuid,
             );
@@ -99,7 +99,7 @@ export async function ensureEnterpriseAppData({
 
           queryClient.setQueryData(subscriptionsQuery.queryKey, {
             ...queryClient.getQueryData(subscriptionsQuery.queryKey),
-            licensesByStatus: updatedLicensesByStatus,
+            subscriptionLicensesByStatus: updatedLicensesByStatus,
             subscriptionPlan: activatedOrAutoAppliedLicense.subscriptionPlan,
             subscriptionLicense: activatedOrAutoAppliedLicense,
             subscriptionLicenses: updatedSubscriptionLicenses,

--- a/src/components/app/routes/loaders/tests/rootLoader.test.jsx
+++ b/src/components/app/routes/loaders/tests/rootLoader.test.jsx
@@ -7,6 +7,7 @@ import makeRootLoader from '../rootLoader';
 import { ensureAuthenticatedUser } from '../../data';
 import {
   extractEnterpriseCustomer,
+  getBaseSubscriptionsData,
   queryBrowseAndRequestConfiguration,
   queryContentHighlightsConfiguration,
   queryCouponCodeRequests,
@@ -191,16 +192,13 @@ describe('rootLoader', () => {
     ).mockResolvedValue(mockRedeemablePolicies);
 
     // Mock subscriptions query
-    const mockSubscriptionsData = {
-      customerAgreement: null,
-      licensesByStatus: {},
-    };
+    const { baseSubscriptionsData } = getBaseSubscriptionsData();
     const subscriptionsQuery = querySubscriptions(enterpriseCustomer.uuid);
     when(mockQueryClient.ensureQueryData).calledWith(
       expect.objectContaining({
         queryKey: subscriptionsQuery.queryKey,
       }),
-    ).mockResolvedValue(mockSubscriptionsData);
+    ).mockResolvedValue(baseSubscriptionsData);
 
     renderWithRouterProvider({
       path: '/:enterpriseSlug',

--- a/src/components/app/routes/loaders/tests/rootLoader.test.jsx
+++ b/src/components/app/routes/loaders/tests/rootLoader.test.jsx
@@ -6,6 +6,7 @@ import { renderWithRouterProvider } from '../../../../../utils/tests';
 import makeRootLoader from '../rootLoader';
 import { ensureAuthenticatedUser } from '../../data';
 import {
+  activateOrAutoApplySubscriptionLicense,
   extractEnterpriseCustomer,
   getBaseSubscriptionsData,
   queryBrowseAndRequestConfiguration,
@@ -20,6 +21,8 @@ import {
   updateUserActiveEnterprise,
 } from '../../../data';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../../data/services/data/__factories__';
+import { isBFFEnabled } from '../../../data/utils';
+import { LICENSE_STATUS } from '../../../../enterprise-user-subsidy/data/constants';
 
 jest.mock('../../data', () => ({
   ...jest.requireActual('../../data'),
@@ -29,6 +32,11 @@ jest.mock('../../../data', () => ({
   ...jest.requireActual('../../../data'),
   extractEnterpriseCustomer: jest.fn(),
   updateUserActiveEnterprise: jest.fn(),
+  activateOrAutoApplySubscriptionLicense: jest.fn(),
+}));
+jest.mock('../../../data/utils', () => ({
+  ...jest.requireActual('../../../data/utils'),
+  isBFFEnabled: jest.fn(),
 }));
 
 const mockAuthenticatedUser = authenticatedUserFactory();
@@ -37,6 +45,8 @@ const mockEnterpriseCustomerTwo = enterpriseCustomerFactory();
 
 const mockQueryClient = {
   ensureQueryData: jest.fn().mockResolvedValue(),
+  getQueryData: jest.fn(),
+  setQueryData: jest.fn(),
 };
 
 describe('rootLoader', () => {
@@ -87,8 +97,40 @@ describe('rootLoader', () => {
     expect(mockQueryClient.ensureQueryData).toHaveBeenCalledTimes(1);
   });
 
-  // TODO: include tests related to resolveBFFQuery within ensureEnterpriseAppData
   it.each([
+    // BFF disabled, non-staff user is linked to requested customer, resolves
+    // requested customer, does not need to update active enterprise, does not
+    // need to activate subscription license
+    {
+      enterpriseSlug: mockEnterpriseCustomerTwo.slug,
+      enterpriseCustomer: mockEnterpriseCustomerTwo,
+      activeEnterpriseCustomer: mockEnterpriseCustomerTwo,
+      allLinkedEnterpriseCustomerUsers: [
+        { enterpriseCustomer: mockEnterpriseCustomer },
+        { enterpriseCustomer: mockEnterpriseCustomerTwo },
+      ],
+      isStaffUser: false,
+      shouldActivateSubscriptionLicense: false,
+      hasResolvedBFFQuery: false,
+    },
+    // BFF disabled, non-staff user is linked to requested customer, resolves
+    // requested customer, does not need to update active enterprise, needs
+    // to activate subscription license
+    {
+      enterpriseSlug: mockEnterpriseCustomerTwo.slug,
+      enterpriseCustomer: mockEnterpriseCustomerTwo,
+      activeEnterpriseCustomer: mockEnterpriseCustomerTwo,
+      allLinkedEnterpriseCustomerUsers: [
+        { enterpriseCustomer: mockEnterpriseCustomer },
+        { enterpriseCustomer: mockEnterpriseCustomerTwo },
+      ],
+      isStaffUser: false,
+      shouldActivateSubscriptionLicense: true,
+      hasResolvedBFFQuery: false,
+    },
+    // BFF disabled, non-staff user is linked to requested customer, resolves
+    // requested customer, needs update to active enterprise, does not
+    // need to activate subscription license
     {
       enterpriseSlug: mockEnterpriseCustomerTwo.slug,
       enterpriseCustomer: mockEnterpriseCustomerTwo,
@@ -98,7 +140,55 @@ describe('rootLoader', () => {
         { enterpriseCustomer: mockEnterpriseCustomerTwo },
       ],
       isStaffUser: false,
+      shouldActivateSubscriptionLicense: false,
+      hasResolvedBFFQuery: false,
     },
+    // BFF disabled, non-staff user is not linked to requested customer, resolves
+    // linked customer, does not need to update active enterprise, does not
+    // need to activate subscription license
+    {
+      enterpriseSlug: mockEnterpriseCustomerTwo.slug,
+      enterpriseCustomer: mockEnterpriseCustomer,
+      activeEnterpriseCustomer: mockEnterpriseCustomer,
+      allLinkedEnterpriseCustomerUsers: [
+        { enterpriseCustomer: mockEnterpriseCustomer },
+      ],
+      isStaffUser: false,
+      shouldActivateSubscriptionLicense: false,
+      hasResolvedBFFQuery: false,
+    },
+    // BFF disabled, staff user is not linked to requested customer, resolves
+    // requested customer, does not need to update active enterprise, does not
+    // need to activate subscription license
+    {
+      enterpriseSlug: mockEnterpriseCustomerTwo.slug,
+      enterpriseCustomer: mockEnterpriseCustomerTwo,
+      activeEnterpriseCustomer: mockEnterpriseCustomer,
+      allLinkedEnterpriseCustomerUsers: [
+        { enterpriseCustomer: mockEnterpriseCustomer },
+      ],
+      isStaffUser: true,
+      shouldActivateSubscriptionLicense: false,
+      hasResolvedBFFQuery: false,
+    },
+    // BFF disabled, staff user is linked to requested customer, resolves
+    // requested customer, needs update to active enterprise, does not
+    // need to activate subscription license
+    {
+      enterpriseSlug: mockEnterpriseCustomerTwo.slug,
+      enterpriseCustomer: mockEnterpriseCustomerTwo,
+      activeEnterpriseCustomer: mockEnterpriseCustomer,
+      allLinkedEnterpriseCustomerUsers: [
+        { enterpriseCustomer: mockEnterpriseCustomer },
+        { enterpriseCustomer: mockEnterpriseCustomerTwo },
+      ],
+      isStaffUser: true,
+      shouldActivateSubscriptionLicense: false,
+      hasResolvedBFFQuery: false,
+    },
+    // BFF enabled, non-staff user is linked to requested customer, resolves
+    // requested customer, needs update to active enterprise, does not
+    // need to activate subscription license
     {
       enterpriseSlug: mockEnterpriseCustomerTwo.slug,
       enterpriseCustomer: mockEnterpriseCustomerTwo,
@@ -108,42 +198,8 @@ describe('rootLoader', () => {
         { enterpriseCustomer: mockEnterpriseCustomerTwo },
       ],
       isStaffUser: false,
-    },
-    {
-      enterpriseSlug: mockEnterpriseCustomerTwo.slug,
-      enterpriseCustomer: mockEnterpriseCustomer,
-      activeEnterpriseCustomer: mockEnterpriseCustomer,
-      allLinkedEnterpriseCustomerUsers: [
-        { enterpriseCustomer: mockEnterpriseCustomer },
-      ],
-      isStaffUser: false,
-    },
-    {
-      enterpriseSlug: mockEnterpriseCustomerTwo.slug,
-      enterpriseCustomer: mockEnterpriseCustomer,
-      activeEnterpriseCustomer: mockEnterpriseCustomer,
-      allLinkedEnterpriseCustomerUsers: [
-        { enterpriseCustomer: mockEnterpriseCustomer },
-      ],
-      isStaffUser: false,
-    },
-    {
-      enterpriseSlug: mockEnterpriseCustomerTwo.slug,
-      enterpriseCustomer: mockEnterpriseCustomerTwo,
-      activeEnterpriseCustomer: mockEnterpriseCustomer,
-      allLinkedEnterpriseCustomerUsers: [
-        { enterpriseCustomer: mockEnterpriseCustomer },
-      ],
-      isStaffUser: true,
-    },
-    {
-      enterpriseSlug: mockEnterpriseCustomerTwo.slug,
-      enterpriseCustomer: mockEnterpriseCustomerTwo,
-      activeEnterpriseCustomer: mockEnterpriseCustomer,
-      allLinkedEnterpriseCustomerUsers: [
-        { enterpriseCustomer: mockEnterpriseCustomer },
-      ],
-      isStaffUser: true,
+      shouldActivateSubscriptionLicense: false,
+      hasResolvedBFFQuery: true,
     },
   ])('ensures all requisite root loader queries are resolved with an active enterprise customer user (%s)', async ({
     isStaffUser,
@@ -151,7 +207,12 @@ describe('rootLoader', () => {
     enterpriseCustomer,
     activeEnterpriseCustomer,
     allLinkedEnterpriseCustomerUsers,
+    shouldActivateSubscriptionLicense,
+    hasResolvedBFFQuery,
   }) => {
+    // Mock whether BFF enabled for enterprise customer and/or user
+    isBFFEnabled.mockReturnValue(hasResolvedBFFQuery);
+
     const enterpriseLearnerQuery = queryEnterpriseLearner(mockAuthenticatedUser.username, enterpriseSlug);
     const enterpriseLearnerQueryTwo = queryEnterpriseLearner(mockAuthenticatedUser.username, enterpriseCustomer.slug);
 
@@ -192,13 +253,39 @@ describe('rootLoader', () => {
     ).mockResolvedValue(mockRedeemablePolicies);
 
     // Mock subscriptions query
-    const { baseSubscriptionsData } = getBaseSubscriptionsData();
+    const { baseSubscriptionsData, baseLicensesByStatus } = getBaseSubscriptionsData();
+    const mockSubscriptionsData = { ...baseSubscriptionsData };
+    if (shouldActivateSubscriptionLicense) {
+      const mockAssignedLicense = {
+        uuid: 'assigned-license-uuid',
+        status: LICENSE_STATUS.ASSIGNED,
+        activationKey: 'assigned-license-activation-key',
+        subscriptionPlan: {
+          uuid: 'subscription-plan-uuid',
+          isCurrent: true,
+        },
+      };
+      mockSubscriptionsData.customerAgreement = {
+        uuid: 'customer-agreement-uuid',
+        netDaysUntilExpiration: 30,
+      };
+      mockSubscriptionsData.subscriptionLicenses = [mockAssignedLicense];
+      mockSubscriptionsData.subscriptionLicensesByStatus[LICENSE_STATUS.ASSIGNED] = [mockAssignedLicense];
+      mockSubscriptionsData.subscriptionLicense = mockAssignedLicense;
+      mockSubscriptionsData.subscriptionPlan = mockAssignedLicense.subscriptionPlan;
+
+      // Mock the `activateOrAutoApplySubscriptionLicense` mutation
+      activateOrAutoApplySubscriptionLicense.mockResolvedValue({
+        ...mockAssignedLicense,
+        status: LICENSE_STATUS.ACTIVATED,
+      });
+    }
     const subscriptionsQuery = querySubscriptions(enterpriseCustomer.uuid);
     when(mockQueryClient.ensureQueryData).calledWith(
       expect.objectContaining({
         queryKey: subscriptionsQuery.queryKey,
       }),
-    ).mockResolvedValue(baseSubscriptionsData);
+    ).mockResolvedValue(mockSubscriptionsData);
 
     renderWithRouterProvider({
       path: '/:enterpriseSlug',
@@ -212,15 +299,15 @@ describe('rootLoader', () => {
 
     await waitFor(() => {
       // Assert that the expected number of queries were made.
+      let expectedQueryCount = 9;
       if (enterpriseSlug !== activeEnterpriseCustomer.slug) {
-        if (isLinked || isStaffUser) {
-          expect(mockQueryClient.ensureQueryData).toHaveBeenCalledTimes(9);
-        } else {
-          expect(mockQueryClient.ensureQueryData).toHaveBeenCalledTimes(2);
+        if (!(isLinked || isStaffUser)) {
+          expectedQueryCount = 2;
         }
-      } else {
-        expect(mockQueryClient.ensureQueryData).toHaveBeenCalledTimes(9);
+      } else if (hasResolvedBFFQuery) {
+        expectedQueryCount = 8;
       }
+      expect(mockQueryClient.ensureQueryData).toHaveBeenCalledTimes(expectedQueryCount);
     });
 
     // Enterprise learner query
@@ -247,13 +334,48 @@ describe('rootLoader', () => {
       }),
     );
 
-    // Subscriptions query
-    expect(mockQueryClient.ensureQueryData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        queryKey: subscriptionsQuery.queryKey,
-        queryFn: expect.any(Function),
-      }),
-    );
+    // Subscriptions query (only called with BFF disabled)
+    if (!hasResolvedBFFQuery) {
+      expect(mockQueryClient.ensureQueryData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: subscriptionsQuery.queryKey,
+          queryFn: expect.any(Function),
+        }),
+      );
+      if (shouldActivateSubscriptionLicense) {
+        expect(activateOrAutoApplySubscriptionLicense).toHaveBeenCalledTimes(1);
+        expect(activateOrAutoApplySubscriptionLicense).toHaveBeenCalledWith({
+          enterpriseCustomer,
+          allLinkedEnterpriseCustomerUsers,
+          subscriptionsData: mockSubscriptionsData,
+          requestUrl: new URL(`http://localhost/${enterpriseSlug}`),
+        });
+
+        // Assert the subscriptions query cache is optimistically updated
+        expect(mockQueryClient.setQueryData).toHaveBeenCalledWith(subscriptionsQuery.queryKey, {
+          subscriptionLicenses: [
+            {
+              ...mockSubscriptionsData.subscriptionLicense,
+              status: LICENSE_STATUS.ACTIVATED,
+            },
+          ],
+          subscriptionLicensesByStatus: {
+            ...baseLicensesByStatus,
+            [LICENSE_STATUS.ACTIVATED]: [
+              {
+                ...mockSubscriptionsData.subscriptionLicense,
+                status: LICENSE_STATUS.ACTIVATED,
+              },
+            ],
+          },
+          subscriptionLicense: {
+            ...mockSubscriptionsData.subscriptionLicense,
+            status: LICENSE_STATUS.ACTIVATED,
+          },
+          subscriptionPlan: mockSubscriptionsData.subscriptionPlan,
+        });
+      }
+    }
 
     // Coupon codes query
     const couponCodesQuery = queryCouponCodes(enterpriseCustomer.uuid);


### PR DESCRIPTION
# Description

No longer uses `transformSubscriptionsData` on the BFF data, since the BFF does the same transforms itself now. `transformSubscriptionsData` is still needed, though, for the non-BFF supported page routes which still calls `learner-licenses` API directly.

Corresponding backend BFF PR (should be merged/released first): https://github.com/openedx/enterprise-access/pull/621

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
