### PR TITLE
chore: bumps version for paragon and catalog search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@1.2.3",
         "@edx/frontend-component-footer": "^14.6.0",
-        "@edx/frontend-enterprise-catalog-search": "10.8.0",
+        "@edx/frontend-enterprise-catalog-search": "11.0.2",
         "@edx/frontend-enterprise-hotjar": "7.1.0",
         "@edx/frontend-enterprise-logistration": "9.1.0",
         "@edx/frontend-enterprise-utils": "9.1.0",
@@ -20,7 +20,7 @@
         "@edx/reactifex": "2.2.0",
         "@loadable/component": "5.16.4",
         "@lukemorales/query-key-factory": "1.3.4",
-        "@openedx/paragon": "21.13.1",
+        "@openedx/paragon": "22.17.0",
         "@tanstack/react-query": "4.36.1",
         "@tanstack/react-query-devtools": "4.36.1",
         "accessible-nprogress": "2.1.2",
@@ -2411,38 +2411,37 @@
       }
     },
     "node_modules/@edx/frontend-enterprise-catalog-search": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-10.8.0.tgz",
-      "integrity": "sha512-iMfH7MhuuBBhmlyQdpkVRICk8J1b3fy9rs0jqZDlrYiGl4SMggo5t+dP6DCseX2QqqmvDXWb/ds5wCH5mMz/+w==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-11.0.2.tgz",
+      "integrity": "sha512-qSnjkaKilPGJFxmar0TPaT5pjCxxr8OYA5R3UAATpqUqRtdnI98KVPxluy6TnnKZaHeHwpFB3LN9zCcKe/wq4g==",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^9.1.0",
-        "classnames": "2.2.5",
-        "lodash.debounce": "4.0.8",
-        "prop-types": "15.7.2"
+        "@edx/frontend-enterprise-utils": "^10.0.0",
+        "classnames": "^2.5.1",
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.8.1"
       },
       "peerDependencies": {
         "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
-        "@openedx/paragon": "^21.0.0",
-        "react": "^16.12.0 || ^17.0.0",
-        "react-dom": "^16.12.0 || ^17.0.0",
+        "@openedx/paragon": "^22.0.0",
+        "react": "^16.12.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.12.0 || ^17.0.0 || ^18.0.0",
         "react-instantsearch-dom": "^6.8.3",
         "react-router-dom": "^6.0.0"
       }
     },
-    "node_modules/@edx/frontend-enterprise-catalog-search/node_modules/classnames": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-      "integrity": "sha512-DTt3GhOUDKhh4ONwIJW4lmhyotQmV2LjNlGK/J2hkwUcqcbKkCLAdJPtxQnxnlc7SR3f1CEXCyMmc7WLUsWbNA=="
-    },
-    "node_modules/@edx/frontend-enterprise-catalog-search/node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "license": "MIT",
+    "node_modules/@edx/frontend-enterprise-catalog-search/node_modules/@edx/frontend-enterprise-utils": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-utils/-/frontend-enterprise-utils-10.0.0.tgz",
+      "integrity": "sha512-MmvX8VvSQHYApjtsTpJlefv2uAqF1SCqR95hZVSqGMwccfKyWN8/GwftjTTXdUTTzsjp1nSh5P3ZX0jYJIm9XQ==",
       "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
+        "history": "^4.10.1"
+      },
+      "peerDependencies": {
+        "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
+        "@testing-library/react": ">11.0.0 <17.0.0",
+        "react": "^16.12.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.12.0 || ^17.0.0 || ^18.0.0",
+        "react-router-dom": "^6.0.0"
       }
     },
     "node_modules/@edx/frontend-enterprise-hotjar": {
@@ -3973,9 +3972,16 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "21.13.1",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-21.13.1.tgz",
-      "integrity": "sha512-sLL+Z3ZWIRM6x+OrKZV0S7/SQpEcSeRcDm7E3FzhsnAWudsJCTELvSW+84uy/8dwV7mJhttsBPqQEtNafbCyYA==",
+      "version": "22.17.0",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.17.0.tgz",
+      "integrity": "sha512-MzOLQ0myaOErwumPJwxVZXTw7zJKrARtu4YMSaISF5Sz6pE1/dYz9qfRcqaraYRcJGNdbPRzOG0v3iqbZo1uHQ==",
+      "workspaces": [
+        "example",
+        "component-generator",
+        "www",
+        "icons",
+        "dependent-usage-analyzer"
+      ],
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -4011,8 +4017,8 @@
         "paragon": "bin/paragon-scripts.js"
       },
       "peerDependencies": {
-        "react": "^16.8.6 || ^17.0.0",
-        "react-dom": "^16.8.6 || ^17.0.0",
+        "react": "^16.8.6 || ^17 || ^18",
+        "react-dom": "^16.8.6 || ^17 || ^18",
         "react-intl": "^5.25.1 || ^6.4.0"
       }
     },
