### PR TITLE
fix: update integration warning logic to check active LMS integrations

### DIFF
--- a/src/components/app/data/services/data/__factories__/enterpriseCustomerUser.factory.ts
+++ b/src/components/app/data/services/data/__factories__/enterpriseCustomerUser.factory.ts
@@ -36,7 +36,16 @@ Factory.define('enterpriseCustomer')
     primary_color: faker.internet.color(),
     secondary_color: faker.internet.color(),
     tertiary_color: faker.internet.color(),
-  });
+  })
+  .attr('active_integrations', [
+    {
+      channel_code: faker.word.adjective({ length: 4 }).toUpperCase(),
+      created: dayjs().toISOString(),
+      modified: dayjs().toISOString(),
+      display_name: faker.company.name(),
+      active: faker.datatype.boolean(),
+    },
+  ]);
 export function enterpriseCustomerFactory(overrides = {}): Types.EnterpriseCustomer {
   return camelCaseObject(Factory.build('enterpriseCustomer', overrides));
 }

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -277,7 +277,7 @@ export function transformEnterpriseCustomer(enterpriseCustomer) {
     !enterpriseCustomer.enableIntegratedCustomerLearnerPortalSearch
     && enterpriseCustomer.identityProvider
   );
-  const showIntegrationWarning = !!(!disableSearch && enterpriseCustomer.identityProvider);
+  const showIntegrationWarning = !!(!disableSearch && enterpriseCustomer.activeIntegrations?.length > 0);
   const brandColors = getBrandColorsFromCSSVariables();
   const defaultPrimaryColor = brandColors.primary;
   const defaultSecondaryColor = brandColors.info100;

--- a/src/components/app/routes/data/utils.test.js
+++ b/src/components/app/routes/data/utils.test.js
@@ -16,34 +16,40 @@ jest.mock('../../data', () => ({
 }));
 
 describe('transformEnterpriseCustomer', () => {
+  const factoryActiveIntegrations = enterpriseCustomerFactory().activeIntegrations;
   it.each([
     {
       identityProvider: undefined,
       enableIntegratedCustomerLearnerPortalSearch: false,
+      activeIntegrations: [],
       expectedDisableSearch: false,
       expectedShowIntegrationWarning: false,
     },
     {
       identityProvider: undefined,
       enableIntegratedCustomerLearnerPortalSearch: true,
+      activeIntegrations: [],
       expectedDisableSearch: false,
       expectedShowIntegrationWarning: false,
     },
     {
       identityProvider: 'example-idp',
       enableIntegratedCustomerLearnerPortalSearch: false,
+      activeIntegrations: [],
       expectedDisableSearch: true,
       expectedShowIntegrationWarning: false,
     },
     {
       identityProvider: 'example-idp',
       enableIntegratedCustomerLearnerPortalSearch: true,
+      activeIntegrations: factoryActiveIntegrations,
       expectedDisableSearch: false,
       expectedShowIntegrationWarning: true,
     },
   ])('returns transformed enterprise customer with enabled learner portal (%s)', ({
     identityProvider,
     enableIntegratedCustomerLearnerPortalSearch,
+    activeIntegrations,
     expectedDisableSearch,
     expectedShowIntegrationWarning,
   }) => {
@@ -51,6 +57,7 @@ describe('transformEnterpriseCustomer', () => {
       enableLearnerPortal: true,
       enableIntegratedCustomerLearnerPortalSearch,
       identityProvider,
+      activeIntegrations,
       brandingConfiguration: {
         primaryColor: '#123456',
         secondaryColor: '#789abc',


### PR DESCRIPTION
Adjust the display logic for the Integration Warning modal in the Learner Portal. Previously, the modal displayed when search was enabled and an identity provider was configured. This resulted in confusion for customers who did not have an LMS integration but saw the modal due to having SSO enabled.

Changes:
- Update the condition to display the Integration Warning modal only if the enterprise customer has an active LMS integration.
- Use the active_integrations field from the BFF or direct LMS API call as the new condition.
- Ensure customers without LMS integrations do not see the modal, regardless of SSO setup.

Ticket Reference: [ENT-10068 - IntegrationWarning showing for a customer with search enabled and no identity provider.](https://2u-internal.atlassian.net/browse/ENT-10068)