### PR TITLE
fix: return null for enterpriseLearnerData enterprise customer to display 404

### DIFF
--- a/src/components/app/data/services/enterpriseCustomerUser.test.js
+++ b/src/components/app/data/services/enterpriseCustomerUser.test.js
@@ -148,9 +148,12 @@ describe('fetchEnterpriseLearnerData', () => {
       return null;
     };
 
-    const getExpectedActiveEnterpriseCustomer = () => (
-      isLinkedToEnterpriseCustomer ? expectedTransformedEnterpriseCustomer : null
-    );
+    const getExpectedActiveEnterpriseCustomer = () => {
+      if (isStaffUser || isLinkedToEnterpriseCustomer) {
+        return expectedTransformedEnterpriseCustomer;
+      }
+      return null;
+    };
 
     const expectedEnterpriseCustomer = getExpectedEnterpriseCustomer();
     const expectedActiveEnterpriseCustomer = getExpectedActiveEnterpriseCustomer();

--- a/src/components/app/data/services/enterpriseCustomerUser.test.js
+++ b/src/components/app/data/services/enterpriseCustomerUser.test.js
@@ -149,7 +149,7 @@ describe('fetchEnterpriseLearnerData', () => {
     };
 
     const getExpectedActiveEnterpriseCustomer = () => (
-      isLinkedToEnterpriseCustomer && enableLearnerPortal ? expectedTransformedEnterpriseCustomer : null
+      isLinkedToEnterpriseCustomer ? expectedTransformedEnterpriseCustomer : null
     );
 
     const expectedEnterpriseCustomer = getExpectedEnterpriseCustomer();
@@ -163,8 +163,8 @@ describe('fetchEnterpriseLearnerData', () => {
           ...ecu,
           enterpriseCustomer: expectedEnterpriseCustomer,
         }))
-        .filter((ecu) => ecu.enterpriseCustomer),
-      staffEnterpriseCustomer: isStaffUser ? expectedEnterpriseCustomer : undefined,
+        .filter((ecu) => !!ecu.enterpriseCustomer?.enableLearnerPortal),
+      staffEnterpriseCustomer: isStaffUser && enableLearnerPortal ? expectedEnterpriseCustomer : null,
       shouldUpdateActiveEnterpriseCustomerUser: false,
     });
   });

--- a/src/components/app/data/services/enterpriseCustomerUser.ts
+++ b/src/components/app/data/services/enterpriseCustomerUser.ts
@@ -80,7 +80,6 @@ Promise<Types.EnterpriseLearnerData> {
           enterpriseCustomer: transformEnterpriseCustomer(enterpriseCustomerUser.enterpriseCustomer),
         }),
       );
-      // .filter(enterpriseCustomerUser => !!enterpriseCustomerUser.enterpriseCustomer);
 
     const activeLinkedEnterpriseCustomerUser = transformedEnterpriseCustomersUsers.find(
       enterpriseCustomerUser => enterpriseCustomerUser.active,
@@ -102,6 +101,7 @@ Promise<Types.EnterpriseLearnerData> {
       const originalStaffEnterpriseCustomer = await fetchEnterpriseCustomerForSlug(enterpriseSlug);
       if (originalStaffEnterpriseCustomer) {
         staffEnterpriseCustomer = transformEnterpriseCustomer(originalStaffEnterpriseCustomer);
+        staffEnterpriseCustomer = staffEnterpriseCustomer.enableLearnerPortal ? staffEnterpriseCustomer : null;
       }
     }
 
@@ -114,12 +114,16 @@ Promise<Types.EnterpriseLearnerData> {
       staffEnterpriseCustomer,
     });
 
