### PR TITLE
feat: update useAlgoliaSearch with BFF sourced data

### DIFF
--- a/.env.development-stage
+++ b/.env.development-stage
@@ -63,4 +63,5 @@ FEATURE_ENABLE_VIDEO_CATALOG='false'
 
 # Algolia
 ALGOLIA_INDEX_NAME='enterprise_catalog_new'
+ALGOLIA_REPLICA_INDEX_NAME='enterprise_catalog_new_duration_desc'
 ALGOLIA_INDEX_NAME_JOBS='stage_taxonomy'

--- a/src/components/academies/AcademyDetailPage.jsx
+++ b/src/components/academies/AcademyDetailPage.jsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { Breadcrumb, Container } from '@openedx/paragon';
 import { Link, useParams } from 'react-router-dom';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import { getConfig } from '@edx/frontend-platform/config';
 import NotFoundPage from '../NotFoundPage';
 import './styles/Academy.scss';

--- a/src/components/academies/AcademyDetailPage.jsx
+++ b/src/components/academies/AcademyDetailPage.jsx
@@ -1,21 +1,34 @@
+import { useMemo } from 'react';
 import { Breadcrumb, Container } from '@openedx/paragon';
 import { Link, useParams } from 'react-router-dom';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
+import algoliasearch from 'algoliasearch';
+import { getConfig } from '@edx/frontend-platform/config';
 import NotFoundPage from '../NotFoundPage';
 import './styles/Academy.scss';
 import { useAcademyDetails, useEnterpriseCustomer } from '../app/data';
 import AcademyContentCard from './AcademyContentCard';
