### PR TITLE
chore: allow users to opt into major upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
     "config:recommended",
     "group:allNonMajor"
   ],
+  "major": {
+    "dependencyDashboardApproval": true
+  },
   "patch": {
     "automerge": true
   },


### PR DESCRIPTION
This is further refinement on the role of renovate in generating PRs for package updates. This change allows for the user to generate PRs for major upgrades by navigating to the renovate [dashboard ](https://github.com/openedx/frontend-app-learner-portal-enterprise/issues/302)found in the issues tab. 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