+    const learnerPortalEnabledEnterpriseCustomerUsers = transformedEnterpriseCustomersUsers.filter(
+      enterpriseCustomerUser => !!enterpriseCustomerUser.enterpriseCustomer?.enableLearnerPortal,
+    );
+
     // shouldUpdateActiveEnterpriseCustomerUser should always be false since its generated primarily from the BFF
     // layer to act as a flag on whether to update the active enterprise customer
     return {
       enterpriseCustomer: enterpriseCustomer || null,
       activeEnterpriseCustomer: activeEnterpriseCustomer || null,
-      allLinkedEnterpriseCustomerUsers: transformedEnterpriseCustomersUsers || [],
+      allLinkedEnterpriseCustomerUsers: learnerPortalEnabledEnterpriseCustomerUsers || [],
       enterpriseFeatures: enterpriseFeatures || {},
       staffEnterpriseCustomer: staffEnterpriseCustomer || null,
       shouldUpdateActiveEnterpriseCustomerUser: false,

--- a/src/components/app/data/services/enterpriseCustomerUser.ts
+++ b/src/components/app/data/services/enterpriseCustomerUser.ts
@@ -86,14 +86,14 @@ Promise<Types.EnterpriseLearnerData> {
     );
 
     const activeEnterpriseCustomer = activeLinkedEnterpriseCustomerUser?.enterpriseCustomer || null;
-
+    console.log(transformedEnterpriseCustomersUsers);
     // Find enterprise customer metadata for the currently viewed
     // enterprise slug in the page route params.
     const foundEnterpriseCustomerUserForCurrentSlug = transformedEnterpriseCustomersUsers.find(
       enterpriseCustomerUser => enterpriseCustomerUser.enterpriseCustomer?.slug === enterpriseSlug,
     );
 
-    // If no enterprise customer is found (i.e., authenticated user not explicitly
+    // If no enterprise customer is found (i.e., authenticated user not explicitlyand
     // linked), but the authenticated user is staff, attempt to retrieve enterprise
     // customer metadata from the `/enterprise-customer` LMS API.
     let staffEnterpriseCustomer;
@@ -104,7 +104,7 @@ Promise<Types.EnterpriseLearnerData> {
         staffEnterpriseCustomer = staffEnterpriseCustomer.enableLearnerPortal ? staffEnterpriseCustomer : null;
       }
     }
-
+    console.log(activeEnterpriseCustomer, enterpriseSlug, foundEnterpriseCustomerUserForCurrentSlug, staffEnterpriseCustomer);
     const {
       enterpriseCustomer,
     } = determineEnterpriseCustomerUserForDisplay({
@@ -118,12 +118,14 @@ Promise<Types.EnterpriseLearnerData> {
       enterpriseCustomerUser => !!enterpriseCustomerUser.enterpriseCustomer?.enableLearnerPortal,
     );
 
+    console.log(enterpriseCustomer);
+
     // shouldUpdateActiveEnterpriseCustomerUser should always be false since its generated primarily from the BFF
     // layer to act as a flag on whether to update the active enterprise customer
     return {
       enterpriseCustomer: enterpriseCustomer || null,
       activeEnterpriseCustomer: activeEnterpriseCustomer || null,
-      allLinkedEnterpriseCustomerUsers: learnerPortalEnabledEnterpriseCustomerUsers || [],
+      allLinkedEnterpriseCustomerUsers: transformedEnterpriseCustomersUsers || [],
       enterpriseFeatures: enterpriseFeatures || {},
       staffEnterpriseCustomer: staffEnterpriseCustomer || null,
       shouldUpdateActiveEnterpriseCustomerUser: false,

--- a/src/components/app/data/services/enterpriseCustomerUser.ts
+++ b/src/components/app/data/services/enterpriseCustomerUser.ts
@@ -79,8 +79,8 @@ Promise<Types.EnterpriseLearnerData> {
           ...enterpriseCustomerUser,
           enterpriseCustomer: transformEnterpriseCustomer(enterpriseCustomerUser.enterpriseCustomer),
         }),
-      )
-      .filter(enterpriseCustomerUser => !!enterpriseCustomerUser.enterpriseCustomer);
+      );
+      // .filter(enterpriseCustomerUser => !!enterpriseCustomerUser.enterpriseCustomer);
 
     const activeLinkedEnterpriseCustomerUser = transformedEnterpriseCustomersUsers.find(
       enterpriseCustomerUser => enterpriseCustomerUser.active,
@@ -114,14 +114,14 @@ Promise<Types.EnterpriseLearnerData> {
       staffEnterpriseCustomer,
     });
 
