### PR TITLE
fix: use fluid image in course page partner logos

### DIFF
--- a/src/components/course/CreatedBy.jsx
+++ b/src/components/course/CreatedBy.jsx
@@ -1,5 +1,5 @@
 import { getConfig } from '@edx/frontend-platform';
-import { Hyperlink } from '@openedx/paragon';
+import { Hyperlink, Image } from '@openedx/paragon';
 
 import { useCoursePartners } from './data/hooks';
 import { useCourseMetadata } from '../app/data';
@@ -23,15 +23,14 @@ const CreatedBy = () => {
           {partners.map(partner => (
             <div className="col-lg-6 mb-3" key={partner.name}>
               <div className="mb-2">
-                <a
-                  href={partner.marketingUrl}
-                  aria-hidden="true"
+                <Hyperlink
+                  destination={partner.marketingUrl}
                   tabIndex="-1"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  showLaunchIcon={false}
                 >
-                  <img src={partner.logoImageUrl} alt={`${partner.name} logo`} />
-                </a>
+                  <Image src={partner.logoImageUrl} alt={`${partner.name} logo`} fluid />
+                </Hyperlink>
               </div>
               <Hyperlink destination={partner.marketingUrl} target="_blank">
                 {partner.name}


### PR DESCRIPTION
See https://enterprise.edx.org/bestrun-successfactors-test-co/course/TUMx+QPLS1x for example with quite large partner logo. Not sure why this particular's partner's logo is not the standard partner logo image size of `200x100`, but our UI should handle any image size regardless.

https://2u-internal.atlassian.net/browse/ENT-10119

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
