### PR TITLE
build: add tsc typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         node-version-file: '.nvmrc'
     - name: Install dependencies
       run: npm ci
+    - name: Check types
+      run: npm run check-types
     - name: Lint
       run: npm run lint
     - name: extract_translations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,28 +9,67 @@ concurrency:
 jobs:
   tests:
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Setup Nodejs
-      uses: actions/setup-node@v4
-      with:
-        node-version-file: '.nvmrc'
-    - name: Install dependencies
-      run: npm ci
-    - name: Check types
-      run: npm run check-types
-    - name: Lint
-      run: npm run lint
-    - name: extract_translations
-      run: make extract_translations
-    - name: Test
-      run: npm run test
-    - name: Upload Coverage
-      uses: codecov/codecov-action@v4
-      with:
-        fail_ci_if_error: false
-        token: ${{ secrets.CODECOV_TOKEN }}
-    - name: Build
-      run: npm run build
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Test
+        run: npm run test
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Check types
+        run: npm run check-types
+      - name: Lint
+        run: npm run lint
+
+  extract_translations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Extract Translations
+        run: make extract_translations
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "build": "fedx-scripts webpack",
     "build:with-theme": "THEME=npm:@edx/brand-edx.org@latest npm run install-theme && npm run build",
     "i18n_extract": "fedx-scripts formatjs extract --throws",
+    "check-types": "tsc --noEmit",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "lint:fix": "fedx-scripts eslint --fix --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "precommit": "npm run lint",


### PR DESCRIPTION
* Ensures TypeScript types are validated in CI.
* Parallelizes GitHub Action workflow steps for more efficient CI (e.g., running tests in parallel with `npm run build`).

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