-import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 const AcademyDetailPage = () => {
+  const config = getConfig();
   const { academyUUID } = useParams();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { data: academy } = useAcademyDetails();
   const academyURL = `/${enterpriseCustomer.slug}/academy/${academyUUID}/?${enterpriseCustomer.uuid}`;
   const intl = useIntl();
-  const {
-    searchIndex: courseIndex,
-  } = useAlgoliaSearchh();
+
+  // init algolia index
+  const courseIndex = useMemo(
+    () => {
+      const client = algoliasearch(
+        config.ALGOLIA_APP_ID,
+        config.ALGOLIA_SEARCH_API_KEY,
+      );
+      return client.initIndex(config.ALGOLIA_INDEX_NAME);
+    },
+    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY],
+  );
+
   if (!academy) {
     return (
       <NotFoundPage

--- a/src/components/academies/AcademyDetailPage.jsx
+++ b/src/components/academies/AcademyDetailPage.jsx
@@ -1,37 +1,21 @@
-import { useMemo } from 'react';
-import {
-  Container, Breadcrumb,
-} from '@openedx/paragon';
-import {
-  useParams, Link,
-} from 'react-router-dom';
-import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
-import algoliasearch from 'algoliasearch/lite';
-import { getConfig } from '@edx/frontend-platform/config';
+import { Breadcrumb, Container } from '@openedx/paragon';
+import { Link, useParams } from 'react-router-dom';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import NotFoundPage from '../NotFoundPage';
 import './styles/Academy.scss';
 import { useAcademyDetails, useEnterpriseCustomer } from '../app/data';
 import AcademyContentCard from './AcademyContentCard';
+import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 const AcademyDetailPage = () => {
-  const config = getConfig();
   const { academyUUID } = useParams();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { data: academy } = useAcademyDetails();
   const academyURL = `/${enterpriseCustomer.slug}/academy/${academyUUID}/?${enterpriseCustomer.uuid}`;
   const intl = useIntl();
-
-  // init algolia index
-  const courseIndex = useMemo(
-    () => {
-      const client = algoliasearch(
-        config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
-      );
-      return client.initIndex(config.ALGOLIA_INDEX_NAME);
-    },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY],
-  );
+  const {
+    searchIndex: courseIndex,
+  } = useAlgoliaSearchh();
   if (!academy) {
     return (
       <NotFoundPage

--- a/src/components/app/data/hooks/index.ts
+++ b/src/components/app/data/hooks/index.ts
@@ -48,3 +48,4 @@ export { default as useVideoCourseReviews } from './useVideoCourseReviews';
 export { default as useBFF } from './useBFF';
 export { default as useIsBFFEnabled } from './useIsBFFEnabled';
 export { default as useHasValidLicenseOrSubscriptionRequestsEnabled } from './useHasValidLicenseOrSubscriptionRequestsEnabled';
+export { default as useAlgoliaSearch } from './useAlgoliaSearch';

--- a/src/components/app/data/hooks/useAlgoliaSearch.test.tsx
+++ b/src/components/app/data/hooks/useAlgoliaSearch.test.tsx
@@ -1,0 +1,215 @@
+import { v4 as uuidv4 } from 'uuid';
+import { QueryClientProvider, UseQueryResult } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { renderHook } from '@testing-library/react-hooks';
+import { getConfig } from '@edx/frontend-platform';
+import { waitFor } from '@testing-library/react';
+import { enterpriseCustomerFactory } from '../services/data/__factories__';
+import { generateTestPermutations, queryClient } from '../../../../utils/tests';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import {
+  fetchEnterpriseLearnerAcademy,
+  fetchEnterpriseLearnerDashboard,
+  fetchEnterpriseLearnerSearch,
+  fetchEnterpriseLearnerSkillsQuiz,
+} from '../services';
+import useAlgoliaSearch from './useAlgoliaSearch';
+import { useEnterpriseFeatures } from './index';
+
+// config
+const APP_CONFIG = {
+  ALGOLIA_INDEX_NAME_JOBS: 'unsupported-index-name',
+  ALGOLIA_INDEX_NAME: 'test-algolia-index',
+  ALGOLIA_APP_ID: 'test-algolia-app-id',
+};
+
+jest.mock('./useEnterpriseCustomer');
+jest.mock('./useEnterpriseFeatures');
+jest.mock('../services', () => ({
+  ...jest.requireActual('../services'),
+  fetchEnterpriseLearnerDashboard: jest.fn(),
+  fetchEnterpriseLearnerSearch: jest.fn(),
+  fetchEnterpriseLearnerAcademy: jest.fn(),
+  fetchEnterpriseLearnerSkillsQuiz: jest.fn(),
+}));
+jest.mock('@edx/frontend-platform', () => ({
+  ...jest.requireActual('@edx/frontend-platform'),
+  getConfig: jest.fn(),
+}));
+const mockedUseEnterpriseCustomer = useEnterpriseCustomer as
+  jest.Mock<UseQueryResult<EnterpriseCustomer>>;
+const mockedUseEnterpriseFeatures = useEnterpriseFeatures as
+  jest.Mock<UseQueryResult<EnterpriseFeatures>, [Record<string, any>?]>;
+
+const mockEnterpriseCustomer = enterpriseCustomerFactory();
+const mockCatalogUuidsToCatalogQueryUuids = Array.from({ length: 3 }, () => [uuidv4(), uuidv4()]);
+const mockEmptyBaseAlgoliaData = {
+  securedAlgoliaApiKey: null,
+  catalogUuidsToCatalogQueryUuids: {},
+};
+const mockBaseAlgoliaData = {
+  securedAlgoliaApiKey: 'test-algolia-api-key',
+  catalogUuidsToCatalogQueryUuids: Object.fromEntries(mockCatalogUuidsToCatalogQueryUuids),
+};
+const mockBaseBFFData = {
+  ...mockBaseAlgoliaData,
+  enterpriseCustomer: mockEnterpriseCustomer,
+  errors: [],
+  warnings: [],
+};
+
+const mockBFFSearchData = {
+  ...mockBaseBFFData,
+};
+
+const mockBFFAcademyData = {
+  ...mockBaseBFFData,
+};
+
+const mockBFFSkillsQuizData = {
+  ...mockBaseBFFData,
+};
+
+const expectedOutputBasedOnIndex = ({ isMatchedRoute, isCatalogQueryFiltersEnabled, indexName }) => {
+  const unsupportedIndexes = [APP_CONFIG.ALGOLIA_INDEX_NAME_JOBS];
+  const isIndexSupported = !unsupportedIndexes.includes(indexName);
+  return isCatalogQueryFiltersEnabled && isIndexSupported && isMatchedRoute
+    ? {
+      catalogUuidsToCatalogQueryUuids: mockBaseAlgoliaData.catalogUuidsToCatalogQueryUuids,
+      searchClient: expect.objectContaining({
+        appId: APP_CONFIG.ALGOLIA_APP_ID,
+      }),
+      searchIndex: expect.objectContaining({
+        appId: APP_CONFIG.ALGOLIA_APP_ID,
+      }),
+    }
+    : {
+      catalogUuidsToCatalogQueryUuids: mockEmptyBaseAlgoliaData.catalogUuidsToCatalogQueryUuids,
+      searchClient: expect.objectContaining({
+        appId: APP_CONFIG.ALGOLIA_APP_ID,
+      }),
+      searchIndex: expect.objectContaining({
+        appId: APP_CONFIG.ALGOLIA_APP_ID,
+      }),
+    };
+};
+
+const matchQueryFnToURLPattern = ({ enterpriseSlug, queryFnToMatch }) => {
+  const queryFnToURLPattern = [{
+    route: `/${enterpriseSlug}`,
+    queryFn: fetchEnterpriseLearnerDashboard,
+  },
+  {
+    route: `/${enterpriseSlug}/search/`,
+    queryFn: fetchEnterpriseLearnerSearch,
+  },
+  {
+    route: `/${enterpriseSlug}/academies/academy-uuid`,
+    queryFn: fetchEnterpriseLearnerAcademy,
+  },
+  {
+    route: `/${enterpriseSlug}/skills-quiz`,
+    queryFn: fetchEnterpriseLearnerSkillsQuiz,
+  },
+  ];
+  const matchedQueryFnToRoute = queryFnToURLPattern.find(({ queryFn }) => queryFn === queryFnToMatch);
+  return matchedQueryFnToRoute?.route;
+};
+
+describe('useAlgoliaSearch', () => {
+  const Wrapper = ({
+    initialEntries = [], children,
+  }: { initialEntries?: string[] | undefined; children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient()}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route path=":enterpriseSlug" element={children} />
+          <Route path=":enterpriseSlug/search" element={children} />
+          <Route path=":enterpriseSlug/academies/:academyUUID" element={children} />
+          <Route path=":enterpriseSlug/skills-quiz" element={children} />
+          <Route path=":enterpriseSlug/unsupported-bff-route" element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // @ts-ignore
+    mockedUseEnterpriseCustomer.mockReturnValue({
+      data: mockEnterpriseCustomer,
+    });
+    // @ts-ignore
+    mockedUseEnterpriseFeatures.mockReturnValue({
+      data: { catalogQuerySearchFiltersEnabled: true },
+    });
+    (fetchEnterpriseLearnerDashboard as jest.Mock).mockResolvedValue(mockBaseBFFData);
+    (fetchEnterpriseLearnerSearch as jest.Mock).mockResolvedValue(mockBFFSearchData);
+    (fetchEnterpriseLearnerAcademy as jest.Mock).mockResolvedValue(mockBFFAcademyData);
+    (fetchEnterpriseLearnerSkillsQuiz as jest.Mock).mockResolvedValue(mockBFFSkillsQuizData);
+    getConfig.mockReturnValue(APP_CONFIG);
+  });
+
+  it.each([
+    // BFF Disabled Routes
+    ...generateTestPermutations({
+      isMatchedBFFRoute: [false],
+      indexName: [
+        APP_CONFIG.ALGOLIA_INDEX_NAME,
+        APP_CONFIG.ALGOLIA_INDEX_NAME_JOBS,
+      ],
+      isCatalogQueryFiltersEnabled: [false, true],
+    }),
+    ...generateTestPermutations({
+      isMatchedBFFRoute: [true],
+      bffServiceFn: [
+        fetchEnterpriseLearnerDashboard,
+        fetchEnterpriseLearnerSearch,
+        fetchEnterpriseLearnerAcademy,
+        fetchEnterpriseLearnerSkillsQuiz,
+      ],
+      indexName: [
+        APP_CONFIG.ALGOLIA_INDEX_NAME,
+        APP_CONFIG.ALGOLIA_INDEX_NAME_JOBS,
+      ],
+      isCatalogQueryFiltersEnabled: [false, true],
+    }),
+  ])('should handle resolved value correctly for based on route (%s)', async ({
+    isMatchedBFFRoute,
+    bffServiceFn,
+    indexName,
+    isCatalogQueryFiltersEnabled,
+  }) => {
+    const initialEntries = isMatchedBFFRoute ? [matchQueryFnToURLPattern({
+      enterpriseSlug: mockEnterpriseCustomer.slug,
+      queryFnToMatch: bffServiceFn,
+    })] : ['/test-enterprise/unsupported-bff-route'];
+    const expectedData = expectedOutputBasedOnIndex(
+      {
+        isMatchedRoute: isMatchedBFFRoute,
+        isCatalogQueryFiltersEnabled,
+        indexName,
+      },
+    );
+    // @ts-ignore
+    mockedUseEnterpriseFeatures.mockReturnValue({
+      data: { catalogQuerySearchFiltersEnabled: isCatalogQueryFiltersEnabled },
+    });
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useAlgoliaSearch(indexName),
+      {
+        wrapper: ({ children }) => (
+          <Wrapper initialEntries={initialEntries.filter((entry): entry is string => entry !== undefined)}>
+            {children}
+          </Wrapper>
+        ),
+      },
+    );
+
+    await waitForNextUpdate();
+    await waitFor(() => expect(result.current).toEqual(
+      expect.objectContaining(expectedData),
+    ));
+  });
+});

--- a/src/components/app/data/hooks/useAlgoliaSearch.ts
+++ b/src/components/app/data/hooks/useAlgoliaSearch.ts
@@ -1,62 +1,103 @@
 import { getConfig } from '@edx/frontend-platform/config';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import algoliasearch from 'algoliasearch';
+import { logError } from '@edx/frontend-platform/logging';
 import useBFF from './useBFF';
 import useEnterpriseFeatures from './useEnterpriseFeatures';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import { queryDefaultEmptyFallback } from '../queries';
 
-const extractAlgolia = ({ data, select, isCatalogQueryFiltersEnabled }) => {
-  if (!isCatalogQueryFiltersEnabled) {
+const extractAlgolia = ({ data, isCatalogQueryFiltersEnabled, isIndexSupported }) => {
+  if (!isCatalogQueryFiltersEnabled || !isIndexSupported || !data) {
     return {
       securedAlgoliaApiKey: null,
       catalogUuidsToCatalogQueryUuids: {},
     };
   }
-  const transformedData = {
+  return {
     securedAlgoliaApiKey: data.securedAlgoliaApiKey,
     catalogUuidsToCatalogQueryUuids: data.catalogUuidsToCatalogQueryUuids,
   };
-  if (select) {
-    return select({
-      original: data,
-      transformed: transformedData,
-    });
-  }
-  return transformedData;
 };
 
-const useAlgoliaSearchh = (queryOptions = {}, indexName = null) => {
-  const { select, ...queryOptionsRest } = queryOptions;
-  const { data: { catalogQuerySearchFiltersEnabled } } = useEnterpriseFeatures();
+const useSecuredAlgoliaMetadata = (indexName) => {
   const config = getConfig();
+  const unsupportedSecuredAlgoliaIndices = [config.ALGOLIA_INDEX_NAME_JOBS];
+  const enterpriseCustomerResult = useEnterpriseCustomer();
+  const enterpriseCustomer = enterpriseCustomerResult.data!;
+  const { data: { catalogQuerySearchFiltersEnabled } } = useEnterpriseFeatures();
   const isCatalogQueryFiltersEnabled = !!(
     catalogQuerySearchFiltersEnabled
     && !!config.ALGOLIA_APP_ID
   );
+  const isIndexSupported = !unsupportedSecuredAlgoliaIndices.includes(indexName);
+  const queryOptions = {
+    select: (data) => extractAlgolia({
+      data,
+      isCatalogQueryFiltersEnabled,
+      isIndexSupported,
+    }),
+  };
+
   const { data: securedAlgoliaMetadata } = useBFF({
     bffQueryOptions: {
-      ...queryOptionsRest,
-      select: (data) => extractAlgolia({ data, select, isCatalogQueryFiltersEnabled }),
+      ...queryOptions,
     },
-    overrideFallbackQueryConfig: true,
+    fallbackQueryConfig: {
+      ...queryDefaultEmptyFallback(),
+      ...queryOptions,
+    },
   });
+
+  useEffect(() => {
+    if (isCatalogQueryFiltersEnabled && isIndexSupported && !securedAlgoliaMetadata.securedAlgoliaApiKey) {
+      logError(`Secured Algolia API key is missing for enterprise_customer_uuid: ${enterpriseCustomer.uuid}.`);
+    }
+  }, [
+    enterpriseCustomer.uuid,
+    isCatalogQueryFiltersEnabled,
+    isIndexSupported,
+    securedAlgoliaMetadata.securedAlgoliaApiKey,
+  ]);
+
+  return {
+    isCatalogQueryFiltersEnabled,
+    securedAlgoliaMetadata,
+    isIndexSupported,
+  };
+};
+
+const useAlgoliaSearchh = (indexName = null) => {
+  const config = getConfig();
+  const {
+    securedAlgoliaMetadata,
+    isCatalogQueryFiltersEnabled,
+    isIndexSupported,
+  } = useSecuredAlgoliaMetadata(indexName);
+
+  const algoliaSearchApiKey = isCatalogQueryFiltersEnabled && isIndexSupported
+    ? securedAlgoliaMetadata?.securedAlgoliaApiKey
+    : config.ALGOLIA_SEARCH_API_KEY;
+  console.log({ algoliaSearchApiKey, isIndexSupported, indexName });
   const algoliaMetadata = useMemo(
     () => {
       const searchClient = algoliasearch(
         config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
+        algoliaSearchApiKey,
       );
       const searchIndex = searchClient.initIndex(indexName || config.ALGOLIA_INDEX_NAME);
       return { searchClient, searchIndex };
     },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY, indexName],
+    [algoliaSearchApiKey, config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, indexName],
   );
+
   return useMemo(
     () => ({
-      ...algoliaMetadata,
-      ...securedAlgoliaMetadata,
-      isCatalogQueryFiltersEnabled,
+      searchIndex: algoliaMetadata.searchIndex,
+      searchClient: algoliaMetadata.searchClient,
+      catalogUuidsToCatalogQueryUuids: securedAlgoliaMetadata.catalogUuidsToCatalogQueryUuids,
     }),
-    [algoliaMetadata, securedAlgoliaMetadata, isCatalogQueryFiltersEnabled],
+    [algoliaMetadata, securedAlgoliaMetadata],
   );
 };
 

--- a/src/components/app/data/hooks/useAlgoliaSearch.ts
+++ b/src/components/app/data/hooks/useAlgoliaSearch.ts
@@ -1,0 +1,63 @@
+import { getConfig } from '@edx/frontend-platform/config';
+import { useMemo } from 'react';
+import algoliasearch from 'algoliasearch';
+import useBFF from './useBFF';
+import useEnterpriseFeatures from './useEnterpriseFeatures';
+
+const extractAlgolia = ({ data, select, isCatalogQueryFiltersEnabled }) => {
+  if (!isCatalogQueryFiltersEnabled) {
+    return {
+      securedAlgoliaApiKey: null,
+      catalogUuidsToCatalogQueryUuids: {},
+    };
+  }
+  const transformedData = {
+    securedAlgoliaApiKey: data.securedAlgoliaApiKey,
+    catalogUuidsToCatalogQueryUuids: data.catalogUuidsToCatalogQueryUuids,
+  };
+  if (select) {
+    return select({
+      original: data,
+      transformed: transformedData,
+    });
+  }
+  return transformedData;
+};
+
+const useAlgoliaSearchh = (queryOptions = {}, indexName = null) => {
+  const { select, ...queryOptionsRest } = queryOptions;
+  const { data: { catalogQuerySearchFiltersEnabled } } = useEnterpriseFeatures();
+  const config = getConfig();
+  const isCatalogQueryFiltersEnabled = !!(
+    catalogQuerySearchFiltersEnabled
+    && !!config.ALGOLIA_APP_ID
+  );
+  const { data: securedAlgoliaMetadata } = useBFF({
+    bffQueryOptions: {
+      ...queryOptionsRest,
+      select: (data) => extractAlgolia({ data, select, isCatalogQueryFiltersEnabled }),
+    },
+    overrideFallbackQueryConfig: true,
+  });
+  const algoliaMetadata = useMemo(
+    () => {
+      const searchClient = algoliasearch(
+        config.ALGOLIA_APP_ID,
+        config.ALGOLIA_SEARCH_API_KEY,
+      );
+      const searchIndex = searchClient.initIndex(indexName || config.ALGOLIA_INDEX_NAME);
+      return { searchClient, searchIndex };
+    },
+    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY, indexName],
+  );
+  return useMemo(
+    () => ({
+      ...algoliaMetadata,
+      ...securedAlgoliaMetadata,
+      isCatalogQueryFiltersEnabled,
+    }),
+    [algoliaMetadata, securedAlgoliaMetadata, isCatalogQueryFiltersEnabled],
+  );
+};
+
+export default useAlgoliaSearchh;

--- a/src/components/app/data/hooks/useAlgoliaSearch.ts
+++ b/src/components/app/data/hooks/useAlgoliaSearch.ts
@@ -78,7 +78,6 @@ const useAlgoliaSearchh = (indexName = null) => {
   const algoliaSearchApiKey = isCatalogQueryFiltersEnabled && isIndexSupported
     ? securedAlgoliaMetadata?.securedAlgoliaApiKey
     : config.ALGOLIA_SEARCH_API_KEY;
-  console.log({ algoliaSearchApiKey, isIndexSupported, indexName });
   const algoliaMetadata = useMemo(
     () => {
       const searchClient = algoliasearch(

--- a/src/components/app/data/hooks/useAlgoliaSearch.ts
+++ b/src/components/app/data/hooks/useAlgoliaSearch.ts
@@ -1,44 +1,95 @@
-import {getConfig} from '@edx/frontend-platform/config';
-import {useEffect, useMemo} from 'react';
+import { getConfig } from '@edx/frontend-platform/config';
+import { useEffect, useMemo } from 'react';
 import algoliasearch from 'algoliasearch';
-import {logError} from '@edx/frontend-platform/logging';
+import { logError } from '@edx/frontend-platform/logging';
 import useBFF from './useBFF';
 import useEnterpriseFeatures from './useEnterpriseFeatures';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
-import {queryDefaultEmptyFallback} from '../queries';
+import { queryDefaultEmptyFallback } from '../queries';
 
-const extractAlgolia = ({ data, isCatalogQueryFiltersEnabled, isIndexSupported }) => {
-  if (!isCatalogQueryFiltersEnabled || !isIndexSupported || !data) {
-    return {
+/**
+ * Extracts secured Algolia metadata from backend data based on feature and index support flags.
+ *
+ * Returns the actual secured Algolia API key and catalog UUID mapping only if:
+ * - catalog query filters are enabled
+ * - the given index is supported
+ * - valid data is provided
+ *
+ * Otherwise, returns a default object with `null` API key and empty mapping.
+ *
+ * @param data - Backend response data containing Algolia metadata.
+ * @param isCatalogQueryFiltersEnabled - Whether catalog query filters are enabled for the enterprise customer.
+ * @param isIndexSupported - Whether the specified Algolia index is supported for secured search.
+ *
+ * @returns An object with the secured Algolia API key and the catalog UUID to query UUID mapping.
+ */
+const extractAlgolia = ({
+  data,
+  isCatalogQueryFiltersEnabled,
+  isIndexSupported,
+}: {
+  data: {
+    securedAlgoliaApiKey: string | null;
+    catalogUuidsToCatalogQueryUuids: Record<string, string>;
+  } | null;
+  isCatalogQueryFiltersEnabled: boolean;
+  isIndexSupported: boolean;
+}) => (
+  isCatalogQueryFiltersEnabled && isIndexSupported && data
+    ? {
+      securedAlgoliaApiKey: data.securedAlgoliaApiKey,
+      catalogUuidsToCatalogQueryUuids: data.catalogUuidsToCatalogQueryUuids,
+    }
+    : {
       securedAlgoliaApiKey: null,
       catalogUuidsToCatalogQueryUuids: {},
-    };
-  }
-  return {
-    securedAlgoliaApiKey: data.securedAlgoliaApiKey,
-    catalogUuidsToCatalogQueryUuids: data.catalogUuidsToCatalogQueryUuids,
-  };
-};
+    }
+);
 
-const useSecuredAlgoliaMetadata = (indexName) => {
+/**
+ * A custom React hook that fetches secured Algolia metadata for a given index,
+ * based on enterprise customer configuration and feature flags.
+ *
+ * Determines whether secured Algolia search can be used for the provided index
+ * by checking:
+ * - If catalog query filters are enabled for the enterprise customer
+ * - If the index is not in the list of unsupported secured indices
+ *
+ * It then uses a BFF query to retrieve the secured Algolia API key and
+ * catalog-to-query UUID mapping. Logs an error if metadata is expected but missing.
+ *
+ * @param indexName - The Algolia index name to check for support.
+ *
+ * @returns An object containing:
+ * - `isCatalogQueryFiltersEnabled`: Whether secured Algolia is enabled via feature flag.
+ * - `isIndexSupported`: Whether the provided index supports secured Algolia.
+ * - `securedAlgoliaMetadata`: Metadata containing the secured API key and catalog-query UUID mapping.
+ */
+const useSecuredAlgoliaMetadata = (indexName: string | null) => {
   const config = getConfig();
   const unsupportedSecuredAlgoliaIndices = [config.ALGOLIA_INDEX_NAME_JOBS];
   const enterpriseCustomerResult = useEnterpriseCustomer();
   const enterpriseCustomer = enterpriseCustomerResult.data!;
   const { data: { catalogQuerySearchFiltersEnabled } } = useEnterpriseFeatures();
+
+  // Waffle flag based determination if we use the secured algolia api key
   const isCatalogQueryFiltersEnabled = !!(
-    catalogQuerySearchFiltersEnabled
-    && !!config.ALGOLIA_APP_ID
+    catalogQuerySearchFiltersEnabled && !!config.ALGOLIA_APP_ID
   );
   const isIndexSupported = !unsupportedSecuredAlgoliaIndices.includes(indexName);
+
+  // Common helper between the BFF call and its empty fallback function
   const queryOptions = {
-    select: (data) => extractAlgolia({
+    select: (data: SecuredAlgoliaApiData | null) => extractAlgolia({
       data,
       isCatalogQueryFiltersEnabled,
       isIndexSupported,
     }),
   };
 
+  // Retrieve secured algolia key from the BFF if the route is enabled
+  // or perform a no-op query that resolves to the default secured
+  // algolia api key data structure
   const { data: securedAlgoliaMetadata } = useBFF({
     bffQueryOptions: {
       ...queryOptions,
@@ -49,14 +100,29 @@ const useSecuredAlgoliaMetadata = (indexName) => {
     },
   });
 
+  // Log an error if the secured API key is missing,
+  // not applicable for the route, or is disabled
   useEffect(() => {
-    if (isCatalogQueryFiltersEnabled && isIndexSupported && !securedAlgoliaMetadata.securedAlgoliaApiKey) {
-      logError(`Secured Algolia API key is missing for enterprise_customer_uuid: ${enterpriseCustomer.uuid}.`);
+    if (
+      isCatalogQueryFiltersEnabled
+      && isIndexSupported
+      && !securedAlgoliaMetadata.securedAlgoliaApiKey
+    ) {
+      logError(
+        `Secured Algolia API key is missing, or no applicable
+        for enterprise_customer_uuid: ${enterpriseCustomer.uuid}.
+        isCatalogQueryFiltersEnabled: ${isCatalogQueryFiltersEnabled},
+        indexName: ${indexName},
+        securedAlgoliaMetadata: ${JSON.stringify(securedAlgoliaMetadata)}
+        `,
+      );
     }
   }, [
     enterpriseCustomer.uuid,
+    indexName,
     isCatalogQueryFiltersEnabled,
     isIndexSupported,
+    securedAlgoliaMetadata,
     securedAlgoliaMetadata.securedAlgoliaApiKey,
   ]);
 
@@ -67,7 +133,24 @@ const useSecuredAlgoliaMetadata = (indexName) => {
   };
 };
 
-const useAlgoliaSearch = (indexName = null) => {
+/**
+ * A custom React hook that initializes and returns Algolia search clients and metadata.
+ *
+ * It determines the appropriate API key (secured or fallback) based on whether:
+ * - catalog query filters are enabled for the enterprise customer, and
+ * - the provided index is supported for secured search.
+ *
+ * It uses `algoliasearch` to instantiate a search client and index, and returns them
+ * along with catalog-to-query UUID mappings used for filtering results.
+ *
+ * @param indexName - Optional custom Algolia index name. Defaults to config's standard index.
+ *
+ * @returns An object containing:
+ * - `searchClient`: The initialized Algolia search client.
+ * - `searchIndex`: The configured search index instance.
+ * - `catalogUuidsToCatalogQueryUuids`: A mapping used for filtering catalog results.
+ */
+const useAlgoliaSearch = (indexName: string | null = null) => {
   const config = getConfig();
   const {
     securedAlgoliaMetadata,
@@ -75,29 +158,28 @@ const useAlgoliaSearch = (indexName = null) => {
     isIndexSupported,
   } = useSecuredAlgoliaMetadata(indexName);
 
+  // Based on the waffle flag and supported indexes, we will use the secured algolia
+  // key or default back to the legacy initialization of the search client and indexes
   const algoliaSearchApiKey = isCatalogQueryFiltersEnabled && isIndexSupported
     ? securedAlgoliaMetadata?.securedAlgoliaApiKey
     : config.ALGOLIA_SEARCH_API_KEY;
-  const algoliaMetadata = useMemo(
-    () => {
-      const searchClient = algoliasearch(
-        config.ALGOLIA_APP_ID,
-        algoliaSearchApiKey,
-      );
-      const searchIndex = searchClient.initIndex(indexName || config.ALGOLIA_INDEX_NAME);
-      return { searchClient, searchIndex };
-    },
-    [algoliaSearchApiKey, config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, indexName],
-  );
 
-  return useMemo(
-    () => ({
-      searchIndex: algoliaMetadata.searchIndex,
-      searchClient: algoliaMetadata.searchClient,
-      catalogUuidsToCatalogQueryUuids: securedAlgoliaMetadata.catalogUuidsToCatalogQueryUuids,
-    }),
-    [algoliaMetadata, securedAlgoliaMetadata],
-  );
+  // Update instantiate search client with or without a secured
+  // algolia api key and retrieve the initialized algolia index
+  const algoliaMetadata = useMemo(() => {
+    const searchClient = algoliasearch(
+      config.ALGOLIA_APP_ID,
+      algoliaSearchApiKey,
+    );
+    const searchIndex = searchClient.initIndex(indexName || config.ALGOLIA_INDEX_NAME);
+    return { searchClient, searchIndex };
+  }, [algoliaSearchApiKey, config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, indexName]);
+
+  return useMemo(() => ({
+    searchIndex: algoliaMetadata.searchIndex,
+    searchClient: algoliaMetadata.searchClient,
+    catalogUuidsToCatalogQueryUuids: securedAlgoliaMetadata.catalogUuidsToCatalogQueryUuids,
+  }), [algoliaMetadata, securedAlgoliaMetadata]);
 };
 
 export default useAlgoliaSearch;

--- a/src/components/app/data/hooks/useAlgoliaSearch.ts
+++ b/src/components/app/data/hooks/useAlgoliaSearch.ts
@@ -1,11 +1,11 @@
-import { getConfig } from '@edx/frontend-platform/config';
-import { useEffect, useMemo } from 'react';
+import {getConfig} from '@edx/frontend-platform/config';
+import {useEffect, useMemo} from 'react';
 import algoliasearch from 'algoliasearch';
-import { logError } from '@edx/frontend-platform/logging';
+import {logError} from '@edx/frontend-platform/logging';
 import useBFF from './useBFF';
 import useEnterpriseFeatures from './useEnterpriseFeatures';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
-import { queryDefaultEmptyFallback } from '../queries';
+import {queryDefaultEmptyFallback} from '../queries';
 
 const extractAlgolia = ({ data, isCatalogQueryFiltersEnabled, isIndexSupported }) => {
   if (!isCatalogQueryFiltersEnabled || !isIndexSupported || !data) {
@@ -67,7 +67,7 @@ const useSecuredAlgoliaMetadata = (indexName) => {
   };
 };
 
-const useAlgoliaSearchh = (indexName = null) => {
+const useAlgoliaSearch = (indexName = null) => {
   const config = getConfig();
   const {
     securedAlgoliaMetadata,
@@ -100,4 +100,4 @@ const useAlgoliaSearchh = (indexName = null) => {
   );
 };
 
-export default useAlgoliaSearchh;
+export default useAlgoliaSearch;

--- a/src/components/app/data/hooks/useAlgoliaSearch.ts
+++ b/src/components/app/data/hooks/useAlgoliaSearch.ts
@@ -32,16 +32,18 @@ const extractAlgolia = ({
   data,
   isCatalogQueryFiltersEnabled,
   isIndexSupported,
-}: ExtractAlgoliaArgs) => (
-  isCatalogQueryFiltersEnabled && isIndexSupported && data
-    ? {
+}: ExtractAlgoliaArgs) => {
+  if (isCatalogQueryFiltersEnabled && isIndexSupported && data) {
+    return {
       securedAlgoliaApiKey: data.securedAlgoliaApiKey,
       catalogUuidsToCatalogQueryUuids: data.catalogUuidsToCatalogQueryUuids,
-    }
-    : {
-      securedAlgoliaApiKey: null,
-      catalogUuidsToCatalogQueryUuids: {},
-    });
+    };
+  }
+  return {
+    securedAlgoliaApiKey: null,
+    catalogUuidsToCatalogQueryUuids: {},
+  };
+};
 
 /**
  * A custom React hook that fetches secured Algolia metadata for a given index,

--- a/src/components/app/data/hooks/useAlgoliaSearch.ts
+++ b/src/components/app/data/hooks/useAlgoliaSearch.ts
@@ -1,4 +1,4 @@
-import { getConfig } from '@edx/frontend-platform/config';
+import { getConfig } from '@edx/frontend-platform';
 import { useEffect, useMemo } from 'react';
 import algoliasearch from 'algoliasearch';
 import { logError } from '@edx/frontend-platform/logging';
@@ -43,8 +43,7 @@ const extractAlgolia = ({
     : {
       securedAlgoliaApiKey: null,
       catalogUuidsToCatalogQueryUuids: {},
-    }
-);
+    });
 
 /**
  * A custom React hook that fetches secured Algolia metadata for a given index,
@@ -71,7 +70,6 @@ const useSecuredAlgoliaMetadata = (indexName: string | null) => {
   const enterpriseCustomerResult = useEnterpriseCustomer();
   const enterpriseCustomer = enterpriseCustomerResult.data!;
   const { data: { catalogQuerySearchFiltersEnabled } } = useEnterpriseFeatures();
-
   // Waffle flag based determination if we use the secured algolia api key
   const isCatalogQueryFiltersEnabled = !!(
     catalogQuerySearchFiltersEnabled && !!config.ALGOLIA_APP_ID
@@ -100,30 +98,25 @@ const useSecuredAlgoliaMetadata = (indexName: string | null) => {
     },
   });
 
-  // Log an error if the secured API key is missing,
-  // not applicable for the route, or is disabled
   useEffect(() => {
-    if (
-      isCatalogQueryFiltersEnabled
+    if (isCatalogQueryFiltersEnabled
       && isIndexSupported
-      && !securedAlgoliaMetadata.securedAlgoliaApiKey
-    ) {
+      && !securedAlgoliaMetadata?.securedAlgoliaApiKey) {
       logError(
         `Secured Algolia API key is missing, or no applicable
-        for enterprise_customer_uuid: ${enterpriseCustomer.uuid}.
-        isCatalogQueryFiltersEnabled: ${isCatalogQueryFiltersEnabled},
-        indexName: ${indexName},
-        securedAlgoliaMetadata: ${JSON.stringify(securedAlgoliaMetadata)}
-        `,
+            for enterprise_customer_uuid: ${enterpriseCustomer.uuid}.
+            isCatalogQueryFiltersEnabled: ${isCatalogQueryFiltersEnabled},
+            indexName: ${indexName},
+            securedAlgoliaMetadata: ${JSON.stringify(securedAlgoliaMetadata)}
+            `,
       );
     }
   }, [
     enterpriseCustomer.uuid,
     indexName,
     isCatalogQueryFiltersEnabled,
-    isIndexSupported,
-    securedAlgoliaMetadata,
-    securedAlgoliaMetadata.securedAlgoliaApiKey,
+    isIndexSupported, securedAlgoliaMetadata,
+    securedAlgoliaMetadata?.securedAlgoliaApiKey,
   ]);
 
   return {
@@ -152,6 +145,7 @@ const useSecuredAlgoliaMetadata = (indexName: string | null) => {
  */
 const useAlgoliaSearch = (indexName: string | null = null) => {
   const config = getConfig();
+
   const {
     securedAlgoliaMetadata,
     isCatalogQueryFiltersEnabled,

--- a/src/components/app/data/hooks/useAlgoliaSearch.ts
+++ b/src/components/app/data/hooks/useAlgoliaSearch.ts
@@ -3,7 +3,8 @@ import { useEffect, useMemo } from 'react';
 import algoliasearch from 'algoliasearch';
 import { logError } from '@edx/frontend-platform/logging';
 import useBFF from './useBFF';
-import { useEnterpriseCustomer, useEnterpriseFeatures } from './index';
+import useEnterpriseCustomer from './useEnterpriseCustomer';
+import useEnterpriseFeatures from './useEnterpriseFeatures';
 import { queryDefaultEmptyFallback } from '../queries';
 
 type ExtractAlgoliaArgs = {

--- a/src/components/app/data/hooks/useBFF.js
+++ b/src/components/app/data/hooks/useBFF.js
@@ -2,6 +2,7 @@ import { useLocation, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { logError } from '@edx/frontend-platform/logging';
 import { resolveBFFQuery } from '../queries';
+import { isObjEmpty } from '../utils';
 
 /**
  * Uses the route to determine which API call to make for the BFF
@@ -16,8 +17,7 @@ import { resolveBFFQuery } from '../queries';
 export default function useBFF({
   bffQueryAdditionalParams = {},
   bffQueryOptions = {},
-  fallbackQueryConfig = null,
-  overrideFallbackQueryConfig = false,
+  fallbackQueryConfig = {},
 }) {
   const { enterpriseSlug } = useParams();
   const location = useLocation();
@@ -33,11 +33,7 @@ export default function useBFF({
       ...matchedBFFQuery({ enterpriseSlug, ...bffQueryAdditionalParams }),
       ...bffQueryOptions,
     };
-  } else if (overrideFallbackQueryConfig) {
-    // This conditional was added to handle date that was migrated into the BFF that is not sourced interally
-    // from our services such as the securedAlgoliaKey which fallback to helper hooks, see useAlgoliaSearchh
-    return { data: null };
-  } else if (fallbackQueryConfig) {
+  } else if (!isObjEmpty(fallbackQueryConfig)) {
     queryConfig = fallbackQueryConfig;
   } else {
     const err = new Error('No BFF query found for the current route and no fallback query provided');

--- a/src/components/app/data/hooks/useBFF.js
+++ b/src/components/app/data/hooks/useBFF.js
@@ -26,6 +26,7 @@ export default function useBFF({
   const matchedBFFQuery = resolveBFFQuery(
     location.pathname,
   );
+
   // Determine which query to call, the original hook or the new BFF
   let queryConfig = {};
   if (matchedBFFQuery) {

--- a/src/components/app/data/hooks/useBFF.js
+++ b/src/components/app/data/hooks/useBFF.js
@@ -10,12 +10,14 @@ import { resolveBFFQuery } from '../queries';
  * @param bffQueryOptions - the queryOptions specifically for the matched BFF query call
  * @param fallbackQueryConfig - if a route is not compatible with the BFF layer, this field
  * allows you to pass a fallback query endpoint to call in lieu of an unmatched BFF query
+ * @param overrideFallbackQueryConfig - if a routes fallback does not require a useQuery call, override the fallback
  * @returns  {Types.UseQueryResult}} The query results for the routes BFF.
  */
 export default function useBFF({
   bffQueryAdditionalParams = {},
   bffQueryOptions = {},
   fallbackQueryConfig = null,
+  overrideFallbackQueryConfig = false,
 }) {
   const { enterpriseSlug } = useParams();
   const location = useLocation();
@@ -24,7 +26,6 @@ export default function useBFF({
   const matchedBFFQuery = resolveBFFQuery(
     location.pathname,
   );
-
   // Determine which query to call, the original hook or the new BFF
   let queryConfig = {};
   if (matchedBFFQuery) {
@@ -32,6 +33,10 @@ export default function useBFF({
       ...matchedBFFQuery({ enterpriseSlug, ...bffQueryAdditionalParams }),
       ...bffQueryOptions,
     };
+  } else if (overrideFallbackQueryConfig) {
+    // This conditional was added to handle date that was migrated into the BFF that is not sourced interally
+    // from our services such as the securedAlgoliaKey which fallback to helper hooks, see useAlgoliaSearchh
+    return { data: null };
   } else if (fallbackQueryConfig) {
     queryConfig = fallbackQueryConfig;
   } else {

--- a/src/components/app/data/hooks/useBFF.test.jsx
+++ b/src/components/app/data/hooks/useBFF.test.jsx
@@ -5,9 +5,9 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { enterpriseCustomerFactory } from '../services/data/__factories__';
 import { queryClient } from '../../../../utils/tests';
 import {
+  fetchEnterpriseLearnerAcademy,
   fetchEnterpriseLearnerDashboard,
   fetchEnterpriseLearnerSearch,
-  fetchEnterpriseLearnerAcademy,
   fetchEnterpriseLearnerSkillsQuiz,
 } from '../services';
 import useBFF from './useBFF';

--- a/src/components/app/data/queries/queries.ts
+++ b/src/components/app/data/queries/queries.ts
@@ -299,3 +299,9 @@ export function queryEnterpriseLearnerSkillsQuizBFF({ enterpriseSlug }) {
     ._ctx.route
     ._ctx.skillsQuiz;
 }
+
+export function queryDefaultEmptyFallback() {
+  return queries
+    .bff
+    .defaultEmptyFallback;
+}

--- a/src/components/app/data/queries/queryKeyFactory.js
+++ b/src/components/app/data/queries/queryKeyFactory.js
@@ -294,6 +294,10 @@ const bff = createQueryKeys('bff', {
       },
     },
   }),
+  defaultEmptyFallback: {
+    queryKey: null,
+    queryFn: () => null,
+  },
 });
 
 const queries = mergeQueryKeys(enterprise, user, content, bff);

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -5,9 +5,9 @@ import { getConfig } from '@edx/frontend-platform/config';
 import { getLoggingService } from '@edx/frontend-platform/logging';
 
 import { isDefinedAndNotNull } from '../../utils/common';
-import { useAlgoliaSearch } from '../../utils/hooks';
 import { pushUserCustomerAttributes } from '../../utils/optimizely';
 import { useEnterpriseCustomer, useIsBFFEnabled } from '../app/data';
+import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 /**
  * Custom hook to set custom attributes for logging service:
@@ -32,7 +32,10 @@ function useLoggingCustomAttributes() {
 
 const EnterprisePage = ({ children }) => {
   const config = getConfig();
-  const [searchClient, searchIndex] = useAlgoliaSearch(config);
+  const {
+    searchIndex,
+    searchClient,
+  } = useAlgoliaSearchh();
   const { authenticatedUser } = useContext(AppContext);
 
   // Set custom attributes via logging service

--- a/src/components/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise-page/EnterprisePage.jsx
@@ -7,7 +7,6 @@ import { getLoggingService } from '@edx/frontend-platform/logging';
 import { isDefinedAndNotNull } from '../../utils/common';
 import { pushUserCustomerAttributes } from '../../utils/optimizely';
 import { useEnterpriseCustomer, useIsBFFEnabled } from '../app/data';
-import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 /**
  * Custom hook to set custom attributes for logging service:
@@ -32,10 +31,6 @@ function useLoggingCustomAttributes() {
 
 const EnterprisePage = ({ children }) => {
   const config = getConfig();
-  const {
-    searchIndex,
-    searchClient,
-  } = useAlgoliaSearchh();
   const { authenticatedUser } = useContext(AppContext);
 
   // Set custom attributes via logging service
@@ -51,11 +46,7 @@ const EnterprisePage = ({ children }) => {
         },
       },
     },
-    algolia: {
-      client: searchClient,
-      index: searchIndex,
-    },
-  }), [config, searchClient, searchIndex, authenticatedUser]);
+  }), [config, authenticatedUser]);
 
   return (
     <AppContext.Provider value={contextValue}>

--- a/src/components/enterprise-page/EnterprisePage.test.jsx
+++ b/src/components/enterprise-page/EnterprisePage.test.jsx
@@ -69,10 +69,6 @@ describe('<EnterprisePage />', () => {
             },
           },
         },
-        algolia: {
-          client: expect.any(Object),
-          index: expect.any(Object),
-        },
       }),
     );
   });

--- a/src/components/my-career/CategoryCard.jsx
+++ b/src/components/my-career/CategoryCard.jsx
@@ -2,9 +2,9 @@ import { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Card, useToggle } from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-
 import algoliasearch from 'algoliasearch/lite';
 import { getConfig } from '@edx/frontend-platform/config';
+
 import LevelBars from './LevelBars';
 import SkillsRecommendationCourses from './SkillsRecommendationCourses';
 import { features } from '../../config';

--- a/src/components/my-career/CategoryCard.jsx
+++ b/src/components/my-career/CategoryCard.jsx
@@ -6,8 +6,7 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import LevelBars from './LevelBars';
 import SkillsRecommendationCourses from './SkillsRecommendationCourses';
 import { features } from '../../config';
-import { useEnterpriseCustomer, useIsAssignmentsOnlyLearner } from '../app/data';
-import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
+import { useAlgoliaSearch, useEnterpriseCustomer, useIsAssignmentsOnlyLearner } from '../app/data';
 
 const CategoryCard = ({ topCategory }) => {
   const { skillsSubcategories } = topCategory;
@@ -25,7 +24,7 @@ const CategoryCard = ({ topCategory }) => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const {
     searchIndex: courseIndex,
-  } = useAlgoliaSearchh();
+  } = useAlgoliaSearch();
 
   const filterRenderableSkills = (skills) => {
     const renderableSkills = [];

--- a/src/components/my-career/CategoryCard.jsx
+++ b/src/components/my-career/CategoryCard.jsx
@@ -1,16 +1,13 @@
-import {
-  useEffect, useMemo, useState,
-} from 'react';
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Card, useToggle } from '@openedx/paragon';
-import { getConfig } from '@edx/frontend-platform/config';
-import algoliasearch from 'algoliasearch/lite';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import LevelBars from './LevelBars';
 import SkillsRecommendationCourses from './SkillsRecommendationCourses';
 import { features } from '../../config';
 import { useEnterpriseCustomer, useIsAssignmentsOnlyLearner } from '../app/data';
+import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 const CategoryCard = ({ topCategory }) => {
   const { skillsSubcategories } = topCategory;
@@ -25,18 +22,10 @@ const CategoryCard = ({ topCategory }) => {
   const isAssignmentsLearnerOnly = useIsAssignmentsOnlyLearner();
   const featuredIsCourseSearchDisabled = features.FEATURE_ENABLE_TOP_DOWN_ASSIGNMENT && isAssignmentsLearnerOnly;
 
-  const config = getConfig();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
-  const courseIndex = useMemo(
-    () => {
-      const client = algoliasearch(
-        config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
-      );
-      return client.initIndex(config.ALGOLIA_INDEX_NAME);
-    },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY],
-  );
+  const {
+    searchIndex: courseIndex,
+  } = useAlgoliaSearchh();
 
   const filterRenderableSkills = (skills) => {
     const renderableSkills = [];
@@ -164,8 +153,7 @@ const CategoryCard = ({ topCategory }) => {
             </span>
           )}
           {
-            !showAll && !showLess && (
-              null)
+            !showAll && !showLess && null
           }
         </Button>
       )}

--- a/src/components/my-career/SearchJobRole.jsx
+++ b/src/components/my-career/SearchJobRole.jsx
@@ -11,14 +11,14 @@ import { Button, Form, StatefulButton } from '@openedx/paragon';
 import { CURRENT_JOB_FACET, JOB_FILTERS } from '../skills-quiz/constants';
 import { fetchJobDetailsFromAlgolia, patchProfile } from './data/service';
 import { CURRENT_JOB_PROFILE_FIELD_NAME } from './data/constants';
-import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
+import { useAlgoliaSearch } from '../app/data';
 
 const SearchJobRole = (props) => {
   const config = getConfig();
   const {
     searchClient,
     searchIndex,
-  } = useAlgoliaSearchh(
+  } = useAlgoliaSearch(
     config.ALGOLIA_INDEX_NAME_JOBS,
   );
   const { authenticatedUser: { username } } = useContext(AppContext);

--- a/src/components/my-career/SearchJobRole.jsx
+++ b/src/components/my-career/SearchJobRole.jsx
@@ -7,11 +7,14 @@ import { deleteRefinementAction, SearchContext } from '@edx/frontend-enterprise-
 import { AppContext } from '@edx/frontend-platform/react';
 import FacetListRefinement from '@edx/frontend-enterprise-catalog-search/FacetListRefinement';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
-import { Button, Form, StatefulButton } from '@openedx/paragon';
+import {
+  Button, Container, Form, StatefulButton,
+} from '@openedx/paragon';
 import { CURRENT_JOB_FACET, JOB_FILTERS } from '../skills-quiz/constants';
 import { fetchJobDetailsFromAlgolia, patchProfile } from './data/service';
 import { CURRENT_JOB_PROFILE_FIELD_NAME } from './data/constants';
 import { useAlgoliaSearch } from '../app/data';
+import { SearchUnavailableAlert } from '../search-unavailable-alert';
 
 const SearchJobRole = (props) => {
   const config = getConfig();
@@ -84,6 +87,14 @@ const SearchJobRole = (props) => {
     }
     props.onCancel();
   };
+
+  if (!searchClient) {
+    return (
+      <Container size="lg" data-testid="search-unavailable-alert">
+        <SearchUnavailableAlert />
+      </Container>
+    );
+  }
 
   return (
     <div>

--- a/src/components/my-career/SearchJobRole.jsx
+++ b/src/components/my-career/SearchJobRole.jsx
@@ -19,7 +19,6 @@ const SearchJobRole = (props) => {
     searchClient,
     searchIndex,
   } = useAlgoliaSearchh(
-    {},
     config.ALGOLIA_INDEX_NAME_JOBS,
   );
   const { authenticatedUser: { username } } = useContext(AppContext);

--- a/src/components/my-career/SearchJobRole.jsx
+++ b/src/components/my-career/SearchJobRole.jsx
@@ -3,21 +3,25 @@ import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform/config';
 import { logError } from '@edx/frontend-platform/logging';
 import { Configure, InstantSearch } from 'react-instantsearch-dom';
-import { SearchContext, deleteRefinementAction } from '@edx/frontend-enterprise-catalog-search';
+import { deleteRefinementAction, SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { AppContext } from '@edx/frontend-platform/react';
 import FacetListRefinement from '@edx/frontend-enterprise-catalog-search/FacetListRefinement';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
-import {
-  Button, Form, StatefulButton,
-} from '@openedx/paragon';
+import { Button, Form, StatefulButton } from '@openedx/paragon';
 import { CURRENT_JOB_FACET, JOB_FILTERS } from '../skills-quiz/constants';
-import { patchProfile, fetchJobDetailsFromAlgolia } from './data/service';
+import { fetchJobDetailsFromAlgolia, patchProfile } from './data/service';
 import { CURRENT_JOB_PROFILE_FIELD_NAME } from './data/constants';
-import { useAlgoliaSearch } from '../../utils/hooks';
+import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 const SearchJobRole = (props) => {
   const config = getConfig();
-  const [searchClient, searchIndex] = useAlgoliaSearch(config, config.ALGOLIA_INDEX_NAME_JOBS);
+  const {
+    searchClient,
+    searchIndex,
+  } = useAlgoliaSearchh(
+    {},
+    config.ALGOLIA_INDEX_NAME_JOBS,
+  );
   const { authenticatedUser: { username } } = useContext(AppContext);
   const { refinements, dispatch } = useContext(SearchContext);
   const { current_job: currentJob } = refinements;

--- a/src/components/my-career/tests/CategoryCard.test.jsx
+++ b/src/components/my-career/tests/CategoryCard.test.jsx
@@ -4,12 +4,7 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import { renderWithRouter } from '../../../utils/tests';
 import CategoryCard from '../CategoryCard';
-import {
-  useAlgoliaSearch,
-  useDefaultSearchFilters,
-  useEnterpriseCustomer,
-  useIsAssignmentsOnlyLearner,
-} from '../../app/data';
+import { useDefaultSearchFilters, useEnterpriseCustomer, useIsAssignmentsOnlyLearner } from '../../app/data';
 import { enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
 
 jest.mock('@edx/frontend-platform/i18n', () => ({
@@ -23,7 +18,6 @@ jest.mock('../../app/data', () => ({
   useEnterpriseCustomer: jest.fn(),
   useIsAssignmentsOnlyLearner: jest.fn(),
   useDefaultSearchFilters: jest.fn(),
-  useAlgoliaSearch: jest.fn(),
 }));
 
 // eslint-disable-next-line no-console
@@ -78,14 +72,6 @@ describe('<CategoryCard />', () => {
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     useIsAssignmentsOnlyLearner.mockReturnValue(false);
     useDefaultSearchFilters.mockReturnValue({ filters: `enterprise_customer_uuids:${mockEnterpriseCustomer.uuid}` });
-    useAlgoliaSearch.mockReturnValue({
-      searchClient: {
-        search: jest.fn(), appId: 'test-app-id',
-      },
-      searchIndex: {
-        indexName: 'mock-index-name',
-      },
-    });
   });
   it('renders the CategoryCard component', () => {
     renderWithRouter(<CategoryCardWithContext />);

--- a/src/components/my-career/tests/CategoryCard.test.jsx
+++ b/src/components/my-career/tests/CategoryCard.test.jsx
@@ -4,7 +4,12 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import { renderWithRouter } from '../../../utils/tests';
 import CategoryCard from '../CategoryCard';
-import { useEnterpriseCustomer, useDefaultSearchFilters, useIsAssignmentsOnlyLearner } from '../../app/data';
+import {
+  useAlgoliaSearch,
+  useDefaultSearchFilters,
+  useEnterpriseCustomer,
+  useIsAssignmentsOnlyLearner,
+} from '../../app/data';
 import { enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
 
 jest.mock('@edx/frontend-platform/i18n', () => ({
@@ -18,6 +23,7 @@ jest.mock('../../app/data', () => ({
   useEnterpriseCustomer: jest.fn(),
   useIsAssignmentsOnlyLearner: jest.fn(),
   useDefaultSearchFilters: jest.fn(),
+  useAlgoliaSearch: jest.fn(),
 }));
 
 // eslint-disable-next-line no-console
@@ -72,6 +78,14 @@ describe('<CategoryCard />', () => {
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     useIsAssignmentsOnlyLearner.mockReturnValue(false);
     useDefaultSearchFilters.mockReturnValue({ filters: `enterprise_customer_uuids:${mockEnterpriseCustomer.uuid}` });
+    useAlgoliaSearch.mockReturnValue({
+      searchClient: {
+        search: jest.fn(), appId: 'test-app-id',
+      },
+      searchIndex: {
+        indexName: 'mock-index-name',
+      },
+    });
   });
   it('renders the CategoryCard component', () => {
     renderWithRouter(<CategoryCardWithContext />);

--- a/src/components/my-career/tests/MyCareerTab.test.jsx
+++ b/src/components/my-career/tests/MyCareerTab.test.jsx
@@ -7,11 +7,12 @@ import * as hooks from '../data/hooks';
 import { renderWithRouter } from '../../../utils/tests';
 import MyCareerTab from '../MyCareerTab';
 import {
+  useAlgoliaSearch,
+  useDefaultSearchFilters,
+  useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
   useIsAssignmentsOnlyLearner,
   useLearnerSkillLevels,
-  useDefaultSearchFilters,
-  useEnterpriseCourseEnrollments,
 } from '../../app/data';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
 
@@ -34,6 +35,7 @@ jest.mock('../../app/data', () => ({
   useIsAssignmentsOnlyLearner: jest.fn(),
   useDefaultSearchFilters: jest.fn(),
   useEnterpriseCourseEnrollments: jest.fn(),
+  useAlgoliaSearch: jest.fn(),
 }));
 
 hooks.usePlotlySpiderChart.mockReturnValue({});
@@ -188,6 +190,14 @@ describe('<MyCareerTab />', () => {
           requested: [],
           assigned: [],
         },
+      },
+    });
+    useAlgoliaSearch.mockReturnValue({
+      searchClient: {
+        search: jest.fn(), appId: 'test-app-id',
+      },
+      searchIndex: {
+        indexName: 'mock-index-name',
       },
     });
   });

--- a/src/components/my-career/tests/SearchJobRole.test.jsx
+++ b/src/components/my-career/tests/SearchJobRole.test.jsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { mount } from 'enzyme';
 import ReactDOM from 'react-dom';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { SearchContext, deleteRefinementAction } from '@edx/frontend-enterprise-catalog-search';
+import { deleteRefinementAction, SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import FacetListRefinement from '@edx/frontend-enterprise-catalog-search/FacetListRefinement';
 import { StatefulButton } from '@openedx/paragon';
 
@@ -11,16 +11,16 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { fetchJobDetailsFromAlgolia, patchProfile } from '../data/service';
 import { renderWithRouter } from '../../../utils/tests';
 import SearchJobRole from '../SearchJobRole';
-import { useAlgoliaSearch } from '../../../utils/hooks';
+import { useAlgoliaSearch } from '../../app/data';
 
+jest.mock('../../app/data', () => ({
+  ...jest.requireActual('../../app/data'),
+  useAlgoliaSearch: jest.fn(),
+}));
 // mocks
 jest.mock('@edx/frontend-enterprise-catalog-search', () => ({
   ...jest.requireActual('@edx/frontend-enterprise-catalog-search'),
   deleteRefinementAction: jest.fn(),
-}));
-
-jest.mock('../../../utils/hooks', () => ({
-  useAlgoliaSearch: jest.fn(),
 }));
 
 jest.mock('../data/service', () => ({
@@ -61,7 +61,14 @@ describe('<SearchJobRole />', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    useAlgoliaSearch.mockReturnValue([jest.fn(), jest.fn()]);
+    useAlgoliaSearch.mockReturnValue({
+      searchClient: {
+        search: jest.fn(), appId: 'test-app-id',
+      },
+      searchIndex: {
+        indexName: 'mock-index-name',
+      },
+    });
   });
 
   it('renders the SearchJobRole component', () => {

--- a/src/components/my-career/tests/VisualizeCareer.test.jsx
+++ b/src/components/my-career/tests/VisualizeCareer.test.jsx
@@ -5,7 +5,7 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 
 import * as hooks from '../data/hooks';
-import { queryClient, renderWithRouter } from '../../../utils/tests';
+import { renderWithRouter } from '../../../utils/tests';
 import VisualizeCareer from '../VisualizeCareer';
 import {
   useAlgoliaSearch,
@@ -159,7 +159,7 @@ const defaultSearchContext = {
   refinements: { skill_names: ['test-skill-1', 'test-skill-2'] },
   dispatch: () => null,
 };
-queryClient();
+
 const VisualizeCareerWithContext = ({
   initialAppState = defaultAppState,
 }) => (

--- a/src/components/my-career/tests/VisualizeCareer.test.jsx
+++ b/src/components/my-career/tests/VisualizeCareer.test.jsx
@@ -5,12 +5,13 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 
 import * as hooks from '../data/hooks';
-import { renderWithRouter } from '../../../utils/tests';
+import { queryClient, renderWithRouter } from '../../../utils/tests';
 import VisualizeCareer from '../VisualizeCareer';
 import {
+  useAlgoliaSearch,
+  useDefaultSearchFilters,
   useEnterpriseCustomer,
   useIsAssignmentsOnlyLearner,
-  useDefaultSearchFilters,
   useLearnerSkillLevels,
 } from '../../app/data';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
@@ -33,6 +34,7 @@ jest.mock('../../app/data', () => ({
   useLearnerSkillLevels: jest.fn(),
   useIsAssignmentsOnlyLearner: jest.fn(),
   useDefaultSearchFilters: jest.fn(),
+  useAlgoliaSearch: jest.fn(),
 }));
 
 hooks.usePlotlySpiderChart.mockReturnValue({
@@ -157,7 +159,7 @@ const defaultSearchContext = {
   refinements: { skill_names: ['test-skill-1', 'test-skill-2'] },
   dispatch: () => null,
 };
-
+queryClient();
 const VisualizeCareerWithContext = ({
   initialAppState = defaultAppState,
 }) => (
@@ -179,6 +181,14 @@ describe('<VisualizeCareer />', () => {
     useLearnerSkillLevels.mockReturnValue({ data: mockLearnerSkillsData });
     useIsAssignmentsOnlyLearner.mockReturnValue(false);
     useDefaultSearchFilters.mockReturnValue({ filters: `enterprise_customer_uuids:${mockEnterpriseCustomer.uuid}` });
+    useAlgoliaSearch.mockReturnValue({
+      searchClient: {
+        search: jest.fn(), appId: 'test-app-id',
+      },
+      searchIndex: {
+        indexName: 'mock-index-name',
+      },
+    });
   });
 
   it('renders the VisualizeCareer component', () => {

--- a/src/components/search-unavailable-alert/SearchUnavailableAlert.tsx
+++ b/src/components/search-unavailable-alert/SearchUnavailableAlert.tsx
@@ -1,0 +1,65 @@
+import PropTypes from 'prop-types';
+import { Alert } from '@openedx/paragon';
+import { Error as ErrorIcon } from '@openedx/paragon/icons';
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+
+interface SearchUnavailableAlertProps {
+  className?: string;
+}
+
+export const messages = defineMessages({
+  alertHeading: {
+    id: 'enterprise.learner_portal.algolia_search_unavailable.alert.heading',
+    defaultMessage: 'Search Unavailable',
+    description: 'Heading for the alert that is displayed when the search service is unavailable.',
+  },
+  alertText: {
+    id: 'enterprise.learner_portal.algolia_search_unavailable.alert.text',
+    defaultMessage: 'We\'re unable to connect to our search service at the moment. This means search functionality is currently unavailable.',
+    description: 'Text for the alert that is displayed when the search service is unavailable.',
+  },
+  alertTextOptionsHeader: {
+    id: 'enterprise.learner_portal.algolia_search_unavailable.alert.text.options.header',
+    defaultMessage: 'What you can do:',
+    description: 'Header for the list of options for the alert that is displayed when the search service is unavailable.',
+  },
+  alertTextOptionRefresh: {
+    id: 'enterprise.learner_portal.algolia_search_unavailable.alert.text.option.refresh',
+    defaultMessage: 'Refresh the page to try again.',
+    description: 'Option for the alert that is displayed when the search service is unavailable.',
+  },
+  alertTextOptionNetwork: {
+    id: 'enterprise.learner_portal.algolia_search_unavailable.alert.text.option.network',
+    defaultMessage: 'Check your network connection.',
+    description: 'Option for the alert that is displayed when the search service is unavailable.',
+  },
+  alertTextOptionSupport: {
+    id: 'enterprise.learner_portal.algolia_search_unavailable.alert.text.option.support',
+    defaultMessage: 'If the issue persists, please contact your administrator or our support team.',
+    description: 'Option for the alert that is displayed when the search service is unavailable.',
+  },
+});
+
+const SearchUnavailableAlert: React.FC<SearchUnavailableAlertProps> = ({ className }) => {
+  const intl = useIntl();
+  return (
+    <Alert data-testid="search-error-alert" variant="danger" icon={ErrorIcon} className={className}>
+      <Alert.Heading>{intl.formatMessage(messages.alertHeading)}</Alert.Heading>
+      <p>
+        {intl.formatMessage(messages.alertText)}
+      </p>
+      <span className="font-weight-bold">{intl.formatMessage(messages.alertTextOptionsHeader)}</span>
+      <ul>
+        <li>{intl.formatMessage(messages.alertTextOptionRefresh)}</li>
+        <li>{intl.formatMessage(messages.alertTextOptionNetwork)}</li>
+        <li>{intl.formatMessage(messages.alertTextOptionSupport)}</li>
+      </ul>
+    </Alert>
+  );
+};
+
+SearchUnavailableAlert.propTypes = {
+  className: PropTypes.string,
+};
+
+export default SearchUnavailableAlert;

--- a/src/components/search-unavailable-alert/index.ts
+++ b/src/components/search-unavailable-alert/index.ts
@@ -1,0 +1,1 @@
+export { default as SearchUnavailableAlert } from './SearchUnavailableAlert';

--- a/src/components/search-unavailable-alert/tests/SearchUnavailableAlert.test.tsx
+++ b/src/components/search-unavailable-alert/tests/SearchUnavailableAlert.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { SearchUnavailableAlert } from '../index';
+import { messages } from '../SearchUnavailableAlert';
+
+describe('<SearchUnavailableAlert />', () => {
+  it('renders with expected content', () => {
+    render(
+      <IntlProvider locale="en">
+        <SearchUnavailableAlert />
+      </IntlProvider>,
+    );
+    Object.entries(messages).forEach(([, message]: [string, { defaultMessage: string }]) => {
+      expect(screen.getByText((message as { defaultMessage: string }).defaultMessage)).toBeInTheDocument();
+    });
+  });
+  it('renders with expected passed classname', () => {
+    render(
+      <IntlProvider locale="en">
+        <SearchUnavailableAlert className="pikachu" />
+      </IntlProvider>,
+    );
+    expect(screen.getByTestId('search-error-alert').className).toContain('pikachu');
+  });
+});

--- a/src/components/search-unavailable-alert/tests/SearchUnavailableAlert.test.tsx
+++ b/src/components/search-unavailable-alert/tests/SearchUnavailableAlert.test.tsx
@@ -11,9 +11,12 @@ describe('<SearchUnavailableAlert />', () => {
         <SearchUnavailableAlert />
       </IntlProvider>,
     );
-    Object.entries(messages).forEach(([, message]: [string, { defaultMessage: string }]) => {
-      expect(screen.getByText((message as { defaultMessage: string }).defaultMessage)).toBeInTheDocument();
-    });
+    expect(screen.getByText(messages.alertHeading.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.alertText.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.alertTextOptionsHeader.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.alertTextOptionRefresh.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.alertTextOptionNetwork.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.alertTextOptionSupport.defaultMessage)).toBeInTheDocument();
   });
   it('renders with expected passed classname', () => {
     render(

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -29,11 +29,11 @@ import {
   useHasValidLicenseOrSubscriptionRequestsEnabled,
   useIsAssignmentsOnlyLearner,
 } from '../app/data';
-import { useAlgoliaSearch } from '../../utils/hooks';
 import ContentTypeSearchResultsContainer from './ContentTypeSearchResultsContainer';
 import SearchVideo from './SearchVideo';
 import VideoBanner from '../microlearning/VideoBanner';
 import CustomSubscriptionExpirationModal from '../custom-expired-subscription-modal';
+import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 function useSearchPathwayModal() {
   const [isLearnerPathwayModalOpen, openLearnerPathwayModal, close] = useToggle(false);
@@ -61,8 +61,10 @@ const Search = () => {
 
   const { refinements } = useContext(SearchContext);
   const filters = useDefaultSearchFilters();
-  const [searchClient, searchIndex] = useAlgoliaSearch(config);
-
+  const {
+    searchIndex,
+    searchClient,
+  } = useAlgoliaSearchh();
   // Flag to toggle highlights visibility
   const { data: canOnlyViewHighlightSets } = useCanOnlyViewHighlights();
   const isAssignmentOnlyLearner = useIsAssignmentsOnlyLearner();

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -22,6 +22,7 @@ import PathwayModal from '../pathway/PathwayModal';
 import SearchAcademy from './SearchAcademy';
 import AssignmentsOnlyEmptyState from './AssignmentsOnlyEmptyState';
 import {
+  useAlgoliaSearch,
   useCanOnlyViewHighlights,
   useDefaultSearchFilters,
   useEnterpriseCustomer,
@@ -33,7 +34,6 @@ import ContentTypeSearchResultsContainer from './ContentTypeSearchResultsContain
 import SearchVideo from './SearchVideo';
 import VideoBanner from '../microlearning/VideoBanner';
 import CustomSubscriptionExpirationModal from '../custom-expired-subscription-modal';
-import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 function useSearchPathwayModal() {
   const [isLearnerPathwayModalOpen, openLearnerPathwayModal, close] = useToggle(false);
@@ -64,7 +64,7 @@ const Search = () => {
   const {
     searchIndex,
     searchClient,
-  } = useAlgoliaSearchh();
+  } = useAlgoliaSearch();
 
   // Flag to toggle highlights visibility
   const { data: canOnlyViewHighlightSets } = useCanOnlyViewHighlights();

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -6,7 +6,7 @@ import { Helmet } from 'react-helmet';
 import { Configure, InstantSearch } from 'react-instantsearch-dom';
 import { getConfig } from '@edx/frontend-platform/config';
 import { SearchContext, SearchHeader } from '@edx/frontend-enterprise-catalog-search';
-import { Stack, useToggle } from '@openedx/paragon';
+import { Container, Stack, useToggle } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { NUM_RESULTS_PER_PAGE } from './constants';
@@ -34,6 +34,7 @@ import ContentTypeSearchResultsContainer from './ContentTypeSearchResultsContain
 import SearchVideo from './SearchVideo';
 import VideoBanner from '../microlearning/VideoBanner';
 import CustomSubscriptionExpirationModal from '../custom-expired-subscription-modal';
+import { SearchUnavailableAlert } from '../search-unavailable-alert';
 
 function useSearchPathwayModal() {
   const [isLearnerPathwayModalOpen, openLearnerPathwayModal, close] = useToggle(false);
@@ -126,6 +127,27 @@ const Search = () => {
   const { content_type: contentType } = refinements;
   const hasRefinements = Object.keys(refinements).filter(refinement => refinement !== 'showAll').length > 0 && (contentType !== undefined ? contentType.length > 0 : true);
 
+  if (!searchClient) {
+    return (
+      <>
+        <CustomSubscriptionExpirationModal />
+        <Helmet title={PAGE_TITLE} />
+        <Stack className="my-5" gap={5}>
+          {canEnrollWithEnterpriseOffers && shouldDisplayBalanceAlert && (
+            <EnterpriseOffersBalanceAlert hasNoEnterpriseOffersBalance={hasNoEnterpriseOffersBalance} />
+          )}
+          {!hasRefinements && <ContentHighlights />}
+          {canOnlyViewHighlightSets === false
+            && (
+              <Container data-testid="search-unavailable-alert-container" size="lg">
+                <SearchUnavailableAlert />
+              </Container>
+            )}
+        </Stack>
+      </>
+    );
+  }
+
   return (
     <>
       <CustomSubscriptionExpirationModal />
@@ -175,11 +197,16 @@ const Search = () => {
             {features.ENABLE_PROGRAMS && (canOnlyViewHighlightSets === false) && <SearchProgram filter={filters} />}
             {canOnlyViewHighlightSets === false && <SearchCourse filter={filters} />}
             {enableVideos && (
-              <SearchVideo filter={filters} showVideosBanner={showVideosBanner} hideVideosBanner={hideVideosBanner} />
+              <SearchVideo
+                filter={filters}
+                showVideosBanner={showVideosBanner}
+                hideVideosBanner={hideVideosBanner}
+              />
             )}
           </Stack>
         )}
-        {/* render a single contentType if the refinement exist and is either a course, program or learnerpathway */}
+        {/* render a single contentType if the refinement
+            exist and is either a course, program or learnerpathway */}
         {contentType?.length > 0 && <ContentTypeSearchResultsContainer contentType={contentType[0]} />}
       </InstantSearch>
       <IntegrationWarningModal isEnabled={enterpriseCustomer.showIntegrationWarning} />

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -65,6 +65,7 @@ const Search = () => {
     searchIndex,
     searchClient,
   } = useAlgoliaSearchh();
+
   // Flag to toggle highlights visibility
   const { data: canOnlyViewHighlightSets } = useCanOnlyViewHighlights();
   const isAssignmentOnlyLearner = useIsAssignmentsOnlyLearner();

--- a/src/components/search/SearchError.jsx
+++ b/src/components/search/SearchError.jsx
@@ -3,8 +3,9 @@ import { Alert } from '@openedx/paragon';
 import { Warning } from '@openedx/paragon/icons';
 import { getSearchErrorMessage } from '../utils/search';
 
-const SearchError = ({ title = 'content' }) => {
+const SearchError = ({ title }) => {
   const searchErrorMessage = getSearchErrorMessage(title);
+
   return (
     <Alert
       variant="danger"
@@ -21,11 +22,7 @@ const SearchError = ({ title = 'content' }) => {
 };
 
 SearchError.propTypes = {
-  title: PropTypes.string,
-};
-
-SearchError.defaultProps = {
-  title: 'content',
+  title: PropTypes.string.isRequired,
 };
 
 export default SearchError;

--- a/src/components/search/SearchError.jsx
+++ b/src/components/search/SearchError.jsx
@@ -3,9 +3,8 @@ import { Alert } from '@openedx/paragon';
 import { Warning } from '@openedx/paragon/icons';
 import { getSearchErrorMessage } from '../utils/search';
 
-const SearchError = ({ title }) => {
+const SearchError = ({ title = 'content' }) => {
   const searchErrorMessage = getSearchErrorMessage(title);
-
   return (
     <Alert
       variant="danger"
@@ -22,7 +21,11 @@ const SearchError = ({ title }) => {
 };
 
 SearchError.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
+};
+
+SearchError.defaultProps = {
+  title: 'content',
 };
 
 export default SearchError;

--- a/src/components/search/SearchVideo.jsx
+++ b/src/components/search/SearchVideo.jsx
@@ -2,12 +2,14 @@ import PropTypes from 'prop-types';
 import { Configure, Index } from 'react-instantsearch-dom';
 import { getConfig } from '@edx/frontend-platform/config';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { VIDEO_TITLE, NUM_RESULTS_VIDEO, CONTENT_TYPE_VIDEO } from './constants';
+import { CONTENT_TYPE_VIDEO, NUM_RESULTS_VIDEO, VIDEO_TITLE } from './constants';
 import { SEARCH_INDEX_IDS } from '../../constants';
 import SearchResults from './SearchResults';
 import SearchVideoCard from './SearchVideoCard';
 
-const SearchVideo = ({ filter, showVideosBanner, hideVideosBanner }) => {
+const SearchVideo = ({
+  filter, showVideosBanner, hideVideosBanner,
+}) => {
   const defaultFilter = `content_type:${CONTENT_TYPE_VIDEO} AND ${filter}`;
   const config = getConfig();
   const intl = useIntl();

--- a/src/components/search/tests/Search.test.jsx
+++ b/src/components/search/tests/Search.test.jsx
@@ -4,17 +4,19 @@ import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { AppContext } from '@edx/frontend-platform/react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import * as MockReactInstantSearch from '../../skills-quiz/__mocks__/react-instantsearch-dom';
-import { queryClient, renderWithRouter } from '../../../utils/tests';
+import { generateTestPermutations, queryClient, renderWithRouter } from '../../../utils/tests';
 import '@testing-library/jest-dom';
 import Search from '../Search';
 import {
   useAlgoliaSearch,
+  useCanOnlyViewHighlights,
   useDefaultSearchFilters,
   useEnterpriseCustomer,
   useHasValidLicenseOrSubscriptionRequestsEnabled,
 } from '../../app/data';
 import { enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
 import { features } from '../../../config';
+import { messages } from '../../search-unavailable-alert/SearchUnavailableAlert';
 
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
@@ -89,7 +91,7 @@ describe('<Search />', () => {
     });
     MockReactInstantSearch.configure.nbHits = 2;
   });
-  test('renders the video beta banner component', () => {
+  it('renders the video beta banner component', () => {
     features.FEATURE_ENABLE_VIDEO_CATALOG = true;
     renderWithRouter(
       <SearchWrapper>
@@ -98,7 +100,7 @@ describe('<Search />', () => {
     );
     expect(screen.getByText('Videos Now Available with Your Subscription')).toBeInTheDocument();
   });
-  test('renders correctly when no search results are found', () => {
+  it('renders correctly when no search results are found', () => {
     MockReactInstantSearch.configure.nbHits = 0;
 
     renderWithRouter(
@@ -108,5 +110,50 @@ describe('<Search />', () => {
     );
 
     expect(screen.queryByText('Videos Now Available with Your Subscription')).toBeNull();
+  });
+  it.each(
+    generateTestPermutations({
+      canOnlyViewHighlights: [true, false],
+      useAlgoliaSearchReturnValue: [{
+        searchClient: null,
+        searchIndex: null,
+      }, {
+        searchClient: {
+          search: jest.fn(), appId: 'test-app-id',
+        },
+        searchIndex: {
+          indexName: 'mock-index-name',
+        },
+      }],
+    }),
+  )('renders the search client error page if no search client is found', ({
+    canOnlyViewHighlights,
+    useAlgoliaSearchReturnValue,
+  }) => {
+    useAlgoliaSearch.mockReturnValue(useAlgoliaSearchReturnValue);
+    useCanOnlyViewHighlights.mockReturnValue({ data: canOnlyViewHighlights });
+    renderWithRouter(
+      <SearchWrapper>
+        <Search />
+      </SearchWrapper>,
+    );
+
+    // Validate the SearchUnavailableAlert is being displayed when no search client is present and whether
+    // highlights are not the only visible content
+    if (!useAlgoliaSearchReturnValue.searchClient && !canOnlyViewHighlights) {
+      expect(screen.getByText(messages.alertHeading.defaultMessage)).toBeInTheDocument();
+      expect(screen.getByText(messages.alertText.defaultMessage)).toBeInTheDocument();
+      expect(screen.getByText(messages.alertTextOptionsHeader.defaultMessage)).toBeInTheDocument();
+      expect(screen.getByText(messages.alertTextOptionRefresh.defaultMessage)).toBeInTheDocument();
+      expect(screen.getByText(messages.alertTextOptionNetwork.defaultMessage)).toBeInTheDocument();
+      expect(screen.getByText(messages.alertTextOptionSupport.defaultMessage)).toBeInTheDocument();
+    } else if (useAlgoliaSearchReturnValue.searchClient || canOnlyViewHighlights) {
+      expect(screen.queryByText(messages.alertHeading.defaultMessage)).not.toBeInTheDocument();
+      expect(screen.queryByText(messages.alertText.defaultMessage)).not.toBeInTheDocument();
+      expect(screen.queryByText(messages.alertTextOptionsHeader.defaultMessage)).not.toBeInTheDocument();
+      expect(screen.queryByText(messages.alertTextOptionRefresh.defaultMessage)).not.toBeInTheDocument();
+      expect(screen.queryByText(messages.alertTextOptionNetwork.defaultMessage)).not.toBeInTheDocument();
+      expect(screen.queryByText(messages.alertTextOptionSupport.defaultMessage)).not.toBeInTheDocument();
+    }
   });
 });

--- a/src/components/search/tests/Search.test.jsx
+++ b/src/components/search/tests/Search.test.jsx
@@ -7,8 +7,12 @@ import * as MockReactInstantSearch from '../../skills-quiz/__mocks__/react-insta
 import { queryClient, renderWithRouter } from '../../../utils/tests';
 import '@testing-library/jest-dom';
 import Search from '../Search';
-import { useDefaultSearchFilters, useEnterpriseCustomer, useHasValidLicenseOrSubscriptionRequestsEnabled } from '../../app/data';
-import { useAlgoliaSearch } from '../../../utils/hooks';
+import {
+  useAlgoliaSearch,
+  useDefaultSearchFilters,
+  useEnterpriseCustomer,
+  useHasValidLicenseOrSubscriptionRequestsEnabled,
+} from '../../app/data';
 import { enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
 import { features } from '../../../config';
 
@@ -23,6 +27,7 @@ jest.mock('../../app/data', () => ({
       },
     },
   })),
+  useAlgoliaSearch: jest.fn(),
   useRedeemablePolicies: jest.fn(() => ({ data: { redeemablePolicies: [] } })),
   useCouponCodes: jest.fn(() => ({ data: { couponCodeAssignments: [] } })),
   useEnterpriseOffers: jest.fn(() => ({ data: { currentEnterpriseOffers: [] } })),
@@ -33,10 +38,7 @@ jest.mock('../../app/data', () => ({
   useDefaultSearchFilters: jest.fn(),
   useHasValidLicenseOrSubscriptionRequestsEnabled: jest.fn(),
 }));
-jest.mock('../../../utils/hooks', () => ({
-  ...jest.requireActual('../../../utils/hooks'),
-  useAlgoliaSearch: jest.fn(),
-}));
+
 jest.mock('../../../utils/optimizely', () => ({
   ...jest.requireActual('../../../utils/optimizely'),
   pushEvent: jest.fn(),
@@ -77,7 +79,14 @@ describe('<Search />', () => {
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     useDefaultSearchFilters.mockReturnValue(mockFilter);
     useHasValidLicenseOrSubscriptionRequestsEnabled.mockReturnValue(true);
-    useAlgoliaSearch.mockReturnValue([{ search: jest.fn(), appId: 'test-app-id' }, { indexName: 'mock-index-name' }]);
+    useAlgoliaSearch.mockReturnValue({
+      searchClient: {
+        search: jest.fn(), appId: 'test-app-id',
+      },
+      searchIndex: {
+        indexName: 'mock-index-name',
+      },
+    });
     MockReactInstantSearch.configure.nbHits = 2;
   });
   test('renders the video beta banner component', () => {

--- a/src/components/search/tests/SearchSections.test.jsx
+++ b/src/components/search/tests/SearchSections.test.jsx
@@ -2,18 +2,19 @@ import { screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { AppContext } from '@edx/frontend-platform/react';
-import { QueryClientProvider } from '@tanstack/react-query';
 import SearchCourse from '../SearchCourse';
 import '../../skills-quiz/__mocks__/react-instantsearch-dom';
-import { queryClient, renderWithRouter } from '../../../utils/tests';
+import { renderWithRouter } from '../../../utils/tests';
 import '@testing-library/jest-dom';
 import SearchProgram from '../SearchProgram';
 import SearchPathway from '../SearchPathway';
 import Search from '../Search';
 import {
-  useDefaultSearchFilters, useEnterpriseCustomer, useHasValidLicenseOrSubscriptionRequestsEnabled,
+  useAlgoliaSearch,
+  useDefaultSearchFilters,
+  useEnterpriseCustomer,
+  useHasValidLicenseOrSubscriptionRequestsEnabled,
 } from '../../app/data';
-import { useAlgoliaSearch } from '../../../utils/hooks';
 import { enterpriseCustomerFactory } from '../../app/data/services/data/__factories__';
 import SearchVideo from '../SearchVideo';
 
@@ -31,10 +32,6 @@ jest.mock('../../app/data', () => ({
   useEnterpriseFeatures: jest.fn().mockReturnValue({ data: undefined }),
   useDefaultSearchFilters: jest.fn(),
   useHasValidLicenseOrSubscriptionRequestsEnabled: jest.fn(),
-}));
-
-jest.mock('../../../utils/hooks', () => ({
-  ...jest.requireActual('../../../utils/hooks'),
   useAlgoliaSearch: jest.fn(),
 }));
 
@@ -69,27 +66,32 @@ const SearchWrapper = ({
   searchContext = searchContext1,
   children,
 }) => (
-  <QueryClientProvider client={queryClient()}>
-    <IntlProvider locale="en">
-      <AppContext.Provider value={appState}>
-        <SearchContext.Provider value={searchContext}>
-          {children}
-        </SearchContext.Provider>
-      </AppContext.Provider>
-    </IntlProvider>
-  </QueryClientProvider>
+  <IntlProvider locale="en">
+    <AppContext.Provider value={appState}>
+      <SearchContext.Provider value={searchContext}>
+        {children}
+      </SearchContext.Provider>
+    </AppContext.Provider>
+  </IntlProvider>
 );
 
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
 const mockFilter = `enterprise_customer_uuids: ${mockEnterpriseCustomer.uuid}`;
 
-describe('<Search />', () => {
+describe('SearchSections', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     useDefaultSearchFilters.mockReturnValue(mockFilter);
     useHasValidLicenseOrSubscriptionRequestsEnabled.mockReturnValue(true);
-    useAlgoliaSearch.mockReturnValue([{ search: jest.fn(), appId: 'test-app-id' }, { indexName: 'mock-index-name' }]);
+    useAlgoliaSearch.mockReturnValue({
+      searchClient: {
+        search: jest.fn(), appId: 'test-app-id',
+      },
+      searchIndex: {
+        indexName: 'mock-index-name',
+      },
+    });
   });
 
   test('renders the course section with the correct title', () => {

--- a/src/components/skills-quiz-v2/SkillsQuizForm.jsx
+++ b/src/components/skills-quiz-v2/SkillsQuizForm.jsx
@@ -4,7 +4,7 @@ import { getConfig } from '@edx/frontend-platform/config';
 import { InstantSearch } from 'react-instantsearch-dom';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import SearchJobDropdown from '../skills-quiz/SearchJobDropdown';
 import CurrentJobDropdown from '../skills-quiz/CurrentJobDropdown';
 import IndustryDropdown from '../skills-quiz/IndustryDropdown';
@@ -98,7 +98,6 @@ const SkillQuizForm = ({ isStyleAutoSuggest }) => {
         <SearchJobCard index={jobIndex} courseIndex={courseIndex} isSkillQuizV2 />
       </InstantSearch>
     </div>
-
   );
 };
 

--- a/src/components/skills-quiz-v2/SkillsQuizForm.jsx
+++ b/src/components/skills-quiz-v2/SkillsQuizForm.jsx
@@ -1,31 +1,32 @@
 import { Button } from '@openedx/paragon';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { getConfig } from '@edx/frontend-platform/config';
 import { InstantSearch } from 'react-instantsearch-dom';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import algoliasearch from 'algoliasearch';
 import SearchJobDropdown from '../skills-quiz/SearchJobDropdown';
 import CurrentJobDropdown from '../skills-quiz/CurrentJobDropdown';
 import IndustryDropdown from '../skills-quiz/IndustryDropdown';
 import GoalDropdown from '../skills-quiz/GoalDropdown';
 import SearchJobCard from '../skills-quiz/SearchJobCard';
-import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 const SkillQuizForm = ({ isStyleAutoSuggest }) => {
   const config = getConfig();
-  const searchIndices = {
-    courseIndex: config.ALGOLIA_INDEX_NAME,
-    jobIndex: config.ALGOLIA_INDEX_NAME_JOBS,
-  };
-
-  const {
-    searchClient,
-    searchIndex: courseIndex,
-  } = useAlgoliaSearchh({}, searchIndices.courseIndex);
-
-  const {
-    searchIndex: jobIndex,
-  } = useAlgoliaSearchh({}, searchIndices.jobIndex);
+  const [searchClient, courseIndex, jobIndex] = useMemo(() => {
+    const client = algoliasearch(
+      config.ALGOLIA_APP_ID,
+      config.ALGOLIA_SEARCH_API_KEY,
+    );
+    const cIndex = client.initIndex(config.ALGOLIA_INDEX_NAME);
+    const jIndex = client.initIndex(config.ALGOLIA_INDEX_NAME_JOBS);
+    return [client, cIndex, jIndex];
+  }, [
+    config.ALGOLIA_APP_ID,
+    config.ALGOLIA_INDEX_NAME,
+    config.ALGOLIA_INDEX_NAME_JOBS,
+    config.ALGOLIA_SEARCH_API_KEY,
+  ]);
 
   const [hide, setHide] = useState(true);
 
@@ -97,6 +98,7 @@ const SkillQuizForm = ({ isStyleAutoSuggest }) => {
         <SearchJobCard index={jobIndex} courseIndex={courseIndex} isSkillQuizV2 />
       </InstantSearch>
     </div>
+
   );
 };
 

--- a/src/components/skills-quiz-v2/SkillsQuizForm.jsx
+++ b/src/components/skills-quiz-v2/SkillsQuizForm.jsx
@@ -1,7 +1,6 @@
 import { Button } from '@openedx/paragon';
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { getConfig } from '@edx/frontend-platform/config';
-import algoliasearch from 'algoliasearch/lite';
 import { InstantSearch } from 'react-instantsearch-dom';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
@@ -10,24 +9,24 @@ import CurrentJobDropdown from '../skills-quiz/CurrentJobDropdown';
 import IndustryDropdown from '../skills-quiz/IndustryDropdown';
 import GoalDropdown from '../skills-quiz/GoalDropdown';
 import SearchJobCard from '../skills-quiz/SearchJobCard';
+import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 const SkillQuizForm = ({ isStyleAutoSuggest }) => {
   const config = getConfig();
+  const searchIndices = {
+    courseIndex: config.ALGOLIA_INDEX_NAME,
+    jobIndex: config.ALGOLIA_INDEX_NAME_JOBS,
+  };
 
-  const [searchClient, courseIndex, jobIndex] = useMemo(() => {
-    const client = algoliasearch(
-      config.ALGOLIA_APP_ID,
-      config.ALGOLIA_SEARCH_API_KEY,
-    );
-    const cIndex = client.initIndex(config.ALGOLIA_INDEX_NAME);
-    const jIndex = client.initIndex(config.ALGOLIA_INDEX_NAME_JOBS);
-    return [client, cIndex, jIndex];
-  }, [
-    config.ALGOLIA_APP_ID,
-    config.ALGOLIA_INDEX_NAME,
-    config.ALGOLIA_INDEX_NAME_JOBS,
-    config.ALGOLIA_SEARCH_API_KEY,
-  ]);
+  const {
+    searchClient,
+    searchIndex: courseIndex,
+  } = useAlgoliaSearchh({}, searchIndices.courseIndex);
+
+  const {
+    searchIndex: jobIndex,
+  } = useAlgoliaSearchh({}, searchIndices.jobIndex);
+
   const [hide, setHide] = useState(true);
 
   return (

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -1,17 +1,9 @@
-import {
-  useEffect, useState, useContext, useMemo,
-} from 'react';
+import { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import {
-  Button,
-  Stepper,
-  ModalDialog,
-  Container,
-  Form,
-  Stack,
+  Button, Container, Form, ModalDialog, Stack, Stepper,
 } from '@openedx/paragon';
-import algoliasearch from 'algoliasearch/lite';
 import { InstantSearch } from 'react-instantsearch-dom';
 import { getConfig } from '@edx/frontend-platform/config';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
@@ -34,11 +26,7 @@ import SelectJobCard from './SelectJobCard';
 import SkillsCourses from './SkillsCourses';
 
 import {
-  DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE,
-  STEP1,
-  STEP2,
-  STEP3,
-  GOAL_DROPDOWN_DEFAULT_OPTION,
+  DROPDOWN_OPTION_IMPROVE_CURRENT_ROLE, GOAL_DROPDOWN_DEFAULT_OPTION, STEP1, STEP2, STEP3,
 } from './constants';
 import { SkillsContext } from './SkillsContextProvider';
 import { SET_KEY_VALUE } from './data/constants';
@@ -50,23 +38,24 @@ import headerImage from './images/headerImage.png';
 import { saveSkillsGoalsAndJobsUserSelected } from './data/utils';
 import { fetchCourseEnrollments } from './data/service';
 import { useEnterpriseCustomer } from '../app/data';
+import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 const SkillsQuizStepper = ({ isStyleAutoSuggest }) => {
   const config = getConfig();
-  const [searchClient, courseIndex, jobIndex] = useMemo(() => {
-    const client = algoliasearch(
-      config.ALGOLIA_APP_ID,
-      config.ALGOLIA_SEARCH_API_KEY,
-    );
-    const cIndex = client.initIndex(config.ALGOLIA_INDEX_NAME);
-    const jIndex = client.initIndex(config.ALGOLIA_INDEX_NAME_JOBS);
-    return [client, cIndex, jIndex];
-  }, [
-    config.ALGOLIA_APP_ID,
-    config.ALGOLIA_INDEX_NAME,
-    config.ALGOLIA_INDEX_NAME_JOBS,
-    config.ALGOLIA_SEARCH_API_KEY,
-  ]);
+  const searchIndices = {
+    courseIndex: config.ALGOLIA_INDEX_NAME,
+    jobIndex: config.ALGOLIA_INDEX_NAME_JOBS,
+  };
+
+  const {
+    searchClient,
+    searchIndex: courseIndex,
+  } = useAlgoliaSearchh({}, searchIndices.courseIndex);
+
+  const {
+    searchIndex: jobIndex,
+  } = useAlgoliaSearchh({}, searchIndices.jobIndex);
+
   const [currentStep, setCurrentStep] = useState(STEP1);
   const [isStudentChecked, setIsStudentChecked] = useState(false);
   const handleIsStudentCheckedChange = (e) => setIsStudentChecked(e.target.checked);

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -15,7 +15,7 @@ import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { logError } from '@edx/frontend-platform/logging';
-import algoliasearch from 'algoliasearch';
+import algoliasearch from 'algoliasearch/lite';
 import GoalDropdown from './GoalDropdown';
 import SearchJobDropdown from './SearchJobDropdown';
 import CurrentJobDropdown from './CurrentJobDropdown';

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -1,4 +1,6 @@
-import { useContext, useEffect, useState } from 'react';
+import {
+  useContext, useEffect, useMemo, useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import {
@@ -13,6 +15,7 @@ import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { logError } from '@edx/frontend-platform/logging';
+import algoliasearch from 'algoliasearch';
 import GoalDropdown from './GoalDropdown';
 import SearchJobDropdown from './SearchJobDropdown';
 import CurrentJobDropdown from './CurrentJobDropdown';
@@ -38,23 +41,24 @@ import headerImage from './images/headerImage.png';
 import { saveSkillsGoalsAndJobsUserSelected } from './data/utils';
 import { fetchCourseEnrollments } from './data/service';
 import { useEnterpriseCustomer } from '../app/data';
-import useAlgoliaSearchh from '../app/data/hooks/useAlgoliaSearch';
 
 const SkillsQuizStepper = ({ isStyleAutoSuggest }) => {
   const config = getConfig();
-  const searchIndices = {
-    courseIndex: config.ALGOLIA_INDEX_NAME,
-    jobIndex: config.ALGOLIA_INDEX_NAME_JOBS,
-  };
 
-  const {
-    searchClient,
-    searchIndex: courseIndex,
-  } = useAlgoliaSearchh({}, searchIndices.courseIndex);
-
-  const {
-    searchIndex: jobIndex,
-  } = useAlgoliaSearchh({}, searchIndices.jobIndex);
+  const [searchClient, courseIndex, jobIndex] = useMemo(() => {
+    const client = algoliasearch(
+      config.ALGOLIA_APP_ID,
+      config.ALGOLIA_SEARCH_API_KEY,
+    );
+    const cIndex = client.initIndex(config.ALGOLIA_INDEX_NAME);
+    const jIndex = client.initIndex(config.ALGOLIA_INDEX_NAME_JOBS);
+    return [client, cIndex, jIndex];
+  }, [
+    config.ALGOLIA_APP_ID,
+    config.ALGOLIA_INDEX_NAME,
+    config.ALGOLIA_INDEX_NAME_JOBS,
+    config.ALGOLIA_SEARCH_API_KEY,
+  ]);
 
   const [currentStep, setCurrentStep] = useState(STEP1);
   const [isStudentChecked, setIsStudentChecked] = useState(false);

--- a/src/components/utils/search.js
+++ b/src/components/utils/search.js
@@ -93,9 +93,9 @@ export const getNoResultsMessage = (title) => {
 };
 
 export const getSearchErrorMessage = (title) => {
-  const messageTitle = `An error occurred while finding ${title.toLowerCase()} that match your search.`;
+  const lowerCaseTitle = title.toLowerCase();
   return {
-    messageTitle,
+    messageTitle: `An error occurred while finding ${lowerCaseTitle} that match your search.`,
     messageContent: 'Please try again later.',
   };
 };

--- a/src/components/utils/search.js
+++ b/src/components/utils/search.js
@@ -1,9 +1,14 @@
 import {
   ACADEMY_TITLE,
-  CONTENT_TYPE_COURSE, CONTENT_TYPE_PATHWAY,
+  CONTENT_TYPE_COURSE,
+  CONTENT_TYPE_PATHWAY,
   CONTENT_TYPE_PROGRAM,
   CONTENT_TYPE_VIDEO,
-  COURSE_TITLE, NUM_RESULTS_ACADEMY, NUM_RESULTS_COURSE, NUM_RESULTS_PATHWAY, NUM_RESULTS_PROGRAM,
+  COURSE_TITLE,
+  NUM_RESULTS_ACADEMY,
+  NUM_RESULTS_COURSE,
+  NUM_RESULTS_PATHWAY,
+  NUM_RESULTS_PROGRAM,
   NUM_RESULTS_VIDEO,
   PATHWAY_TITLE,
   PROGRAM_TITLE,
@@ -88,9 +93,9 @@ export const getNoResultsMessage = (title) => {
 };
 
 export const getSearchErrorMessage = (title) => {
-  const lowerCaseTitle = title.toLowerCase();
+  const messageTitle = `An error occurred while finding ${title.toLowerCase()} that match your search.`;
   return {
-    messageTitle: `An error occurred while finding ${lowerCaseTitle} that match your search.`,
+    messageTitle,
     messageContent: 'Please try again later.',
   };
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -68,6 +68,11 @@ declare global {
     shouldUpdateActiveEnterpriseCustomerUser: boolean;
   }
 
+  interface SecuredAlgoliaApiData {
+    securedAlgoliaApiKey: string | null;
+    catalogUuidsToCatalogQueryUuids: Record<string, string>;
+  }
+
   interface EnrollmentDueDate {
     name: string;
     date: string;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -50,6 +50,7 @@ declare global {
 
   interface EnterpriseFeatures {
     enterpriseLearnerBffEnabled?: boolean;
+    catalogQuerySearchFiltersEnabled?: boolean;
     [key: string]: boolean;
   }
 

--- a/src/utils/hooks.jsx
+++ b/src/utils/hooks.jsx
@@ -1,5 +1,4 @@
-import { useCallback, useMemo } from 'react';
-import algoliasearch from 'algoliasearch';
+import { useCallback } from 'react';
 
 export const useRenderContactHelpText = (enterpriseCustomer) => {
   const renderContactHelpText = useCallback(
@@ -19,19 +18,4 @@ export const useRenderContactHelpText = (enterpriseCustomer) => {
   );
 
   return renderContactHelpText;
-};
-
-export const useAlgoliaSearch = (config, indexName) => {
-  const [searchClient, searchIndex] = useMemo(
-    () => {
-      const client = algoliasearch(
-        config.ALGOLIA_APP_ID,
-        config.ALGOLIA_SEARCH_API_KEY,
-      );
-      const index = client.initIndex(indexName || config.ALGOLIA_INDEX_NAME);
-      return [client, index];
-    },
-    [config.ALGOLIA_APP_ID, config.ALGOLIA_INDEX_NAME, config.ALGOLIA_SEARCH_API_KEY, indexName],
-  );
-  return [searchClient, searchIndex];
 };

--- a/src/utils/tests.jsx
+++ b/src/utils/tests.jsx
@@ -123,8 +123,13 @@ export function queryClient(defaultOptions = {}) {
 /**
  * Generates all possible permutations of an object where each key has multiple possible values.
  *
- * @param {Object.<string, any[]>} options - An object where each key has an array of possible values.
- * @returns {Object[]} - An array of objects containing all possible combinations of the input values.
+ * This function returns the [cartesian product](https://en.wikipedia.org/wiki/Cartesian_product) of the input values:
+ * if there are `n` keys, and each key `k` has `v_k` possible values, then the total number of combinations is:
+ *
+ *    total = v₁ × v₂ × ... × vₙ
+ *
+ * @param {Object.<string, any[]>} options - An object where each key maps to an array of possible values.
+ * @returns {Object[]} - An array of objects, each representing a unique combination of the input values.
  *
  * @example
  * const input = {
@@ -132,6 +137,7 @@ export function queryClient(defaultOptions = {}) {
  *   isBFFData: [true, false],
  *   anotherFlag: ["A", "B"]
  * };
+ * // The total number of permutations is: 2 × 2 × 2 = 8
  *
  * const result = generatePermutations(input);
  * console.log(result);


### PR DESCRIPTION
Integrates metadata returned from the BFF related to the secured algolia api key into a reusable hook that is backward compatible with the existing implementation of instantiating an Algolia search client and initializing search indices. 

Creates a new `useAlgoliaSearch` hook that replaces the existing implementation to abstract data from the BFF to be consumed by algolia instant search components. One major difference between the implementation of the new `useAlgoliaSearch` client is the datastructure produced is now an object as opposed to an array. This allows us to predictably abstract necessary data without worrying about the order of a composed array.

We also create a fallback component alert to be displayed if the search client is not returned successfully. Below is an example using the Search page. The likelihood of falling into this error state is rare, but a fallback has been provided to guard defensively against it. 
![Screenshot 2025-04-03 at 8 38 28 AM](https://github.com/user-attachments/assets/18d072be-9ed5-410d-9ac2-537ec975a16b)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
