### PR TITLE
fix: use camelCase course statuses as keys in fallback BFF response

### DIFF
--- a/src/components/app/data/services/bffs.ts
+++ b/src/components/app/data/services/bffs.ts
@@ -2,7 +2,6 @@ import { getConfig } from '@edx/frontend-platform/config';
 import { logError, logInfo } from '@edx/frontend-platform/logging';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { camelCaseObject, snakeCaseObject } from '@edx/frontend-platform/utils';
-import { COURSE_STATUSES } from '../../../../constants';
 
 export const baseLearnerBFFResponse = {
   enterpriseCustomerUserSubsidies: {
@@ -20,10 +19,10 @@ export const learnerDashboardBFFResponse = {
   ...baseLearnerBFFResponse,
   enterpriseCourseEnrollments: [],
   allEnrollmentsByStatus: {
-    [COURSE_STATUSES.inProgress]: [],
-    [COURSE_STATUSES.upcoming]: [],
-    [COURSE_STATUSES.completed]: [],
-    [COURSE_STATUSES.savedForLater]: [],
+    inProgress: [],
+    upcoming: [],
+    completed: [],
+    savedForLater: [],
   },
 };
 
@@ -62,6 +61,7 @@ export async function makeBFFRequest({
 
   // If neither enterpriseId or enterpriseSlug is provided, return the default response.
   if (!enterpriseId && !enterpriseSlug) {
+    logError('Enterprise ID or slug is required to make a BFF request.');
     return defaultResponse;
   }
 


### PR DESCRIPTION
[ENT-10028](https://2u-internal.atlassian.net/browse/ENT-10028)

The constant `learnerDashboardBFFResponse` ([source](https://github.com/openedx/frontend-app-learner-portal-enterprise/blob/2c41e5ad4a493de927c569e6fb69ea143328ddd0/src/components/app/data/services/bffs.ts#L22-L27)) intends to be the base empty state response for the Dashboard BFF, containing the empty fields where appropriate for downstream consumers of these data to access instead of erroring:

```js
export const learnerDashboardBFFResponse = {
  ...baseLearnerBFFResponse,
  enterpriseCourseEnrollments: [],
  allEnrollmentsByStatus: {
    [COURSE_STATUSES.inProgress]: [],
    [COURSE_STATUSES.upcoming]: [],
    [COURSE_STATUSES.completed]: [],
    [COURSE_STATUSES.savedForLater]: [],
  },
};
```

However, in the `allEnrollmentsByStatus` object, we use the constants like `COURSE_STATUSES.inProgress` to define the keys for each enrollment status. These constants currently use snake_case for the statuses (e.g., `in_progress`). However, in `useCourseEnrollmentsBySection` ([source](https://github.com/openedx/frontend-app-learner-portal-enterprise/blob/2c41e5ad4a493de927c569e6fb69ea143328ddd0/src/components/dashboard/main-content/course-enrollments/data/hooks.js#L431)), we expect camelCase statuses (e.g., `inProgress`).

This leads to errors such as `Spread syntax requires ...iterable not be null or undefined` ([example](https://app.datadoghq.com/error-tracking?query=%40application.id%3A244bdc29-640a-4e50-a2ef-1df06b117c1d&fromUser=false&issueId=c278e942-e314-11ef-bfe3-da7ad0900002&refresh_mode=sliding&source=all&from_ts=1738595706831&to_ts=1739200506831&live=true)) when the Dashboard BFF throws an error (e.g., returns a 401).

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
