### PR TITLE
fix: return null on extractEnterpriseCustomer

### DIFF
--- a/src/components/app/data/queries/extractEnterpriseCustomer.test.js
+++ b/src/components/app/data/queries/extractEnterpriseCustomer.test.js
@@ -66,7 +66,7 @@ describe('extractEnterpriseCustomer', () => {
       routeEnterpriseSlug: undefined,
       enterpriseCustomerUser: undefined,
       staffEnterpriseCustomer: mockEnterpriseCustomer,
-      expectedEnterpriseCustomer: undefined,
+      expectedEnterpriseCustomer: null,
       isBFFRoute: true,
     },
     {
@@ -80,7 +80,7 @@ describe('extractEnterpriseCustomer', () => {
       routeEnterpriseSlug: mockEnterpriseCustomer.slug,
       enterpriseCustomerUser: undefined,
       staffEnterpriseCustomer: undefined,
-      expectedEnterpriseCustomer: undefined,
+      expectedEnterpriseCustomer: null,
       isBFFRoute: true,
     },
     // iaBFFRoute false
@@ -116,7 +116,7 @@ describe('extractEnterpriseCustomer', () => {
       routeEnterpriseSlug: undefined,
       enterpriseCustomerUser: undefined,
       staffEnterpriseCustomer: mockEnterpriseCustomer,
-      expectedEnterpriseCustomer: undefined,
+      expectedEnterpriseCustomer: null,
       isBFFRoute: false,
     },
     {
@@ -130,7 +130,7 @@ describe('extractEnterpriseCustomer', () => {
       routeEnterpriseSlug: mockEnterpriseCustomer.slug,
       enterpriseCustomerUser: undefined,
       staffEnterpriseCustomer: undefined,
-      expectedEnterpriseCustomer: undefined,
+      expectedEnterpriseCustomer: null,
       isBFFRoute: false,
     },
   ])('should return or throw error as expected (%s)', async ({
@@ -148,7 +148,7 @@ describe('extractEnterpriseCustomer', () => {
     };
     const queryEnterpriseLearnerResult = {
       enterpriseCustomer: expectedEnterpriseCustomer,
-      activeEnterpriseCustomer: enterpriseCustomerUser?.enterpriseCustomer,
+      activeEnterpriseCustomer: enterpriseCustomerUser?.enterpriseCustomer || null,
       allLinkedEnterpriseCustomerUsers: enterpriseCustomerUser ? [enterpriseCustomerUser] : [],
       staffEnterpriseCustomer,
       enterpriseFeatures: { something: true },

--- a/src/components/app/data/queries/extractEnterpriseCustomer.ts
+++ b/src/components/app/data/queries/extractEnterpriseCustomer.ts
@@ -1,3 +1,4 @@
+import { logError } from '@edx/frontend-platform/logging';
 import { getEnterpriseLearnerQueryData } from './utils';
 
 interface ExtractEnterpriseCustomerArgs {
@@ -48,8 +49,9 @@ async function extractEnterpriseCustomer({
     return foundEnterpriseCustomerForSlug || staffEnterpriseCustomer;
   }
 
-  // If no enterprise customer is found for the given user/slug, throw an error.
-  throw new Error(`Could not find enterprise customer for slug ${enterpriseSlug}`);
+  // If no enterprise customer is found for the given user/slug, log an error and display a 404 from return null.
+  logError(`Could not find enterprise customer for slug ${enterpriseSlug}`);
+  return null;
 }
 
 export default extractEnterpriseCustomer;

--- a/src/components/app/data/queries/utils.js
+++ b/src/components/app/data/queries/utils.js
@@ -67,8 +67,8 @@ export async function getEnterpriseLearnerQueryData({
       activeEnterpriseCustomer: bffResponse.activeEnterpriseCustomer || null,
       allLinkedEnterpriseCustomerUsers: bffResponse.allLinkedEnterpriseCustomerUsers || [],
       staffEnterpriseCustomer: bffResponse.staffEnterpriseCustomer || null,
-      enterpriseFeatures: bffResponse.enterpriseFeatures || null,
-      shouldUpdateActiveEnterpriseCustomerUser: bffResponse.shouldUpdateActiveEnterpriseCustomerUser || null,
+      enterpriseFeatures: bffResponse.enterpriseFeatures || {},
+      shouldUpdateActiveEnterpriseCustomerUser: bffResponse.shouldUpdateActiveEnterpriseCustomerUser || false,
     };
   } else {
     enterpriseLearnerData = await queryClient.ensureQueryData(

--- a/src/components/app/data/queries/utils.js
+++ b/src/components/app/data/queries/utils.js
@@ -63,12 +63,12 @@ export async function getEnterpriseLearnerQueryData({
       matchedBFFQuery({ enterpriseSlug }),
     );
     enterpriseLearnerData = {
-      enterpriseCustomer: bffResponse.enterpriseCustomer,
-      activeEnterpriseCustomer: bffResponse.activeEnterpriseCustomer,
-      allLinkedEnterpriseCustomerUsers: bffResponse.allLinkedEnterpriseCustomerUsers,
-      staffEnterpriseCustomer: bffResponse.staffEnterpriseCustomer,
-      enterpriseFeatures: bffResponse.enterpriseFeatures,
-      shouldUpdateActiveEnterpriseCustomerUser: bffResponse.shouldUpdateActiveEnterpriseCustomerUser,
+      enterpriseCustomer: bffResponse.enterpriseCustomer || null,
+      activeEnterpriseCustomer: bffResponse.activeEnterpriseCustomer || null,
+      allLinkedEnterpriseCustomerUsers: bffResponse.allLinkedEnterpriseCustomerUsers || [],
+      staffEnterpriseCustomer: bffResponse.staffEnterpriseCustomer || null,
+      enterpriseFeatures: bffResponse.enterpriseFeatures || null,
+      shouldUpdateActiveEnterpriseCustomerUser: bffResponse.shouldUpdateActiveEnterpriseCustomerUser || null,
     };
   } else {
     enterpriseLearnerData = await queryClient.ensureQueryData(

--- a/src/components/app/routes/RouteErrorBoundary.jsx
+++ b/src/components/app/routes/RouteErrorBoundary.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useAsyncError, useRouteError } from 'react-router-dom';
 import { logError, logInfo } from '@edx/frontend-platform/logging';
-import { FormattedMessage, defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+import { defineMessages, FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import {
   ActionRow, AlertModal, Button, useToggle,
 } from '@openedx/paragon';
@@ -83,6 +83,7 @@ function useHandleErrorsOrAppUpdate() {
     error: routeError,
     isAppUpdateAvailable,
   } = useHandleRouteError();
+
   const asyncError = useHandleAsyncError();
 
   const error = routeError || asyncError;


### PR DESCRIPTION
We return null and log an error as opposed to throwing the error. If the user reaches this state, they are most likely unauthenticated or do not have access to the learner portal and refreshing the page as part of this error message will not yield different results.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