@@ -4628,7 +4634,6 @@
       "version": "12.1.5",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
       "integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0",
@@ -4660,7 +4665,6 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
       "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@1.2.3",
     "@edx/frontend-component-footer": "^14.6.0",
-    "@edx/frontend-enterprise-catalog-search": "10.8.0",
+    "@edx/frontend-enterprise-catalog-search": "11.0.2",
     "@edx/frontend-enterprise-hotjar": "7.1.0",
     "@edx/frontend-enterprise-logistration": "9.1.0",
     "@edx/frontend-enterprise-utils": "9.1.0",
@@ -18,7 +18,7 @@
     "@edx/reactifex": "2.2.0",
     "@loadable/component": "5.16.4",
     "@lukemorales/query-key-factory": "1.3.4",
-    "@openedx/paragon": "21.13.1",
+    "@openedx/paragon": "22.17.0",
     "@tanstack/react-query": "4.36.1",
     "@tanstack/react-query-devtools": "4.36.1",
     "accessible-nprogress": "2.1.2",

--- a/src/components/Toasts/Toasts.test.jsx
+++ b/src/components/Toasts/Toasts.test.jsx
@@ -53,13 +53,11 @@ describe('ToastsProvider', () => {
     expect(toastsContext.toasts[0].message).toBe('Hello World');
     expect(screen.getByText('Hello World')).toBeTruthy();
     const closeButton = screen.getByLabelText('Close');
-    const toastContainerClassesBefore = screen.getAllByRole('alert')[1].className;
+    const toastContainer = screen.getByRole('alert');
 
-    expect(toastContainerClassesBefore.match(/show/)).toBeTruthy();
+    expect(toastContainer.className).toMatch(/show/);
 
     userEvent.click(closeButton);
-    const toastContainerClassesAfter = screen.getAllByRole('alert')[0].className;
-
-    expect(toastContainerClassesAfter.match(/show/)).toBeFalsy();
+    expect(screen.queryByText('Hello World')).toBeFalsy();
   });
 });

--- a/src/components/app/routes/LicenseActivationRoute.test.jsx
+++ b/src/components/app/routes/LicenseActivationRoute.test.jsx
@@ -2,6 +2,7 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { mergeConfig } from '@edx/frontend-platform';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import { authenticatedUserFactory } from '../data/services/data/__factories__';
 import LicenseActivationRoute from './LicenseActivationRoute';
