### PR TITLE
fix: hide program messaging in CourseHeader when programs are disabled for customer

### DIFF
--- a/src/components/course/course-header/CourseHeader.jsx
+++ b/src/components/course/course-header/CourseHeader.jsx
@@ -41,8 +41,11 @@ const CourseHeader = () => {
   const isCourseArchived = courseMetadata.courseRuns.every((courseRun) => isArchived(courseRun));
   const [partners] = useCoursePartners(courseMetadata);
   const defaultProgram = useMemo(
-    () => getDefaultProgram(courseMetadata.programs),
-    [courseMetadata],
+    () => getDefaultProgram({
+      programs: courseMetadata.programs,
+      isProgramsEnabled: enterpriseCustomer.enablePrograms,
+    }),
+    [courseMetadata, enterpriseCustomer.enablePrograms],
   );
   const routeLinks = [
     {

--- a/src/components/course/course-header/tests/CourseHeader.test.jsx
+++ b/src/components/course/course-header/tests/CourseHeader.test.jsx
@@ -427,5 +427,20 @@ describe('<CourseHeader />', () => {
       const messaging = `This course is part of a ${profCert}`;
       expect(screen.getByText(messaging, { exact: false })).toBeInTheDocument();
     });
+
+    test('does not render program messaging if the enterprise customer has programs disabled', () => {
+      const mockCustomerDisabledPrograms = { ...mockEnterpriseCustomer, enablePrograms: false };
+      useEnterpriseCustomer.mockReturnValue({ data: mockCustomerDisabledPrograms });
+      const profCert = 'Professional Certificate';
+      mockCourseMetadataWithProgramType(profCert);
+      renderWithRouterProvider({
+        path: '/:enterpriseSlug/course/:courseKey',
+        element: <CourseHeaderWrapper />,
+      }, {
+        initialEntries: [`/${mockEnterpriseCustomer.slug}/course/${mockCourseMetadata.key}`],
+      });
+      const messaging = `This course is part of a ${profCert}`;
+      expect(screen.queryByText(messaging, { exact: false })).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/course/data/utils.jsx
+++ b/src/components/course/data/utils.jsx
@@ -103,8 +103,14 @@ export const getNormalizedStartDate = ({
   return startDateIso;
 };
 
-export function getDefaultProgram(programs = []) {
-  if (programs.length === 0) {
+/**
+ * If programs are enabled, determine which program to use as the default program type to display
+ * in the course header.
+ *
+ * If programs are NOT enabled, no default program is returned.
+ */
+export function getDefaultProgram({ programs = [], isProgramsEnabled = true }) {
+  if (programs.length === 0 || !isProgramsEnabled) {
     return undefined;
   }
 


### PR DESCRIPTION
This PR makes the "This course is part of a Professional Certificate." messaging that appears beneath the course run cards on the Course page adhere to the same customer-specific flag (`enterpriseCustomer.enablePrograms`) as controlling the "Associated Programs" display.

This mitigates UX concerns that learners from customers with `enablePrograms: false` do not have any means to determine _which_ program (e.g., Professional Certificate) due to the "Associated Programs" not appearing in the sidebar. Given the goal is to avoid mention of programs with this flag, moving this messaging behind the flag makes sense.

![image](https://github.com/user-attachments/assets/02caf5bf-cfc7-470f-ae92-964248dddaeb)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
