### PR TITLE
fix: adds check for isMarketableExternal to course run filter

### DIFF
--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -573,7 +573,7 @@ export function getAvailableCourseRuns({ course, lateEnrollmentBufferDays }) {
   }
   // These are the standard rules used for determining whether a run is "available".
   const standardAvailableCourseRunsFilter = (courseRun) => (
-    courseRun.isMarketable && !isArchived(courseRun) && courseRun.isEnrollable
+    (courseRun.isMarketable || courseRun?.isMarketableExternal) && !isArchived(courseRun) && courseRun.isEnrollable
   );
 
   // These are more relaxed availability rules when late enrollment is applicable. We still never show archived courses,


### PR DESCRIPTION
Adds a check to the isMarketableExternal flag to the `standardAvailableCourseRunsFilter`

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
