### PR TITLE
fix: ensure relevant queries are pre-seeded for video and program progress routes

### DIFF
--- a/src/components/microlearning/data/videosLoader.test.jsx
+++ b/src/components/microlearning/data/videosLoader.test.jsx
@@ -1,11 +1,16 @@
-/* eslint-disable react/jsx-filename-extension */
+import { when } from 'jest-when';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { renderWithRouterProvider } from '../../../utils/tests';
 import makeVideosLoader from './videosLoader';
 import { ensureAuthenticatedUser } from '../../app/routes/data';
-import { extractEnterpriseCustomer, queryVideoDetail } from '../../app/data';
+import {
+  extractEnterpriseCustomer,
+  queryCourseMetadata,
+  queryCourseReviews,
+  queryVideoDetail,
+} from '../../app/data';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
 
 jest.mock('../../app/routes/data', () => ({
@@ -26,7 +31,7 @@ const mockVideoUUID = 'test-video-uuid';
 const mockVideosURL = `/${mockEnterpriseSlug}/videos/${mockVideoUUID}/`;
 
 const mockQueryClient = {
-  ensureQueryData: jest.fn().mockResolvedValue({}),
+  ensureQueryData: jest.fn().mockResolvedValue(),
 };
 
 describe('videosLoader', () => {
@@ -40,7 +45,7 @@ describe('videosLoader', () => {
     ensureAuthenticatedUser.mockResolvedValue(null);
     renderWithRouterProvider(
       {
-        path: '/:enterpriseSlug/videos/:videoUUID/',
+        path: '/:enterpriseSlug/videos/:videoUUID',
         element: <div>hello world</div>,
         loader: makeVideosLoader(mockQueryClient),
       },
@@ -54,10 +59,34 @@ describe('videosLoader', () => {
     expect(mockQueryClient.ensureQueryData).not.toHaveBeenCalled();
   });
 
-  it('ensures the requisite video data is resolved', async () => {
+  it.each([
+    { hasVideoDetailData: true },
+    { hasVideoDetailData: false },
+  ])('ensures the requisite video data is resolved', async ({ hasVideoDetailData }) => {
+    const mockCourseKey = 'test-course-key';
+    const videoDetailQuery = queryVideoDetail(mockVideoUUID, mockEnterpriseId);
+    const courseMetadataQuery = queryCourseMetadata(mockCourseKey);
+    const courseReviewsQuery = queryCourseReviews(mockCourseKey);
+
+    // Mock the resolved data for the queries
+    when(mockQueryClient.ensureQueryData).calledWith(
+      expect.objectContaining({
+        queryKey: videoDetailQuery.queryKey,
+      }),
+    ).mockResolvedValue(hasVideoDetailData ? { courseKey: mockCourseKey } : null);
+    when(mockQueryClient.ensureQueryData).calledWith(
+      expect.objectContaining(courseMetadataQuery),
+    ).mockResolvedValue({
+      key: mockCourseKey,
+    });
+    when(mockQueryClient.ensureQueryData).calledWith(
+      expect.objectContaining(courseReviewsQuery),
+    ).mockResolvedValue([]);
+
+    // Render the route with videosLoader
     renderWithRouterProvider(
       {
-        path: '/:enterpriseSlug/videos/:videoUUID/',
+        path: '/:enterpriseSlug/videos/:videoUUID',
         element: <div>hello world</div>,
         loader: makeVideosLoader(mockQueryClient),
       },
@@ -68,7 +97,8 @@ describe('videosLoader', () => {
 
     expect(await screen.findByText('hello world')).toBeInTheDocument();
 
-    expect(mockQueryClient.ensureQueryData).toHaveBeenCalledTimes(1);
+    const expectedQueryCount = hasVideoDetailData ? 3 : 1;
+    expect(mockQueryClient.ensureQueryData).toHaveBeenCalledTimes(expectedQueryCount);
     expect(mockQueryClient.ensureQueryData).toHaveBeenCalledWith(
       expect.objectContaining({
         queryKey: queryVideoDetail(mockVideoUUID, mockEnterpriseId).queryKey,

--- a/src/components/microlearning/data/videosLoader.ts
+++ b/src/components/microlearning/data/videosLoader.ts
@@ -1,5 +1,10 @@
 import { ensureAuthenticatedUser } from '../../app/routes/data';
-import { extractEnterpriseCustomer, queryVideoDetail } from '../../app/data';
+import {
+  extractEnterpriseCustomer,
+  queryCourseMetadata,
+  queryCourseReviews,
+  queryVideoDetail,
+} from '../../app/data';
 
 type VideoRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
   readonly videoUUID: string;
@@ -25,7 +30,14 @@ const makeVideosLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function 
       enterpriseSlug,
     });
 
-    await queryClient.ensureQueryData(queryVideoDetail(videoUUID, enterpriseCustomer.uuid));
+    const videoData = await queryClient.ensureQueryData(queryVideoDetail(videoUUID, enterpriseCustomer.uuid));
+    if (videoData) {
+      const { courseKey } = videoData;
+      await Promise.all([
+        queryClient.ensureQueryData(queryCourseMetadata(courseKey)),
+        queryClient.ensureQueryData(queryCourseReviews(courseKey)),
+      ]);
+    }
 
     return null;
   };


### PR DESCRIPTION
This PR fixes forward an issue identified after releasing https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/1256, which removes a parent `Suspense` fallback that previously caught asynchronous query loading states.

On the video detail and program progress pages routes, there was an increase in errors containing the message "a component suspended without a fallback UI specified", which suggests there are queries used during render that have not been pre-fetched in a route loader.

Replicating the issues for these 2 page routes locally, the relevant queries are now pre-fetched in the appropriate loaders, mitigating these observed errors in development.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