-    // shouldUpdateActiveEnterpriseCustomerUser should always be null since its generated primarily from the BFF
+    // shouldUpdateActiveEnterpriseCustomerUser should always be false since its generated primarily from the BFF
     // layer to act as a flag on whether to update the active enterprise customer
     return {
-      enterpriseCustomer,
-      activeEnterpriseCustomer,
-      allLinkedEnterpriseCustomerUsers: transformedEnterpriseCustomersUsers,
-      enterpriseFeatures,
-      staffEnterpriseCustomer,
+      enterpriseCustomer: enterpriseCustomer || null,
+      activeEnterpriseCustomer: activeEnterpriseCustomer || null,
+      allLinkedEnterpriseCustomerUsers: transformedEnterpriseCustomersUsers || [],
+      enterpriseFeatures: enterpriseFeatures || {},
+      staffEnterpriseCustomer: staffEnterpriseCustomer || null,
       shouldUpdateActiveEnterpriseCustomerUser: false,
     };
   } catch (error) {

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -146,10 +146,7 @@ export function determineEnterpriseCustomerUserForDisplay({
   foundEnterpriseCustomerUserForCurrentSlug,
   staffEnterpriseCustomer,
 }) {
-  if (
-    foundEnterpriseCustomerUserForCurrentSlug
-    && !foundEnterpriseCustomerUserForCurrentSlug.enterpriseCustomer.enableLearnerPortal
-  ) {
+  if (foundEnterpriseCustomerUserForCurrentSlug?.enterpriseCustomer.enableLearnerPortal === false) {
     return {
       enterpriseCustomer: null,
     };
@@ -165,7 +162,10 @@ export function determineEnterpriseCustomerUserForDisplay({
   // If the enterprise slug in the URL does not match the active enterprise
   // customer user's slug and there is a linked enterprise customer user for
   // the requested slug, return the linked enterprise customer user.
-  if (enterpriseSlug !== activeEnterpriseCustomer?.slug && foundEnterpriseCustomerUserForCurrentSlug) {
+  if (
+    enterpriseSlug !== activeEnterpriseCustomer?.slug
+    && foundEnterpriseCustomerUserForCurrentSlug?.enterpriseCustomer.enableLearnerPortal
+  ) {
     return {
       enterpriseCustomer: foundEnterpriseCustomerUserForCurrentSlug.enterpriseCustomer,
     };

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -146,6 +146,14 @@ export function determineEnterpriseCustomerUserForDisplay({
   foundEnterpriseCustomerUserForCurrentSlug,
   staffEnterpriseCustomer,
 }) {
+  if (
+    foundEnterpriseCustomerUserForCurrentSlug
+    && !foundEnterpriseCustomerUserForCurrentSlug.enterpriseCustomer.enableLearnerPortal
+  ) {
+    return {
+      enterpriseCustomer: null,
+    };
+  }
   const activeEnterpriseCustomerUser = {
     enterpriseCustomer: activeEnterpriseCustomer,
   };
@@ -165,7 +173,7 @@ export function determineEnterpriseCustomerUserForDisplay({
 
   if (staffEnterpriseCustomer) {
     return {
-      enterpriseCustomer: staffEnterpriseCustomer,
+      enterpriseCustomer: staffEnterpriseCustomer.enableLearnerPortal ? staffEnterpriseCustomer : null,
     };
   }
 
@@ -272,12 +280,6 @@ export function getAssignmentsByState(assignments = []) {
  * @returns
  */
 export function transformEnterpriseCustomer(enterpriseCustomer) {
-  // If the learner portal is not enabled for the displayed enterprise customer, return null. This
-  // results in the enterprise learner portal not being accessible for the user, showing a 404 page.
-  // This logic needs to be maintained for individuals checks against the enterprise customer for staff users
-  if (!enterpriseCustomer.enableLearnerPortal) {
-    return null;
-  }
   // Otherwise, learner portal is enabled, so transform the enterprise customer data.
   const disableSearch = !!(
     !enterpriseCustomer.enableIntegratedCustomerLearnerPortalSearch

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -146,11 +146,18 @@ export function determineEnterpriseCustomerUserForDisplay({
   foundEnterpriseCustomerUserForCurrentSlug,
   staffEnterpriseCustomer,
 }) {
+  if (staffEnterpriseCustomer) {
+    return {
+      enterpriseCustomer: staffEnterpriseCustomer.enableLearnerPortal ? staffEnterpriseCustomer : null,
+    };
+  }
+
   if (foundEnterpriseCustomerUserForCurrentSlug?.enterpriseCustomer.enableLearnerPortal === false) {
     return {
       enterpriseCustomer: null,
     };
   }
+
   const activeEnterpriseCustomerUser = {
     enterpriseCustomer: activeEnterpriseCustomer,
   };
@@ -162,18 +169,11 @@ export function determineEnterpriseCustomerUserForDisplay({
   // If the enterprise slug in the URL does not match the active enterprise
   // customer user's slug and there is a linked enterprise customer user for
   // the requested slug, return the linked enterprise customer user.
-  if (
-    enterpriseSlug !== activeEnterpriseCustomer?.slug
-    && foundEnterpriseCustomerUserForCurrentSlug?.enterpriseCustomer.enableLearnerPortal
-  ) {
+  if (enterpriseSlug !== activeEnterpriseCustomer?.slug) {
     return {
-      enterpriseCustomer: foundEnterpriseCustomerUserForCurrentSlug.enterpriseCustomer,
-    };
-  }
-
-  if (staffEnterpriseCustomer) {
-    return {
-      enterpriseCustomer: staffEnterpriseCustomer.enableLearnerPortal ? staffEnterpriseCustomer : null,
+      enterpriseCustomer: foundEnterpriseCustomerUserForCurrentSlug
+        ? foundEnterpriseCustomerUserForCurrentSlug?.enterpriseCustomer
+        : null,
     };
   }
 

--- a/src/components/app/routes/data/utils.js
+++ b/src/components/app/routes/data/utils.js
@@ -275,6 +275,7 @@ export async function ensureActiveEnterpriseCustomerUser({
   const {
     shouldUpdateActiveEnterpriseCustomerUser,
   } = enterpriseLearnerData;
+  console.log(enterpriseLearnerData);
   const matchedBFFQuery = resolveBFFQuery(requestUrl.pathname);
   // If the enterprise slug in the URL matches the active enterprise customer user's slug OR no
   // active enterprise customer exists, return early.

--- a/src/components/app/routes/data/utils.test.js
+++ b/src/components/app/routes/data/utils.test.js
@@ -16,14 +16,6 @@ jest.mock('../../data', () => ({
 }));
 
 describe('transformEnterpriseCustomer', () => {
-  it('returns null with disabled learner portal', () => {
-    const enterpriseCustomer = {
-      enableLearnerPortal: false,
-    };
-    const result = transformEnterpriseCustomer(enterpriseCustomer);
-    expect(result).toBeNull();
-  });
-
   it.each([
     {
       identityProvider: undefined,

--- a/src/components/course/data/courseLoader.ts
+++ b/src/components/course/data/courseLoader.ts
@@ -60,6 +60,7 @@ const makeCourseLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function 
       authenticatedUser,
       enterpriseSlug,
     });
+
     if (!enterpriseCustomer) {
       return null;
     }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,4 @@
-import {
-  matchPath, Outlet,
-} from 'react-router-dom';
+import { matchPath, Outlet } from 'react-router-dom';
 import { PageWrap } from '@edx/frontend-platform/react';
 
 import RouteErrorBoundary from './components/app/routes/RouteErrorBoundary';
@@ -251,7 +249,6 @@ export function getRoutes(queryClient?: Types.QueryClient) {
       element: <NotFoundPage />,
     },
   ];
-
   const routes: Types.RouteObject[] = [
     {
       path: '/',


### PR DESCRIPTION
On non bff enabled routes, if the enterprise learner portal is not enabled, it should display a 404. 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
