### PR TITLE
feat: integrate BFF API for search, academy detail, and skills quiz routes

### DIFF
--- a/src/components/academies/data/academyLoader.ts
+++ b/src/components/academies/data/academyLoader.ts
@@ -1,15 +1,15 @@
 import { ensureAuthenticatedUser } from '../../app/routes/data';
 import { extractEnterpriseCustomer, queryAcademiesDetail } from '../../app/data';
 
-type AcademyRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
+type AcademyRouteParams<Key extends string = string> = RouteParams<Key> & {
   readonly academyUUID: string;
   readonly enterpriseSlug: string;
 };
-interface AcademyLoaderFunctionArgs extends Types.RouteLoaderFunctionArgs {
+interface AcademyLoaderFunctionArgs extends RouteLoaderFunctionArgs {
   params: AcademyRouteParams;
 }
 
-const makeAcademiesLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function makeAcademiesLoader(queryClient) {
+const makeAcademiesLoader: MakeRouteLoaderFunctionWithQueryClient = function makeAcademiesLoader(queryClient) {
   return async function academiesLoader({ params, request }: AcademyLoaderFunctionArgs) {
     const requestUrl = new URL(request.url);
     const authenticatedUser = await ensureAuthenticatedUser(requestUrl, params);

--- a/src/components/app/data/hooks/useBFF.test.jsx
+++ b/src/components/app/data/hooks/useBFF.test.jsx
@@ -121,7 +121,7 @@ describe('useBFF', () => {
       <MemoryRouter initialEntries={initialEntries}>
         <Routes>
           <Route path=":enterpriseSlug" element={children} />
-          <Route path=":enterpriseSlug/search" element={children} />
+          <Route path=":enterpriseSlug/unsupported-bff-route" element={children} />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>
@@ -176,7 +176,7 @@ describe('useBFF', () => {
       mockBFFQueryOptions.select = mockSelect;
       mockFallbackQueryConfig.select = mockSelect;
     }
-    const initialEntries = isMatchedBFFRoute ? ['/test-enterprise'] : ['/test-enterprise/search'];
+    const initialEntries = isMatchedBFFRoute ? ['/test-enterprise'] : ['/test-enterprise/unsupported-bff-route'];
     const { result, waitForNextUpdate } = renderHook(
       () => useBFF({
         bffQueryOptions: {

--- a/src/components/app/data/hooks/useEnterpriseCustomer.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseCustomer.test.jsx
@@ -56,7 +56,7 @@ describe('useEnterpriseCustomer', () => {
       <MemoryRouter initialEntries={initialEntries}>
         <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
           <Routes>
-            <Route path=":enterpriseSlug/search?" element={children} />
+            <Route path=":enterpriseSlug/unsupported-bff-route?" element={children} />
           </Routes>
         </AppContext.Provider>
       </MemoryRouter>
@@ -80,7 +80,7 @@ describe('useEnterpriseCustomer', () => {
       fetchEnterpriseLearnerData.mockResolvedValue(mockEnterpriseLearnerData);
     }
     const mockSelect = jest.fn(data => data.transformed);
-    const initialEntries = isMatchedBFFRoute ? ['/test-enterprise'] : ['/test-enterprise/search'];
+    const initialEntries = isMatchedBFFRoute ? ['/test-enterprise'] : ['/test-enterprise/unsupported-bff-route'];
     const enterpriseCustomerHookArgs = hasCustomSelect ? { select: mockSelect } : {};
     const { result, waitForNextUpdate } = renderHook(
       () => (useEnterpriseCustomer(enterpriseCustomerHookArgs)),

--- a/src/components/app/data/hooks/useEnterpriseFeatures.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseFeatures.test.jsx
@@ -57,7 +57,7 @@ describe('useEnterpriseFeatures', () => {
       <MemoryRouter initialEntries={initialEntries}>
         <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
           <Routes>
-            <Route path=":enterpriseSlug/search?" element={children} />
+            <Route path=":enterpriseSlug/unsupported-bff-route?" element={children} />
           </Routes>
         </AppContext.Provider>
       </MemoryRouter>
@@ -83,7 +83,7 @@ describe('useEnterpriseFeatures', () => {
       fetchEnterpriseLearnerData.mockResolvedValue(mockEnterpriseLearnerData);
     }
     const mockSelect = jest.fn(data => data.transformed);
-    const initialEntries = isMatchedBFFRoute ? ['/test-enterprise'] : ['/test-enterprise/search'];
+    const initialEntries = isMatchedBFFRoute ? ['/test-enterprise'] : ['/test-enterprise/unsupported-bff-route'];
     const enterpriseFeatureHookArgs = hasCustomSelect ? { select: mockSelect } : {};
     const { result, waitForNextUpdate } = renderHook(
       () => (useEnterpriseFeatures(enterpriseFeatureHookArgs)),

--- a/src/components/app/data/hooks/useEnterpriseLearner.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseLearner.test.jsx
@@ -67,7 +67,7 @@ describe('useEnterpriseLearner', () => {
       <MemoryRouter initialEntries={initialEntries}>
         <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
           <Routes>
-            <Route path=":enterpriseSlug/search?" element={children} />
+            <Route path=":enterpriseSlug/unsupported-bff-route?" element={children} />
           </Routes>
         </AppContext.Provider>
       </MemoryRouter>
@@ -93,7 +93,7 @@ describe('useEnterpriseLearner', () => {
       fetchEnterpriseLearnerData.mockResolvedValue(mockEnterpriseLearnerData);
     }
     const mockSelect = jest.fn(data => data.transformed);
-    const initialEntries = isMatchedBFFRoute ? ['/test-enterprise'] : ['/test-enterprise/search'];
+    const initialEntries = isMatchedBFFRoute ? ['/test-enterprise'] : ['/test-enterprise/unsupported-bff-route'];
     const enterpriseLearnerHookArgs = hasCustomSelect ? { select: mockSelect } : {};
     const { result, waitForNextUpdate } = renderHook(
       () => (useEnterpriseLearner(enterpriseLearnerHookArgs)),

--- a/src/components/app/data/hooks/useNProgressLoader.ts
+++ b/src/components/app/data/hooks/useNProgressLoader.ts
@@ -13,7 +13,7 @@ export interface UseNProgressLoaderOptions {
 }
 
 function useNProgressLoader({ shouldCompleteBeforeUnmount = true }: UseNProgressLoaderOptions = {}) {
-  const { authenticatedUser }: Types.AppContextValue = useContext(AppContext);
+  const { authenticatedUser }: AppContextValue = useContext(AppContext);
   const isAuthenticatedUserHydrated = !!authenticatedUser?.extendedProfile;
   const navigation = useNavigation();
   const fetchers = useFetchers();

--- a/src/components/app/data/queries/extractEnterpriseCustomer.test.js
+++ b/src/components/app/data/queries/extractEnterpriseCustomer.test.js
@@ -21,7 +21,7 @@ const mockEnterpriseCustomerUser = enterpriseCustomerUserFactory({
   },
 });
 const mockBFFRequestUrl = new URL(`/${mockEnterpriseCustomer.slug}`, 'https://example.com');
-const mockNonBFFRequestUrl = new URL(`/${mockEnterpriseCustomer.slug}/search`, 'https://example.com');
+const mockNonBFFRequestUrl = new URL(`/${mockEnterpriseCustomer.slug}/unsupported-bff-route`, 'https://example.com');
 const getQueryEnterpriseLearner = ({ hasEnterpriseSlug = true } = {}) => queryEnterpriseLearner(
   mockAuthenticatedUser.username,
   hasEnterpriseSlug ? mockEnterpriseCustomer.slug : undefined,

--- a/src/components/app/data/queries/extractEnterpriseCustomer.ts
+++ b/src/components/app/data/queries/extractEnterpriseCustomer.ts
@@ -3,8 +3,8 @@ import { getEnterpriseLearnerQueryData } from './utils';
 
 interface ExtractEnterpriseCustomerArgs {
   requestUrl: URL,
-  queryClient: Types.QueryClient;
-  authenticatedUser: Types.AuthenticatedUser;
+  queryClient: QueryClient;
+  authenticatedUser: AuthenticatedUser;
   enterpriseSlug?: string;
 }
 
@@ -16,7 +16,7 @@ async function extractEnterpriseCustomer({
   queryClient,
   authenticatedUser,
   enterpriseSlug,
-} : ExtractEnterpriseCustomerArgs): Promise<Types.EnterpriseCustomer | null> {
+} : ExtractEnterpriseCustomerArgs): Promise<EnterpriseCustomer | null> {
   // Retrieve linked enterprise customers for the current user from query cache, or
   // fetch from the server if not available.
   const { data: enterpriseLearnerData } = await getEnterpriseLearnerQueryData({

--- a/src/components/app/data/queries/extractEnterpriseFeatures.ts
+++ b/src/components/app/data/queries/extractEnterpriseFeatures.ts
@@ -1,8 +1,8 @@
 import { queryEnterpriseLearner } from './queries';
 
 interface ExtractEnterpriseCustomerArgs {
-  queryClient: Types.QueryClient;
-  authenticatedUser: Types.AuthenticatedUser;
+  queryClient: QueryClient;
+  authenticatedUser: AuthenticatedUser;
   enterpriseSlug?: string;
 }
 
@@ -13,7 +13,7 @@ async function extractEnterpriseFeatures({
   queryClient,
   authenticatedUser,
   enterpriseSlug,
-} : ExtractEnterpriseCustomerArgs) : Promise<Types.EnterpriseFeatures> {
+} : ExtractEnterpriseCustomerArgs) : Promise<EnterpriseFeatures> {
   // Retrieve linked enterprise customers for the current user from query cache, or
   // fetch from the server if not available.
   const linkedEnterpriseCustomersQuery = queryEnterpriseLearner(authenticatedUser.username, enterpriseSlug);

--- a/src/components/app/data/queries/queries.ts
+++ b/src/components/app/data/queries/queries.ts
@@ -211,7 +211,7 @@ export function queryRequestsContextQueryKey(enterpriseUuid: string) {
 export function queryLicenseRequests(
   enterpriseUuid: string,
   userEmail: string,
-  state: Types.SubsidyRequestState = SUBSIDY_REQUEST_STATE.REQUESTED,
+  state: SubsidyRequestState = SUBSIDY_REQUEST_STATE.REQUESTED,
 ) {
   return queries
     .enterprise
@@ -225,7 +225,7 @@ export function queryLicenseRequests(
 export function queryCouponCodeRequests(
   enterpriseUuid: string,
   userEmail: string,
-  state: Types.SubsidyRequestState = SUBSIDY_REQUEST_STATE.REQUESTED,
+  state: SubsidyRequestState = SUBSIDY_REQUEST_STATE.REQUESTED,
 ) {
   return queries
     .enterprise
@@ -267,10 +267,35 @@ export function queryVideoDetail(videoUUID: string, enterpriseUUID: string) {
 }
 
 // BFF queries
+
 export function queryEnterpriseLearnerDashboardBFF({ enterpriseSlug }) {
   return queries
     .bff
     .enterpriseSlug(enterpriseSlug)
     ._ctx.route
     ._ctx.dashboard;
+}
+
+export function queryEnterpriseLearnerSearchBFF({ enterpriseSlug }) {
+  return queries
+    .bff
+    .enterpriseSlug(enterpriseSlug)
+    ._ctx.route
+    ._ctx.search;
+}
+
+export function queryEnterpriseLearnerAcademyBFF({ enterpriseSlug }) {
+  return queries
+    .bff
+    .enterpriseSlug(enterpriseSlug)
+    ._ctx.route
+    ._ctx.academy;
+}
+
+export function queryEnterpriseLearnerSkillsQuizBFF({ enterpriseSlug }) {
+  return queries
+    .bff
+    .enterpriseSlug(enterpriseSlug)
+    ._ctx.route
+    ._ctx.skillsQuiz;
 }

--- a/src/components/app/data/queries/queryKeyFactory.js
+++ b/src/components/app/data/queries/queryKeyFactory.js
@@ -16,8 +16,11 @@ import {
   fetchEnterpriseCourseEnrollments,
   fetchEnterpriseCuration,
   fetchEnterpriseCustomerContainsContent,
+  fetchEnterpriseLearnerAcademy,
   fetchEnterpriseLearnerDashboard,
   fetchEnterpriseLearnerData,
+  fetchEnterpriseLearnerSearch,
+  fetchEnterpriseLearnerSkillsQuiz,
   fetchEnterpriseOffers,
   fetchInProgressPathways,
   fetchLearnerProgramProgressDetail,
@@ -274,6 +277,18 @@ const bff = createQueryKeys('bff', {
           dashboard: ({
             queryKey: null,
             queryFn: ({ queryKey }) => fetchEnterpriseLearnerDashboard({ enterpriseSlug: queryKey[2] }),
+          }),
+          search: ({
+            queryKey: null,
+            queryFn: ({ queryKey }) => fetchEnterpriseLearnerSearch({ enterpriseSlug: queryKey[2] }),
+          }),
+          academy: ({
+            queryKey: null,
+            queryFn: ({ queryKey }) => fetchEnterpriseLearnerAcademy({ enterpriseSlug: queryKey[2] }),
+          }),
+          skillsQuiz: ({
+            queryKey: null,
+            queryFn: ({ queryKey }) => fetchEnterpriseLearnerSkillsQuiz({ enterpriseSlug: queryKey[2] }),
           }),
         },
       },

--- a/src/components/app/data/queries/utils.js
+++ b/src/components/app/data/queries/utils.js
@@ -36,7 +36,14 @@ export function resolveBFFQuery(pathname) {
   ];
 
   // Find the matching route and return the corresponding query function
-  const matchedRoute = routeToBFFQueryMap.find((route) => matchPath(route.pattern, pathname));
+  const matchedRoute = routeToBFFQueryMap.find((route) => {
+    console.log('matchedRoute?!', {
+      pathname,
+      pattern: route.pattern,
+      matchPath: matchPath(route.pattern, pathname),
+    });
+    return matchPath(route.pattern, pathname);
+  });
 
   if (matchedRoute) {
     return matchedRoute.query;

--- a/src/components/app/data/queries/utils.js
+++ b/src/components/app/data/queries/utils.js
@@ -1,5 +1,11 @@
 import { matchPath } from 'react-router-dom';
-import { queryEnterpriseLearner, queryEnterpriseLearnerDashboardBFF } from './queries';
+import {
+  queryEnterpriseLearner,
+  queryEnterpriseLearnerAcademyBFF,
+  queryEnterpriseLearnerDashboardBFF,
+  queryEnterpriseLearnerSearchBFF,
+  queryEnterpriseLearnerSkillsQuizBFF,
+} from './queries';
 
 /**
  * Resolves the appropriate BFF query function to use for the current route.
@@ -13,6 +19,18 @@ export function resolveBFFQuery(pathname) {
     {
       pattern: '/:enterpriseSlug',
       query: queryEnterpriseLearnerDashboardBFF,
+    },
+    {
+      pattern: '/:enterpriseSlug/search/:pathwayUUID?',
+      query: queryEnterpriseLearnerSearchBFF,
+    },
+    {
+      pattern: '/:enterpriseSlug/academies/:academyUUID',
+      query: queryEnterpriseLearnerAcademyBFF,
+    },
+    {
+      pattern: '/:enterpriseSlug/skills-quiz',
+      query: queryEnterpriseLearnerSkillsQuizBFF,
     },
     // Add more routes and queries incrementally as needed
   ];

--- a/src/components/app/data/queries/utils.js
+++ b/src/components/app/data/queries/utils.js
@@ -36,14 +36,7 @@ export function resolveBFFQuery(pathname) {
   ];
 
   // Find the matching route and return the corresponding query function
-  const matchedRoute = routeToBFFQueryMap.find((route) => {
-    console.log('matchedRoute?!', {
-      pathname,
-      pattern: route.pattern,
-      matchPath: matchPath(route.pattern, pathname),
-    });
-    return matchPath(route.pattern, pathname);
-  });
+  const matchedRoute = routeToBFFQueryMap.find((route) => matchPath(route.pattern, pathname));
 
   if (matchedRoute) {
     return matchedRoute.query;

--- a/src/components/app/data/services/bffs.test.ts
+++ b/src/components/app/data/services/bffs.test.ts
@@ -6,7 +6,16 @@ import { logError, logInfo } from '@edx/frontend-platform/logging';
 import { v4 as uuidv4 } from 'uuid';
 import { camelCaseObject } from '@edx/frontend-platform';
 import { enterpriseCustomerFactory } from './data/__factories__';
-import { fetchEnterpriseLearnerDashboard, learnerDashboardBFFResponse } from './bffs';
+import {
+  fetchEnterpriseLearnerAcademy,
+  fetchEnterpriseLearnerDashboard,
+  fetchEnterpriseLearnerSearch,
+  fetchEnterpriseLearnerSkillsQuiz,
+  learnerAcademyBFFResponse,
+  learnerDashboardBFFResponse,
+  learnerSearchBFFResponse,
+  learnerSkillsQuizBFFResponse,
+} from './bffs';
 
 const axiosMock = new MockAdapter(axios);
 getAuthenticatedHttpClient.mockReturnValue(axios);
@@ -134,60 +143,24 @@ const mockBFFDashboardResponse = {
   ],
 };
 
-describe('fetchEnterpriseLearnerDashboard', () => {
-  const urlForDashboardBFF = `${APP_CONFIG.ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/dashboard/`;
+const mockBFFSearchResponse = {
+  ...mockBaseLearnerBFFResponse,
+};
 
+const mockBFFAcademyResponse = {
+  ...mockBaseLearnerBFFResponse,
+};
+
+const mockBFFSkillsQuizResponse = {
+  ...mockBaseLearnerBFFResponse,
+};
+
+const urlForDashboardBFF = `${APP_CONFIG.ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/dashboard/`;
+
+describe('makeBFFRequest', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     axiosMock.reset();
-  });
-
-  it.each([
-    {
-      enterpriseId: mockEnterpriseCustomer.uuid,
-      enterpriseSlug: undefined,
-    },
-    {
-      enterpriseId: undefined,
-      enterpriseSlug: mockEnterpriseCustomer.slug,
-    },
-    {
-      enterpriseId: mockEnterpriseCustomer.uuid,
-      enterpriseSlug: mockEnterpriseCustomer.slug,
-    },
-  ])('returns learner dashboard metadata (%s)', async ({
-    enterpriseId,
-    enterpriseSlug,
-  }) => {
-    axiosMock.onPost(urlForDashboardBFF).reply(200, mockBFFDashboardResponse);
-    const result = await fetchEnterpriseLearnerDashboard({ enterpriseId, enterpriseSlug });
-    expect(result).toEqual(camelCaseObject(mockBFFDashboardResponse));
-  });
-
-  it.each([
-    {
-      enterpriseId: mockEnterpriseCustomer.uuid,
-      enterpriseSlug: undefined,
-    },
-    {
-      enterpriseId: undefined,
-      enterpriseSlug: mockEnterpriseCustomer.slug,
-    },
-    {
-      enterpriseId: mockEnterpriseCustomer.uuid,
-      enterpriseSlug: mockEnterpriseCustomer.slug,
-    },
-    {
-      enterpriseId: undefined,
-      enterpriseSlug: undefined,
-    },
-  ])('catches error and returns default dashboard BFF response (%s)', async ({
-    enterpriseId,
-    enterpriseSlug,
-  }) => {
-    axiosMock.onPost(urlForDashboardBFF).reply(404, learnerDashboardBFFResponse);
-    const result = await fetchEnterpriseLearnerDashboard({ enterpriseId, enterpriseSlug });
-    expect(result).toEqual(learnerDashboardBFFResponse);
   });
 
   it('logs errors and warnings from BFF response', async () => {
@@ -209,5 +182,87 @@ describe('fetchEnterpriseLearnerDashboard', () => {
     // Assert the logError and logInfo functions were called with the expected arguments.
     expect(logError).toHaveBeenCalledWith(`BFF Error (${urlForDashboardBFF}): ${mockError.developer_message}`);
     expect(logInfo).toHaveBeenCalledWith(`BFF Warning (${urlForDashboardBFF}): ${mockWarning.developer_message}`);
+  });
+});
+
+describe('fetchEnterpriseLearnerDashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axiosMock.reset();
+  });
+
+  it('returns learner dashboard metadata', async () => {
+    axiosMock.onPost(urlForDashboardBFF).reply(200, mockBFFDashboardResponse);
+    const result = await fetchEnterpriseLearnerDashboard({ enterpriseSlug: mockEnterpriseCustomer.slug });
+    expect(result).toEqual(camelCaseObject(mockBFFDashboardResponse));
+  });
+
+  it('catches error and returns default dashboard BFF response', async () => {
+    axiosMock.onPost(urlForDashboardBFF).reply(404, undefined);
+    const result = await fetchEnterpriseLearnerDashboard({ enterpriseSlug: mockEnterpriseCustomer.slug });
+    expect(result).toEqual(learnerDashboardBFFResponse);
+  });
+});
+
+describe('fetchEnterpriseLearnerSearch', () => {
+  const urlForSearchBFF = `${APP_CONFIG.ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/search/`;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axiosMock.reset();
+  });
+
+  it('returns learner search metadata', async () => {
+    axiosMock.onPost(urlForSearchBFF).reply(200, mockBFFSearchResponse);
+    const result = await fetchEnterpriseLearnerSearch({ enterpriseSlug: mockEnterpriseCustomer.slug });
+    expect(result).toEqual(camelCaseObject(mockBFFSearchResponse));
+  });
+
+  it('catches error and returns default search BFF response', async () => {
+    axiosMock.onPost(urlForSearchBFF).reply(404, undefined);
+    const result = await fetchEnterpriseLearnerSearch({ enterpriseSlug: mockEnterpriseCustomer.slug });
+    expect(result).toEqual(learnerSearchBFFResponse);
+  });
+});
+
+describe('fetchEnterpriseLearnerAcademy', () => {
+  const urlForAcademyBFF = `${APP_CONFIG.ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/academy/`;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axiosMock.reset();
+  });
+
+  it('returns learner academy metadata', async () => {
+    axiosMock.onPost(urlForAcademyBFF).reply(200, mockBFFAcademyResponse);
+    const result = await fetchEnterpriseLearnerAcademy({ enterpriseSlug: mockEnterpriseCustomer.slug });
+    expect(result).toEqual(camelCaseObject(mockBFFAcademyResponse));
+  });
+
+  it('catches error and returns default academy BFF response', async () => {
+    axiosMock.onPost(urlForAcademyBFF).reply(404, undefined);
+    const result = await fetchEnterpriseLearnerAcademy({ enterpriseSlug: mockEnterpriseCustomer.slug });
+    expect(result).toEqual(learnerAcademyBFFResponse);
+  });
+});
+
+describe('fetchEnterpriseLearnerSkillsQuiz', () => {
+  const urlForSkillsQuizBFF = `${APP_CONFIG.ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/skills-quiz/`;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axiosMock.reset();
+  });
+
+  it('returns learner skills quiz metadata', async () => {
+    axiosMock.onPost(urlForSkillsQuizBFF).reply(200, mockBFFSkillsQuizResponse);
+    const result = await fetchEnterpriseLearnerSkillsQuiz({ enterpriseSlug: mockEnterpriseCustomer.slug });
+    expect(result).toEqual(camelCaseObject(mockBFFSkillsQuizResponse));
+  });
+
+  it('catches error and returns default skills quiz BFF response', async () => {
+    axiosMock.onPost(urlForSkillsQuizBFF).reply(404, undefined);
+    const result = await fetchEnterpriseLearnerSkillsQuiz({ enterpriseSlug: mockEnterpriseCustomer.slug });
+    expect(result).toEqual(learnerSkillsQuizBFFResponse);
   });
 });

--- a/src/components/app/data/services/bffs.ts
+++ b/src/components/app/data/services/bffs.ts
@@ -26,6 +26,18 @@ export const learnerDashboardBFFResponse = {
   },
 };
 
+export const learnerSearchBFFResponse = {
+  ...baseLearnerBFFResponse,
+};
+
+export const learnerAcademyBFFResponse = {
+  ...baseLearnerBFFResponse,
+};
+
+export const learnerSkillsQuizBFFResponse = {
+  ...baseLearnerBFFResponse,
+};
+
 /**
  * Log any errors and warnings from the BFF response.
  * @param {Object} args
@@ -54,7 +66,7 @@ export function logErrorsAndWarningsFromBFFResponse({ url, response }) {
 export async function makeBFFRequest({
   url,
   defaultResponse,
-  options = {} as Types.BFFRequestOptions,
+  options = {} as BFFRequestOptions,
 }) {
   const { enterpriseId, enterpriseSlug, ...optionsRest } = options;
   const snakeCaseOptionsRest = optionsRest ? snakeCaseObject(optionsRest) : {};
@@ -87,32 +99,50 @@ export async function makeBFFRequest({
   }
 }
 
-export interface EnterpriseLearnerDashboardOptions {
-  enterpriseId?: string;
-  enterpriseSlug?: string;
-}
-
 /**
  * Fetch the learner dashboard BFF API for the specified enterprise customer.
- * @param {Object} args
- * @param {String} [args.enterpriseId] - The UUID of the enterprise customer.
- * @param {String} [args.enterpriseSlug] - The slug of the enterprise customer.
- * @returns {Promise<Object>} - The learner dashboard metadata.
  */
-export async function fetchEnterpriseLearnerDashboard({
-  enterpriseId,
-  enterpriseSlug,
-}: EnterpriseLearnerDashboardOptions) {
-  const options = {} as Types.BFFRequestOptions;
-  if (enterpriseId) {
-    options.enterpriseId = enterpriseId;
-  }
-  if (enterpriseSlug) {
-    options.enterpriseSlug = enterpriseSlug;
-  }
+export async function fetchEnterpriseLearnerDashboard({ enterpriseSlug }: BFFRequestOptions) {
+  const options = { enterpriseSlug } as BFFRequestOptions;
   return makeBFFRequest({
     url: `${getConfig().ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/dashboard/`,
     defaultResponse: learnerDashboardBFFResponse,
+    options,
+  });
+}
+
+/**
+ * Fetch the learner search BFF API for the specified enterprise customer.
+ */
+export async function fetchEnterpriseLearnerSearch({ enterpriseSlug }: BFFRequestOptions) {
+  const options = { enterpriseSlug } as BFFRequestOptions;
+  return makeBFFRequest({
+    url: `${getConfig().ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/search/`,
+    defaultResponse: learnerSearchBFFResponse,
+    options,
+  });
+}
+
+/**
+ * Fetch the learner academy BFF API for the specified enterprise customer.
+ */
+export async function fetchEnterpriseLearnerAcademy({ enterpriseSlug }: BFFRequestOptions) {
+  const options = { enterpriseSlug } as BFFRequestOptions;
+  return makeBFFRequest({
+    url: `${getConfig().ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/academy/`,
+    defaultResponse: learnerAcademyBFFResponse,
+    options,
+  });
+}
+
+/**
+ * Fetch the learner skills quiz BFF API for the specified enterprise customer.
+ */
+export async function fetchEnterpriseLearnerSkillsQuiz({ enterpriseSlug }: BFFRequestOptions) {
+  const options = { enterpriseSlug } as BFFRequestOptions;
+  return makeBFFRequest({
+    url: `${getConfig().ENTERPRISE_ACCESS_BASE_URL}/api/v1/bffs/learner/skills-quiz/`,
+    defaultResponse: learnerSkillsQuizBFFResponse,
     options,
   });
 }

--- a/src/components/app/data/services/data/__factories__/enterpriseCustomerUser.factory.ts
+++ b/src/components/app/data/services/data/__factories__/enterpriseCustomerUser.factory.ts
@@ -46,7 +46,7 @@ Factory.define('enterpriseCustomer')
       active: faker.datatype.boolean(),
     },
   ]);
-export function enterpriseCustomerFactory(overrides = {}): Types.EnterpriseCustomer {
+export function enterpriseCustomerFactory(overrides = {}): EnterpriseCustomer {
   return camelCaseObject(Factory.build('enterpriseCustomer', overrides));
 }
 

--- a/src/components/app/data/services/enterpriseCustomerUser.ts
+++ b/src/components/app/data/services/enterpriseCustomerUser.ts
@@ -58,7 +58,7 @@ export async function fetchEnterpriseCustomerForSlug(enterpriseSlug) {
  * @returns
  */
 export async function fetchEnterpriseLearnerData(username, enterpriseSlug, options = {}):
-Promise<Types.EnterpriseLearnerData> {
+Promise<EnterpriseLearnerData> {
   const enterpriseLearnerUrl = `${getConfig().LMS_BASE_URL}/enterprise/api/v1/enterprise-learner/`;
   const queryParams = new URLSearchParams({
     username,
@@ -97,7 +97,7 @@ Promise<Types.EnterpriseLearnerData> {
     // If no enterprise customer is found (i.e., authenticated user not explicitly
     // linked), but the authenticated user is staff, attempt to retrieve enterprise
     // customer metadata from the `/enterprise-customer` LMS API.
-    let staffEnterpriseCustomer: Types.EnterpriseCustomer | null = null;
+    let staffEnterpriseCustomer: EnterpriseCustomer | null = null;
     if (getAuthenticatedUser().administrator && enterpriseSlug && !foundEnterpriseCustomerUserForCurrentSlug) {
       const staffEnterpriseCustomerResult = await fetchEnterpriseCustomerForSlug(enterpriseSlug);
       if (staffEnterpriseCustomerResult?.enableLearnerPortal) {

--- a/src/components/app/data/utils.test.js
+++ b/src/components/app/data/utils.test.js
@@ -1,8 +1,6 @@
 import MockDate from 'mockdate';
 
 import dayjs from 'dayjs';
-import { matchPath } from 'react-router-dom';
-import { getConfig } from '@edx/frontend-platform/config';
 import { LICENSE_STATUS } from '../../enterprise-user-subsidy/data/constants';
 import { POLICY_TYPES } from '../../enterprise-user-subsidy/enterprise-offers/data/constants';
 import {
@@ -27,17 +25,6 @@ import {
 import { resolveBFFQuery } from './queries';
 import { enterpriseCustomerFactory } from './services/data/__factories__';
 import { DATE_FORMAT } from '../../course/data';
-
-jest.mock('react-router-dom', () => ({
-  matchPath: jest.fn(),
-}));
-
-jest.mock('@edx/frontend-platform/config', () => ({
-  ...jest.requireActual('@edx/frontend-platform/config'),
-  getConfig: jest.fn(() => ({
-    FEATURE_ENABLE_BFF_API_FOR_ENTERPRISE_CUSTOMERS: [],
-  })),
-}));
 
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
 
@@ -1351,46 +1338,48 @@ describe('transformLearnerContentAssignment', () => {
     expect(transformedAllocatedAssignment.courseRunId).toEqual(contentKey);
   });
 });
+
 describe('resolveBFFQuery', () => {
-  const dashboardRoute = '/:enterpriseSlug';
-  const routes = [dashboardRoute];
   beforeEach(() => {
     jest.clearAllMocks();
-    getConfig.mockReturnValue({
-      FEATURE_ENABLE_BFF_API_FOR_ENTERPRISE_CUSTOMERS: [mockEnterpriseCustomer.uuid],
-    });
   });
-  it('returns the dashboard query key', () => {
-    const pathname = '/testEnterpriseSlug';
-    const mockParams = { enterpriseSlug: 'testEnterpriseSlug' };
+
+  it.each([
+    {
+      currentPathname: `/${mockEnterpriseCustomer.slug}`,
+      expectedRouteKey: 'dashboard',
+    },
+    {
+      currentPathname: `/${mockEnterpriseCustomer.slug}/search`,
+      expectedRouteKey: 'search',
+    },
+    {
+      currentPathname: `/${mockEnterpriseCustomer.slug}/search/pathway-uuid`,
+      expectedRouteKey: 'search',
+    },
+    {
+      currentPathname: `/${mockEnterpriseCustomer.slug}/academies/academy-uuid`,
+      expectedRouteKey: 'academy',
+    },
+    {
+      currentPathname: `/${mockEnterpriseCustomer.slug}/skills-quiz`,
+      expectedRouteKey: 'skillsQuiz',
+    },
+  ])('returns the expected query key (%s)', ({ currentPathname, expectedRouteKey }) => {
     const expectedQueryKey = [
       'bff',
       'enterpriseSlug',
-      'testEnterpriseSlug',
+      mockEnterpriseCustomer.slug,
       'route',
-      'dashboard',
+      expectedRouteKey,
     ];
-    matchPath.mockImplementation((pattern, path) => {
-      if (routes.includes(pattern) && path === '/testEnterpriseSlug') {
-        return { params: mockParams };
-      }
-      return null;
-    });
-    const result = resolveBFFQuery(pathname);
-    expect(matchPath).toHaveBeenCalledWith('/:enterpriseSlug', pathname);
-    expect(result({ enterpriseSlug: 'testEnterpriseSlug' }).queryKey).toEqual(expectedQueryKey);
+    const result = resolveBFFQuery(currentPathname);
+    expect(result({ enterpriseSlug: mockEnterpriseCustomer.slug }).queryKey).toEqual(expectedQueryKey);
   });
+
   it('returns null from unmatched query key', () => {
-    const pathname = '/testEnterpriseSlug/Slugma';
-    const mockParams = { enterpriseSlug: 'testEnterpriseSlug' };
-    matchPath.mockImplementation((pattern, path) => {
-      if (routes.includes(pattern) && path === '/testEnterpriseSlug') {
-        return { params: mockParams };
-      }
-      return null;
-    });
+    const pathname = `/${mockEnterpriseCustomer.slug}/unsupported-bff-route`;
     const result = resolveBFFQuery(pathname);
-    expect(matchPath).toHaveBeenCalledWith('/:enterpriseSlug', pathname);
     expect(result).toEqual(null);
   });
 });

--- a/src/components/app/routes/createAppRouter.ts
+++ b/src/components/app/routes/createAppRouter.ts
@@ -8,7 +8,7 @@ import { getRoutes } from '../../../routes';
  * @param {Object} queryClient React Query query client.
  * @returns {Object} React Router browser router.
  */
-export default function createAppRouter(queryClient: Types.QueryClient): Types.Router {
+export default function createAppRouter(queryClient: QueryClient): Router {
   const { routes } = getRoutes(queryClient);
   const router = createBrowserRouter(routes);
   return router;

--- a/src/components/app/routes/loaders/enterpriseInviteLoader.ts
+++ b/src/components/app/routes/loaders/enterpriseInviteLoader.ts
@@ -4,10 +4,10 @@ import { logError } from '@edx/frontend-platform/logging';
 import { postLinkEnterpriseLearner } from '../../data';
 import { ensureAuthenticatedUser } from '../data';
 
-type EnterpriseInviteParams<Key extends string = string> = Types.RouteParams<Key> & {
+type EnterpriseInviteParams<Key extends string = string> = RouteParams<Key> & {
   readonly enterpriseCustomerInviteKey: string;
 };
-interface EnterpriseInviteLoaderFunctionArgs extends Types.RouteLoaderFunctionArgs {
+interface EnterpriseInviteLoaderFunctionArgs extends RouteLoaderFunctionArgs {
   params: EnterpriseInviteParams;
 }
 
@@ -16,7 +16,7 @@ interface EnterpriseInviteLoaderFunctionArgs extends Types.RouteLoaderFunctionAr
  * customer based on the invite key in the route URL. If linking is successful,
  * the user is redirected to the dashboard route for the now-linked enterprise.
  */
-const makeEnterpriseInviteLoader: Types.MakeRouteLoaderFunction = function makeEnterpriseInviteLoader() {
+const makeEnterpriseInviteLoader: MakeRouteLoaderFunction = function makeEnterpriseInviteLoader() {
   return async function enterpriseInviteLoader({ params, request }: EnterpriseInviteLoaderFunctionArgs) {
     const requestUrl = new URL(request.url);
     const authenticatedUser = await ensureAuthenticatedUser(requestUrl, params);

--- a/src/components/app/routes/loaders/rootLoader.ts
+++ b/src/components/app/routes/loaders/rootLoader.ts
@@ -10,7 +10,7 @@ import {
 /**
  * Root loader for the enterprise learner portal.
  */
-const makeRootLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function makeRootLoader(queryClient) {
+const makeRootLoader: MakeRouteLoaderFunctionWithQueryClient = function makeRootLoader(queryClient) {
   return async function rootLoader({ params = {}, request }) {
     const requestUrl = new URL(request.url);
     const authenticatedUser = await ensureAuthenticatedUser(requestUrl, params);

--- a/src/components/app/routes/loaders/tests/rootLoader.test.jsx
+++ b/src/components/app/routes/loaders/tests/rootLoader.test.jsx
@@ -148,7 +148,7 @@ describe('rootLoader', () => {
 
     const routeMetadata = isMatchedBFFRoute
       ? { path: '/:enterpriseSlug', initialEntries: [`/${mockEnterpriseCustomer.slug}`] }
-      : { path: '/:enterpriseSlug/search', initialEntries: [`/${mockEnterpriseCustomer.slug}/search`] };
+      : { path: '/:enterpriseSlug/unsupported-bff-route', initialEntries: [`/${mockEnterpriseCustomer.slug}/unsupported-bff-route`] };
     renderWithRouterProvider({
       path: routeMetadata.path,
       element: <div>hello world</div>,
@@ -364,7 +364,7 @@ describe('rootLoader', () => {
 
     const routeMetadata = isMatchedBFFRoute
       ? { path: '/:enterpriseSlug', initialEntries: [`/${enterpriseSlug}`] }
-      : { path: '/:enterpriseSlug/search', initialEntries: [`/${enterpriseSlug}/search`] };
+      : { path: '/:enterpriseSlug/unsupported-bff-route', initialEntries: [`/${enterpriseSlug}/unsupported-bff-route`] };
 
     renderWithRouterProvider({
       path: routeMetadata.path,

--- a/src/components/course/data/courseLoader.ts
+++ b/src/components/course/data/courseLoader.ts
@@ -26,11 +26,11 @@ import {
 import { ensureAuthenticatedUser } from '../../app/routes/data';
 import { getCourseTypeConfig, getLinkToCourse, pathContainsCourseTypeSlug } from './utils';
 
-type CourseRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
+type CourseRouteParams<Key extends string = string> = RouteParams<Key> & {
   readonly courseKey: string;
   readonly enterpriseSlug: string;
 };
-interface CourseLoaderFunctionArgs extends Types.RouteLoaderFunctionArgs {
+interface CourseLoaderFunctionArgs extends RouteLoaderFunctionArgs {
   params: CourseRouteParams;
 }
 type CourseMetadata = {
@@ -40,7 +40,7 @@ type CourseMetadata = {
 /**
  * Course loader for the course related page routes.
  */
-const makeCourseLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function makeCourseLoader(queryClient) {
+const makeCourseLoader: MakeRouteLoaderFunctionWithQueryClient = function makeCourseLoader(queryClient) {
   return async function courseLoader({ params, request }: CourseLoaderFunctionArgs) {
     const requestUrl = new URL(request.url);
     const authenticatedUser = await ensureAuthenticatedUser(requestUrl, params);

--- a/src/components/course/routes/externalCourseEnrollmentLoader.ts
+++ b/src/components/course/routes/externalCourseEnrollmentLoader.ts
@@ -9,17 +9,17 @@ import {
 } from '../../app/data';
 import { ensureAuthenticatedUser } from '../../app/routes/data';
 
-type ExternalCourseEnrollmentRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
+type ExternalCourseEnrollmentRouteParams<Key extends string = string> = RouteParams<Key> & {
   readonly courseType: string;
   readonly courseKey: string;
   readonly courseRunKey: string;
   readonly enterpriseSlug: string;
 };
-interface ExternalCourseEnrollmentLoaderFunctionArgs extends Types.RouteLoaderFunctionArgs {
+interface ExternalCourseEnrollmentLoaderFunctionArgs extends RouteLoaderFunctionArgs {
   params: ExternalCourseEnrollmentRouteParams;
 }
 
-const makeExternalCourseEnrollmentLoader: Types.MakeRouteLoaderFunctionWithQueryClient = (
+const makeExternalCourseEnrollmentLoader: MakeRouteLoaderFunctionWithQueryClient = (
   function makeExternalCourseEnrollmentLoader(queryClient) {
     return async function externalCourseEnrollmentLoader(
       { params, request }: ExternalCourseEnrollmentLoaderFunctionArgs,

--- a/src/components/dashboard/data/dashboardLoader.ts
+++ b/src/components/dashboard/data/dashboardLoader.ts
@@ -8,20 +8,20 @@ import {
   resolveBFFQuery,
 } from '../../app/data';
 
-type DashboardRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
+type DashboardRouteParams<Key extends string = string> = RouteParams<Key> & {
   readonly enterpriseSlug: string;
 };
-interface DashboardLoaderFunctionArgs extends Types.RouteLoaderFunctionArgs {
+interface DashboardLoaderFunctionArgs extends RouteLoaderFunctionArgs {
   params: DashboardRouteParams;
 }
 interface DashboardBFFResponse {
-  enterpriseCourseEnrollments: Types.EnterpriseCourseEnrollment[];
+  enterpriseCourseEnrollments: EnterpriseCourseEnrollment[];
 }
 
 /**
  * Returns a loader function responsible for loading the dashboard related data.
  */
-const makeDashboardLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function makeDashboardLoader(queryClient) {
+const makeDashboardLoader: MakeRouteLoaderFunctionWithQueryClient = function makeDashboardLoader(queryClient) {
   return async function dashboardLoader({ params, request }: DashboardLoaderFunctionArgs) {
     const requestUrl = new URL(request.url);
     const authenticatedUser = await ensureAuthenticatedUser(requestUrl, params);
@@ -63,7 +63,7 @@ const makeDashboardLoader: Types.MakeRouteLoaderFunctionWithQueryClient = functi
     ]).then((responses) => {
       const enterpriseCourseEnrollments = dashboardBFFQuery
         ? (responses[0] as DashboardBFFResponse).enterpriseCourseEnrollments
-        : responses[0] as Types.EnterpriseCourseEnrollment[];
+        : responses[0] as EnterpriseCourseEnrollment[];
       const redeemablePolicies = responses[1];
       // Redirect user to search page, for first-time users with no enrollments and/or assignments.
       redirectToSearchPageForNewUser({

--- a/src/components/microlearning/data/videosLoader.ts
+++ b/src/components/microlearning/data/videosLoader.ts
@@ -3,15 +3,15 @@ import {
   extractEnterpriseCustomer, queryCourseMetadata, queryCourseReviews, queryVideoDetail,
 } from '../../app/data';
 
-type VideoRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
+type VideoRouteParams<Key extends string = string> = RouteParams<Key> & {
   readonly videoUUID: string;
   readonly enterpriseSlug: string;
 };
-interface VideoLoaderFunctionArgs extends Types.RouteLoaderFunctionArgs {
+interface VideoLoaderFunctionArgs extends RouteLoaderFunctionArgs {
   params: VideoRouteParams;
 }
 
-const makeVideosLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function makeVideosLoader(queryClient) {
+const makeVideosLoader: MakeRouteLoaderFunctionWithQueryClient = function makeVideosLoader(queryClient) {
   return async function videosLoader({ params, request } : VideoLoaderFunctionArgs) {
     const requestUrl = new URL(request.url);
     const authenticatedUser = await ensureAuthenticatedUser(requestUrl, params);

--- a/src/components/pathway-progress/data/pathwayProgressLoader.ts
+++ b/src/components/pathway-progress/data/pathwayProgressLoader.ts
@@ -1,14 +1,14 @@
 import { queryLearnerPathwayProgressData } from '../../app/data';
 import { ensureAuthenticatedUser } from '../../app/routes/data';
 
-type PathwayProgressRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
+type PathwayProgressRouteParams<Key extends string = string> = RouteParams<Key> & {
   readonly pathwayUUID: string;
 };
-interface PathwayProgressLoaderFunctionArgs extends Types.RouteLoaderFunctionArgs {
+interface PathwayProgressLoaderFunctionArgs extends RouteLoaderFunctionArgs {
   params: PathwayProgressRouteParams;
 }
 
-const makePathwayProgressLoader: Types.MakeRouteLoaderFunctionWithQueryClient = (
+const makePathwayProgressLoader: MakeRouteLoaderFunctionWithQueryClient = (
   function makePathwayProgressLoader(queryClient) {
     return async function pathwayProgressLoader({ params, request }: PathwayProgressLoaderFunctionArgs) {
       const requestUrl = new URL(request.url);

--- a/src/components/program-progress/data/programProgressLoader.ts
+++ b/src/components/program-progress/data/programProgressLoader.ts
@@ -5,14 +5,14 @@ import {
 } from '../../app/data';
 import { ensureAuthenticatedUser } from '../../app/routes/data';
 
-type ProgramProgressRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
+type ProgramProgressRouteParams<Key extends string = string> = RouteParams<Key> & {
   readonly programUUID: string;
 };
-interface ProgramProgressLoaderFunctionArgs extends Types.RouteLoaderFunctionArgs {
+interface ProgramProgressLoaderFunctionArgs extends RouteLoaderFunctionArgs {
   params: ProgramProgressRouteParams;
 }
 
-const makeProgramProgressLoader: Types.MakeRouteLoaderFunctionWithQueryClient = (
+const makeProgramProgressLoader: MakeRouteLoaderFunctionWithQueryClient = (
   function makeProgramProgressLoader(queryClient) {
     return async function programProgressLoader({ params, request }: ProgramProgressLoaderFunctionArgs) {
       const requestUrl = new URL(request.url);

--- a/src/components/program/data/programLoader.ts
+++ b/src/components/program/data/programLoader.ts
@@ -1,15 +1,15 @@
 import { ensureAuthenticatedUser } from '../../app/routes/data';
 import { extractEnterpriseCustomer, queryEnterpriseProgram } from '../../app/data';
 
-type ProgramRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
+type ProgramRouteParams<Key extends string = string> = RouteParams<Key> & {
   readonly programUUID: string;
   readonly enterpriseSlug: string;
 };
-interface ProgramLoaderFunctionArgs extends Types.RouteLoaderFunctionArgs {
+interface ProgramLoaderFunctionArgs extends RouteLoaderFunctionArgs {
   params: ProgramRouteParams;
 }
 
-const makeProgramLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function makeProgramLoader(queryClient) {
+const makeProgramLoader: MakeRouteLoaderFunctionWithQueryClient = function makeProgramLoader(queryClient) {
   return async function programLoader({ params, request }: ProgramLoaderFunctionArgs) {
     const requestUrl = new URL(request.url);
     const authenticatedUser = await ensureAuthenticatedUser(requestUrl, params);

--- a/src/components/search/data/searchLoader.ts
+++ b/src/components/search/data/searchLoader.ts
@@ -3,17 +3,17 @@ import { getConfig } from '@edx/frontend-platform/config';
 import { ensureAuthenticatedUser } from '../../app/routes/data/utils';
 import { extractEnterpriseCustomer, queryAcademiesList, queryContentHighlightSets } from '../../app/data';
 
-type SearchRouteParams<Key extends string = string> = Types.RouteParams<Key> & {
+type SearchRouteParams<Key extends string = string> = RouteParams<Key> & {
   readonly enterpriseSlug: string;
 };
-interface SearchLoaderFunctionArgs extends Types.RouteLoaderFunctionArgs {
+interface SearchLoaderFunctionArgs extends RouteLoaderFunctionArgs {
   params: SearchRouteParams;
 }
 interface Academy {
   uuid: string;
 }
 
-const makeSearchLoader: Types.MakeRouteLoaderFunctionWithQueryClient = function makeSearchLoader(queryClient) {
+const makeSearchLoader: MakeRouteLoaderFunctionWithQueryClient = function makeSearchLoader(queryClient) {
   return async function searchLoader({ params, request } : SearchLoaderFunctionArgs) {
     const requestUrl = new URL(request.url);
     const authenticatedUser = await ensureAuthenticatedUser(requestUrl, params);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,7 +13,7 @@ import AppErrorBoundary from './components/app/AppErrorBoundary';
 /**
  * Returns the route loader function if a queryClient is available; otherwise, returns null.
  */
-export function getRouteLoader(makeRouteLoaderFn: Types.MakeRouteLoaderFunction, queryClient?: Types.QueryClient) {
+export function getRouteLoader(makeRouteLoaderFn: MakeRouteLoaderFunction, queryClient?: QueryClient) {
   if (!queryClient) {
     return undefined;
   }
@@ -23,8 +23,8 @@ export function getRouteLoader(makeRouteLoaderFn: Types.MakeRouteLoaderFunction,
 /**
  * Returns the routes nested under the enterprise slug prefix.
  */
-function getEnterpriseSlugRoutes(queryClient?: Types.QueryClient) {
-  const enterpriseSlugChildRoutes: Types.RouteObject[] = [
+function getEnterpriseSlugRoutes(queryClient?: QueryClient) {
+  const enterpriseSlugChildRoutes: RouteObject[] = [
     {
       index: true,
       lazy: async () => {
@@ -173,7 +173,7 @@ function getEnterpriseSlugRoutes(queryClient?: Types.QueryClient) {
       element: <NotFoundPage />,
     },
   ];
-  const enterpriseSlugRoutes: Types.RouteObject[] = [
+  const enterpriseSlugRoutes: RouteObject[] = [
     {
       path: ':enterpriseSlug?',
       loader: getRouteLoader(makeRootLoader, queryClient),
@@ -197,7 +197,7 @@ function getEnterpriseSlugRoutes(queryClient?: Types.QueryClient) {
  * Returns other routes that are not nested under the enterprise slug prefix.
  */
 function getOtherRoutes() {
-  const otherRoutes: Types.RouteObject[] = [
+  const otherRoutes: RouteObject[] = [
     {
       path: 'invite/:enterpriseCustomerInviteKey',
       lazy: async () => {
@@ -240,10 +240,10 @@ function getOtherRoutes() {
 /**
  * Returns the routes for the application.
  */
-export function getRoutes(queryClient?: Types.QueryClient) {
+export function getRoutes(queryClient?: QueryClient) {
   const enterpriseSlugRoutes = getEnterpriseSlugRoutes(queryClient);
   const otherRoutes = getOtherRoutes();
-  const rootChildRoutes: Types.RouteObject[] = [
+  const rootChildRoutes: RouteObject[] = [
     ...otherRoutes,
     ...enterpriseSlugRoutes,
     {
@@ -252,7 +252,7 @@ export function getRoutes(queryClient?: Types.QueryClient) {
     },
   ];
 
-  const routes: Types.RouteObject[] = [
+  const routes: RouteObject[] = [
     {
       path: '/',
       element: (
@@ -324,7 +324,7 @@ export function getRoutes(queryClient?: Types.QueryClient) {
  *   '/:enterpriseSlug?/:courseType?/course/:courseKey/enroll/:courseRunKey',
  * ]
  */
-export function flattenRoutePaths(routes: Types.RouteObject[], basePath = '/') {
+export function flattenRoutePaths(routes: RouteObject[], basePath = '/') {
   let paths: string[] = [];
   routes.forEach((route) => {
     // Construct the full path by combining basePath with route.path

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,104 +1,104 @@
 import { queries } from './components/app/data';
 import { SUBSIDY_REQUEST_STATE } from './constants';
 
-// React Query
-export type UseQueryResult = import('@tanstack/react-query').UseQueryResult;
-export type UseQueryOptions = import('@tanstack/react-query').UseQueryOptions;
-export type QueryObserverOptions = import('@tanstack/react-query').QueryObserverOptions;
-export type QueryClient = import('@tanstack/react-query').QueryClient;
-export type QueryObserverResult = import('@tanstack/react-query').QueryObserverResult;
-export type Query = import('@tanstack/react-query').Query;
-export type QueryOptions = import('@tanstack/react-query').QueryOptions;
+declare global {
+  // React Query
+  type UseQueryResult = import('@tanstack/react-query').UseQueryResult;
+  type UseQueryOptions = import('@tanstack/react-query').UseQueryOptions;
+  type QueryObserverOptions = import('@tanstack/react-query').QueryObserverOptions;
+  type QueryClient = import('@tanstack/react-query').QueryClient;
+  type QueryObserverResult = import('@tanstack/react-query').QueryObserverResult;
+  type Query = import('@tanstack/react-query').Query;
+  type QueryOptions = import('@tanstack/react-query').QueryOptions;
 
-// Query Key Factory
-export type QueryKeys = import('@lukemorales/query-key-factory').inferQueryKeyStore<typeof queries>;
+  // Query Key Factory
+  type QueryKeys = import('@lukemorales/query-key-factory').inferQueryKeyStore<typeof queries>;
 
-// Routes
-export type RouteParams<Key extends string = string> = import('react-router-dom').Params<Key>;
-export type RouteLoaderFunction = import('react-router-dom').LoaderFunction;
-export type RouteLoaderFunctionArgs = import('react-router-dom').LoaderFunctionArgs;
-export type MakeRouteLoaderFunction = (queryClient?: QueryClient) => RouteLoaderFunction;
-export type MakeRouteLoaderFunctionWithQueryClient = (queryClient: QueryClient) => RouteLoaderFunction;
-export type RouteObject = import('react-router-dom').RouteObject;
-export type Router = import('@remix-run/router').Router;
+  // Routes
+  type RouteParams<Key extends string = string> = import('react-router-dom').Params<Key>;
+  type RouteLoaderFunction = import('react-router-dom').LoaderFunction;
+  type RouteLoaderFunctionArgs = import('react-router-dom').LoaderFunctionArgs;
+  type MakeRouteLoaderFunction = (queryClient?: QueryClient) => RouteLoaderFunction;
+  type MakeRouteLoaderFunctionWithQueryClient = (queryClient: QueryClient) => RouteLoaderFunction;
+  type RouteObject = import('react-router-dom').RouteObject;
+  type Router = import('@remix-run/router').Router;
 
-// Application Data (general)
-export interface AuthenticatedUser {
-  userId: string;
-  username: string;
-  roles: string[];
-  administrator: boolean;
-  extendedProfile?: Record<string, any>;
+  // Application Data (general)
+  interface AuthenticatedUser {
+    userId: string;
+    username: string;
+    roles: string[];
+    administrator: boolean;
+    extendedProfile?: Record<string, any>;
+  }
+  interface AppContextValue {
+    authenticatedUser: AuthenticatedUser;
+  }
+
+  interface BFFRequestAdditionalOptions {
+    [key: string]: any; // Allow any additional properties
+  }
+
+  type BFFRequestOptions = { enterpriseSlug: string; } & BFFRequestAdditionalOptions;
+
+  interface EnterpriseCustomer {
+    uuid: string;
+    slug: string;
+    name: string;
+    enableOneAcademy: boolean;
+  }
+
+  interface EnterpriseFeatures {
+    enterpriseLearnerBffEnabled?: boolean;
+    [key: string]: boolean;
+  }
+
+  interface EnterpriseCustomerUser {
+    id: number,
+    enterpriseCustomer: EnterpriseCustomer,
+    active: boolean,
+  }
+
+  interface EnterpriseLearnerData {
+    enterpriseCustomer: EnterpriseCustomer | null;
+    activeEnterpriseCustomer: EnterpriseCustomer | null;
+    allLinkedEnterpriseCustomerUsers: EnterpriseCustomerUser[];
+    staffEnterpriseCustomer: EnterpriseCustomer | null;
+    enterpriseFeatures: EnterpriseFeatures;
+    shouldUpdateActiveEnterpriseCustomerUser: boolean;
+  }
+
+  interface EnrollmentDueDate {
+    name: string;
+    date: string;
+    url: string;
+  }
+
+  interface EnterpriseCourseEnrollment {
+    course_run_id: string;
+    course_key: string;
+    course_type: string;
+    org_name: string;
+    course_run_status: string;
+    display_name: string;
+    emails_enabled?: boolean;
+    certificate_download_url?: string;
+    created: string;
+    start_date?: string;
+    end_date?: string;
+    mode: string;
+    is_enrollment_active: boolean;
+    product_source: string;
+    enroll_by?: string;
+    pacing: boolean;
+    course_run_url: string;
+    resume_course_run_url?: string;
+    is_revoked: boolean;
+    due_dates: EnrollmentDueDate[];
+  }
+
+  // Application Data (subsidy)
+  type SubsidyRequestState = typeof SUBSIDY_REQUEST_STATE[keyof typeof SUBSIDY_REQUEST_STATE];
 }
-export interface AppContextValue {
-  authenticatedUser: AuthenticatedUser;
-}
 
-export interface BFFRequestAdditionalOptions {
-  [key: string]: any; // Allow any additional properties
-}
-
-export type BFFRequestOptions =
-  | ({ enterpriseId: string; enterpriseSlug?: string; } & BFFRequestAdditionalOptions)
-  | ({ enterpriseId?: string; enterpriseSlug: string; } & BFFRequestAdditionalOptions);
-
-export interface EnterpriseCustomer {
-  uuid: string;
-  slug: string;
-  name: string;
-  enableOneAcademy: boolean;
-}
-
-export interface EnterpriseFeatures {
-  enterpriseLearnerBffEnabled?: boolean;
-  [key: string]: boolean;
-}
-
-export interface EnterpriseCustomerUser {
-  id: number,
-  enterpriseCustomer: Types.EnterpriseCustomer,
-  active: boolean,
-}
-
-export interface EnterpriseLearnerData {
-  enterpriseCustomer: Types.EnterpriseCustomer | null;
-  activeEnterpriseCustomer: Types.EnterpriseCustomer | null;
-  allLinkedEnterpriseCustomerUsers: EnterpriseCustomerUser[];
-  staffEnterpriseCustomer: Types.EnterpriseCustomer | null;
-  enterpriseFeatures: Types.EnterpriseFeatures;
-  shouldUpdateActiveEnterpriseCustomerUser: boolean;
-}
-
-interface EnrollmentDueDate {
-  name: string;
-  date: string;
-  url: string;
-}
-
-export interface EnterpriseCourseEnrollment {
-  course_run_id: string;
-  course_key: string;
-  course_type: string;
-  org_name: string;
-  course_run_status: string;
-  display_name: string;
-  emails_enabled?: boolean;
-  certificate_download_url?: string;
-  created: string;
-  start_date?: string;
-  end_date?: string;
-  mode: string;
-  is_enrollment_active: boolean;
-  product_source: string;
-  enroll_by?: string;
-  pacing: boolean;
-  course_run_url: string;
-  resume_course_run_url?: string;
-  is_revoked: boolean;
-  due_dates: EnrollmentDueDate[];
-}
-
-// Application Data (subsidy)
-export type SubsidyRequestState = typeof SUBSIDY_REQUEST_STATE[keyof typeof SUBSIDY_REQUEST_STATE];
-
-export as namespace Types;
+export {};


### PR DESCRIPTION
## Jira

Ticket: [ENT-10118](https://2u-internal.atlassian.net/browse/ENT-10118)

## Changes

* [clean up] Declare `global` namespace in `types.d.ts` to avoid needing to rely on `Types.` when accessing our type definitions throughout the repository.
* [new] Integrates with 3 new BFF APIs:
  * Impacted page routes
    * Search
    * Academy detail
    * Skills quiz
  * Created service functions, query keys, and query functions for the new BFF APIs.
  * Updated `resolveBFFQuery` to map the route patterns for the listed routes above with their respective BFF query function. This will ensure any route loader / custom query hook that has been incrementally migrated to conditionally rely on BFF APIs depending on the current page route will begin sourcing its data from the new APIs. This is largely a no-op in terms of user impact as the route-specific data for these routes are still coming from the direct service calls rather than coming from the BFF as they have not yet been incrementally migrated to support the BFF.

## Testing Instructions

1. Run `npm run start:stage:with-theme` (e.g., using `@edx/brand-edx.org`).
2. Navigate to https://localhost.stage.edx.org:8734/exec-ed-2u-integration-qa.
3. Observe the Dashboard page route continues to rely on `/dashboard/` BFF API.
4. Click "Find a Course". 
5. Observe network request to new `/search/` BFF API.
6. Click "Recommend courses for me" (Skills Quiz).
7. Observe network request to new `/skills-quiz/` BFF API.
8. Close the Skills Quiz and click an Academy search result.
9. Observe a network request to new `/academy/` BFF API.
10. For each of these above use cases, observe data not-yet-migrated to the BFF (e.g., route-specific metadata for these 3 routes) are still sourced from the direct service calls from the frontend vs. the BFF APIs.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