@@ -9,9 +10,11 @@ import LicenseActivationRoute from './LicenseActivationRoute';
 const mockAuthenticatedUser = authenticatedUserFactory();
 
 const LicenseActivationRouteWrapper = () => (
-  <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
-    <LicenseActivationRoute />
-  </AppContext.Provider>
+  <IntlProvider locale="en">
+    <AppContext.Provider value={{ authenticatedUser: mockAuthenticatedUser }}>
+      <LicenseActivationRoute />
+    </AppContext.Provider>
+  </IntlProvider>
 );
 
 describe('LicenseActivationRoute', () => {

--- a/src/components/app/routes/RouteErrorBoundary.jsx
+++ b/src/components/app/routes/RouteErrorBoundary.jsx
@@ -116,6 +116,7 @@ const RouteErrorBoundary = ({
         variant="danger"
         isOpen={isAppUpdateAvailable}
         onClose={() => {}}
+        isOverflowVisible={false}
         footerNode={(
           <ActionRow>
             <Button

--- a/src/components/budget-expiry-notification/index.jsx
+++ b/src/components/budget-expiry-notification/index.jsx
@@ -89,6 +89,7 @@ const BudgetExpiryNotification = () => {
           size="md"
           isOpen={modalIsOpen}
           onClose={dismissModal}
+          isOverflowVisible={false}
           footerNode={(
             <ActionRow>
               <Button variant="primary" onClick={dismissModal}>OK</Button>

--- a/src/components/course/EnrollModal.jsx
+++ b/src/components/course/EnrollModal.jsx
@@ -285,6 +285,7 @@ const EnrollModal = ({
       isOpen={isModalOpen}
       closeLabel={intl.formatMessage(messages.modalCancelCta)}
       title={titleText}
+      isOverflowVisible={false}
       footerNode={(
         <ActionRow>
           <Button

--- a/src/components/course/data/tests/utils.test.jsx
+++ b/src/components/course/data/tests/utils.test.jsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import { render, screen } from '@testing-library/react';
 import MockDate from 'mockdate';
 import '@testing-library/jest-dom/extend-expect';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import { getConfig } from '@edx/frontend-platform';
 import { DISABLED_ENROLL_REASON_TYPES } from '../constants';
@@ -344,6 +345,12 @@ describe('getCourseStartDate tests', () => {
 });
 
 describe('getMissingSubsidyReasonActions', () => {
+  const renderWithIntl = (component) => render(
+    <IntlProvider locale="en">
+      {component}
+    </IntlProvider>,
+  );
+
   it.each([
     DISABLED_ENROLL_REASON_TYPES.LEARNER_MAX_SPEND_REACHED,
     DISABLED_ENROLL_REASON_TYPES.LEARNER_MAX_ENROLLMENTS_REACHED,
@@ -353,7 +360,7 @@ describe('getMissingSubsidyReasonActions', () => {
       enterpriseAdminUsers: [],
       contactEmail: 'randomEmail@edx.org',
     });
-    render(ActionsComponent);
+    renderWithIntl(ActionsComponent);
     const ctaBtn = screen.getByText('Learn about limits');
     expect(ctaBtn).toBeInTheDocument();
     expect(ctaBtn.getAttribute('href')).toEqual('https://limits.url');
@@ -365,7 +372,7 @@ describe('getMissingSubsidyReasonActions', () => {
       enterpriseAdminUsers: [],
       contactEmail: 'randomEmail@edx.org',
     });
-    render(ActionsComponent);
+    renderWithIntl(ActionsComponent);
     const ctaBtn = screen.getByText('Learn about deactivation');
     expect(ctaBtn).toBeInTheDocument();
     expect(ctaBtn.getAttribute('href')).toEqual('https://deactivation.url');
@@ -386,7 +393,7 @@ describe('getMissingSubsidyReasonActions', () => {
       enterpriseAdminUsers: [{ email: 'admin@example.com' }],
       contactEmail: undefined,
     });
-    render(ActionsComponent);
+    renderWithIntl(ActionsComponent);
     const ctaBtn = screen.getByText('Contact administrator');
     expect(ctaBtn).toBeInTheDocument();
     expect(ctaBtn.getAttribute('href')).toEqual('mailto:admin@example.com');
@@ -407,7 +414,7 @@ describe('getMissingSubsidyReasonActions', () => {
       enterpriseAdminUsers: [{ email: 'admin@example.com' }],
       contactEmail: 'testEmail@edx.org',
     });
-    render(ActionsComponent);
+    renderWithIntl(ActionsComponent);
     const ctaBtn = screen.getByText('Contact administrator');
     expect(ctaBtn).toBeInTheDocument();
     expect(ctaBtn.getAttribute('href')).toEqual('mailto:testEmail@edx.org');
@@ -428,7 +435,7 @@ describe('getMissingSubsidyReasonActions', () => {
       enterpriseAdminUsers: [],
       contactEmail: 'randomEmail@edx.org',
     });
-    const { container } = render(ActionsComponent);
+    const { container } = renderWithIntl(ActionsComponent);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -438,7 +445,7 @@ describe('getMissingSubsidyReasonActions', () => {
       enterpriseAdminUsers: [],
       contactEmail: 'randomEmail@edx.org',
     });
-    const { container } = render(ActionsComponent);
+    const { container } = renderWithIntl(ActionsComponent);
     expect(container).toBeEmptyDOMElement();
   });
 });

--- a/src/components/course/tests/__snapshots__/CourseMainContent.test.jsx.snap
+++ b/src/components/course/tests/__snapshots__/CourseMainContent.test.jsx.snap
@@ -51,7 +51,6 @@ exports[`CourseMainContent renders and matches snapshot 1`] = `
         <a
           className="pgn__hyperlink default-link standalone-link"
           href="https://test-marketing-site-base-url/https://test.org"
-          onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/src/components/custom-expired-subscription-modal/index.jsx
+++ b/src/components/custom-expired-subscription-modal/index.jsx
@@ -41,6 +41,7 @@ const CustomSubscriptionExpirationModal = () => {
       title={<h3 className="mb-2">{customerAgreement.modalHeaderTextV2}</h3>}
       isOpen={isOpen}
       isBlocking
+      isOverflowVisible={false}
       footerNode={(
         <ActionRow>
           <StatefulButton

--- a/src/components/dashboard/SubscriptionExpirationModal.jsx
+++ b/src/components/dashboard/SubscriptionExpirationModal.jsx
@@ -102,6 +102,7 @@ const SubscriptionExpirationModal = () => {
         className={`${MODAL_DIALOG_CLASS_NAME} expired`}
         isOpen={isOpen}
         data-testid="expired-modal"
+        isOverflowVisible={false}
         footerNode={(
           <ActionRow>
             <Button variant="primary" onClick={handleSubscriptionExpiredModalDismissal} data-testid="subscription-expiration-button">OK</Button>
@@ -164,6 +165,7 @@ const SubscriptionExpirationModal = () => {
       // Mark that the user has seen this range's expiration modal when they close it
       isOpen={isOpen}
       data-testid="expiration-modal"
+      isOverflowVisible={false}
       footerNode={(
         <ActionRow>
           <Button variant="primary" onClick={handleSubscriptionExpiringModalDismissal} data-testid="subscription-expiration-button">OK</Button>

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/email-settings/EmailSettingsModal.jsx
@@ -117,6 +117,7 @@ class EmailSettingsModal extends Component {
         onClose={this.handleOnClose}
         hasCloseButton
         isFullscreenOnMobile
+        isOverflowVisible={false}
         footerNode={(
           <ActionRow>
             <Button variant="tertiary" onClick={this.handleOnClose} data-testid="email-setting-modal-close-btn">Close</Button>

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx
@@ -81,6 +81,7 @@ const MarkCompleteModal = ({
         onClose={handleModalOnClose}
         hasCloseButton
         isFullscreenOnMobile
+        isOverflowVisible={false}
         footerNode={(
           <ActionRow>
             <Button variant="tertiary" onClick={handleModalOnClose} data-testid="mark-complete-modal-cancel-btn">Cancel</Button>

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/MoveToInProgressModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/move-to-in-progress-modal/MoveToInProgressModal.jsx
@@ -75,6 +75,7 @@ const MoveToInProgressModal = ({
         onClose={handleModalOnClose}
         hasCloseButton
         isFullscreenOnMobile
+        isOverflowVisible={false}
         footerNode={(
           <ActionRow>
             <Button variant="tertiary" onClick={onClose}>Cancel</Button>

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/unenroll/UnenrollModal.jsx
@@ -96,6 +96,7 @@ const UnenrollModal = ({
       title="Unenroll from course?"
       isOpen={isOpen}
       onClose={handleClose}
+      isOverflowVisible={false}
       footerNode={(
         <ActionRow>
           <Button

--- a/src/components/integration-warning-modal/IntegrationWarningModal.jsx
+++ b/src/components/integration-warning-modal/IntegrationWarningModal.jsx
@@ -31,6 +31,7 @@ const IntegrationWarningModal = ({
       title={MODAL_TITLE}
       isOpen={dismissed}
       onClose={handleModalOnClose}
+      isOverflowVisible={false}
       footerNode={(
         <Button
           variant="primary"

--- a/src/components/pathway/PathwayModal.jsx
+++ b/src/components/pathway/PathwayModal.jsx
@@ -107,6 +107,7 @@ const PathwayModal = ({ learnerPathwayUuid, isOpen, onClose }) => {
       isOpen={isOpen}
       onClose={onClose}
       size="xl"
+      isOverflowVisible={false}
       heroNode={isLoading ? <Skeleton height={120} data-testid="pathway-banner-loading" /> : (
         <ModalDialog.Hero>
           <ModalDialog.Hero.Background

--- a/src/components/program-progress/CouponCodesWarningModal.jsx
+++ b/src/components/program-progress/CouponCodesWarningModal.jsx
@@ -24,6 +24,7 @@ const CouponCodesWarningModal = ({ isCouponCodeWarningModalOpen, onCouponCodeWar
       isOpen={isCouponCodeWarningModalOpen}
       onClose={onCouponCodeWarningModalClose}
       hasCloseButton={false}
+      isOverflowVisible={false}
       footerNode={(
         <ActionRow>
           <Button onClick={onCouponCodeWarningModalClose}>OK</Button>

--- a/src/components/program-progress/SubscriptionExpiringWarningModal.jsx
+++ b/src/components/program-progress/SubscriptionExpiringWarningModal.jsx
@@ -51,6 +51,7 @@ const SubscriptionExpirationWarningModal = ({
       isOpen={isSubscriptionExpiringWarningModalOpen}
       onClose={onSubscriptionExpiringWarningModalClose}
       hasCloseButton={false}
+      isOverflowVisible={false}
       footerNode={(
         <ActionRow>
           <Button onClick={onSubscriptionExpiringWarningModalClose}>OK</Button>

--- a/src/components/program/tests/ProgramInstructors.test.jsx
+++ b/src/components/program/tests/ProgramInstructors.test.jsx
@@ -1,5 +1,6 @@
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import ProgramInstructors from '../ProgramInstructors';
 import { useEnterpriseCustomer, useProgramDetails } from '../../app/data';
@@ -45,6 +46,12 @@ const initialState = {
 
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
 
+const renderWithIntl = (component) => render(
+  <IntlProvider locale="en">
+    {component}
+  </IntlProvider>,
+);
+
 describe('<ProgramInstructors />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -53,7 +60,7 @@ describe('<ProgramInstructors />', () => {
   });
 
   test('renders program authoring organizations', () => {
-    render(<ProgramInstructors />);
+    renderWithIntl(<ProgramInstructors />);
     initialState.authoringOrganizations.forEach((org) => {
       expect(screen.getByAltText(`${org.name} logo`)).toHaveAttribute('src', org.logoImageUrl);
       expect(screen.getByText(org.name)).toHaveAttribute('href', org.marketingUrl);
@@ -61,7 +68,7 @@ describe('<ProgramInstructors />', () => {
   });
 
   test('renders program instructors', () => {
-    render(<ProgramInstructors />);
+    renderWithIntl(<ProgramInstructors />);
     initialState.staff.forEach((staff) => {
       const fullName = `${staff.givenName} ${staff.familyName}`;
       expect(screen.queryByText(fullName)).toBeInTheDocument();

--- a/src/components/skills-quiz-v2/SkillsQuiz.jsx
+++ b/src/components/skills-quiz-v2/SkillsQuiz.jsx
@@ -53,6 +53,7 @@ const SkillsQuizV2 = ({ isStyleAutoSuggest }) => {
         onClose={close}
         size="sm"
         hasCloseButton={false}
+        isOverflowVisible={false}
       >
         <ModalDialog.Header>
           <ModalDialog.Title>
@@ -96,6 +97,7 @@ const SkillsQuizV2 = ({ isStyleAutoSuggest }) => {
         className="bg-light-200 skills-quiz-modal skills-quiz-v2"
         isOpen
         onClose={open}
+        isOverflowVisible={false}
       >
         <ModalDialog.Hero className="md-img">
           <ModalDialog.Hero.Background backgroundSrc={headerImage} />

--- a/src/components/skills-quiz/SkillsQuizStepper.jsx
+++ b/src/components/skills-quiz/SkillsQuizStepper.jsx
@@ -186,6 +186,7 @@ const SkillsQuizStepper = ({ isStyleAutoSuggest }) => {
         size="fullscreen"
         className="bg-light-200 skills-quiz-modal"
         isOpen
+        isOverflowVisible={false}
         onClose={closeSkillsQuiz}
       >
         <ModalDialog.Hero className="bg-img">


### PR DESCRIPTION
# For all changes

Bumping version for `@edx/frontend-enterprise-catalog-search` and `@openedx/paragon` to bring in the latest change from https://github.com/openedx/frontend-enterprise/pull/462

Applied changes to the modals per breaking changes from this paragon upgrade https://github.com/openedx/paragon/releases/tag/v22.0.0 and https://github.com/openedx/paragon/releases/tag/v22.17.0

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
