### PR TITLE
chore: replacing legacy links

### DIFF
--- a/src/components/app/routes/LicenseActivationRoute.jsx
+++ b/src/components/app/routes/LicenseActivationRoute.jsx
@@ -43,7 +43,7 @@ const LicenseActivationRoute = () => {
           </li>
           <li>
             <Hyperlink
-              destination={`${getConfig().LMS_BASE_URL}/account/settings`}
+              destination={`${getConfig().ACCOUNT_SETTINGS_URL}`}
               variant="muted"
               isInline
             >

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -53,7 +53,7 @@ const SubscriptionExpirationModal = () => {
   };
 
   const renderCertificateText = () => (
-    <a href={`${config.LMS_BASE_URL}/u/${username}`} className="font-weight-bold">
+    <a href={`${config.ACCOUNT_PROFILE_URL}/u/${username}`} className="font-weight-bold">
       download your completed certificates
     </a>
   );

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/CompletedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/CompletedCourseCard.jsx
@@ -52,7 +52,7 @@ const CompletedCourseCard = (props) => {
           <div className="mb-0 small">
             View your certificate on{' '}
             <Hyperlink
-              destination={`${config.LMS_BASE_URL}/u/${username}`}
+              destination={`${config.ACCOUNT_PROFILE_URL}/u/${username}`}
               target="_blank"
               className={classNames('text-underline', {
                 'text-light-200': isExecutiveEducation2UCourse,

--- a/src/components/site-header/AvatarDropdown.jsx
+++ b/src/components/site-header/AvatarDropdown.jsx
@@ -96,7 +96,7 @@ const AvatarDropdown = ({ showLabel }) => {
             description: 'My profile link title in avatar dropdown.',
           })}
         </Dropdown.Item>
-       <Dropdown.Item href={ACCOUNT_SETTINGS_URL}>
+        <Dropdown.Item href={ACCOUNT_SETTINGS_URL}>
           {intl.formatMessage({
             id: 'site.header.avatar.dropdown.account.settings.title',
             defaultMessage: 'Account settings',

--- a/src/components/site-header/AvatarDropdown.jsx
+++ b/src/components/site-header/AvatarDropdown.jsx
@@ -10,6 +10,8 @@ import { useEnterpriseLearner } from '../app/data';
 
 const AvatarDropdown = ({ showLabel }) => {
   const {
+    ACCOUNT_PROFILE_URL,
+    ACCOUNT_SETTINGS_URL,
     BASE_URL,
     LMS_BASE_URL,
     LOGOUT_URL,
@@ -87,14 +89,14 @@ const AvatarDropdown = ({ showLabel }) => {
             );
           })}
         <Dropdown.Divider className="border-light" />
-        <Dropdown.Item href={`${LMS_BASE_URL}/u/${username}`}>
+        <Dropdown.Item href={`${ACCOUNT_PROFILE_URL}/u/${username}`}>
           {intl.formatMessage({
             id: 'site.header.avatar.dropdown.my.profile.title',
             defaultMessage: 'My profile',
             description: 'My profile link title in avatar dropdown.',
           })}
         </Dropdown.Item>
-        <Dropdown.Item href={`${LMS_BASE_URL}/account/settings`}>
+       <Dropdown.Item href={ACCOUNT_SETTINGS_URL}>
           {intl.formatMessage({
             id: 'site.header.avatar.dropdown.account.settings.title',
             defaultMessage: 'Account settings',


### PR DESCRIPTION
now that the legacy account and profile applications are gone, the redirect from these legacy links no longer works, so I am replacing them with direct links to the MFEs.

FIXES: APER-3884

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
