### PR TITLE
fix: Add logic check on learner credit subsidy

### DIFF
--- a/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.js
+++ b/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.js
@@ -17,22 +17,23 @@ export default function useCanUpgradeWithLearnerCredit(courseRunKey, queryOption
     select: (data) => {
       // Base transformed data
       const transformedData = {
-        applicableSubsidyAccessPolicy: null,
+        applicableSubsidyAccessPolicy: {
+          isPolicyRedemptionEnabled: false,
+          redeemableSubsidyAccessPolicy: null,
+        },
         listPrice: null,
       };
-
       // Determine whether the course run key is redeemable. If so, update the transformed data with the
       // applicable subsidy access policy and list price.
-      const redeemableCourseRun = data.filter((canRedeemData) => (
+      const redeemableCourseRun = data.find((canRedeemData) => (
         canRedeemData.canRedeem && canRedeemData.redeemableSubsidyAccessPolicy
-      ))[0];
+      ));
 
-      // TODO: Consolidate redemption and upgrade data-structure into one.
-      // See usage in components/dashboard/main-content/course-enrollments/data/hooks.js -> useCourseUpgradeData()
       if (redeemableCourseRun) {
-        const applicableSubsidyAccessPolicy = redeemableCourseRun.redeemableSubsidyAccessPolicy;
-        applicableSubsidyAccessPolicy.isPolicyRedemptionEnabled = true;
-        transformedData.applicableSubsidyAccessPolicy = applicableSubsidyAccessPolicy;
+        transformedData.applicableSubsidyAccessPolicy = {
+          isPolicyRedemptionEnabled: true,
+          redeemableSubsidyAccessPolicy: redeemableCourseRun.redeemableSubsidyAccessPolicy,
+        };
         transformedData.listPrice = redeemableCourseRun.listPrice.usd;
       }
 

--- a/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.js
+++ b/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.js
@@ -26,6 +26,9 @@ export default function useCanUpgradeWithLearnerCredit(courseRunKey, queryOption
       const redeemableCourseRun = data.filter((canRedeemData) => (
         canRedeemData.canRedeem && canRedeemData.redeemableSubsidyAccessPolicy
       ))[0];
+
+      // TODO: Consolidate redemption and upgrade data-structure into one.
+      // See usage in components/dashboard/main-content/course-enrollments/data/hooks.js -> useCourseUpgradeData()
       if (redeemableCourseRun) {
         const applicableSubsidyAccessPolicy = redeemableCourseRun.redeemableSubsidyAccessPolicy;
         applicableSubsidyAccessPolicy.isPolicyRedemptionEnabled = true;

--- a/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.test.jsx
+++ b/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.test.jsx
@@ -77,7 +77,7 @@ describe('useCanUpgradeWithLearnerCredit', () => {
     await waitForNextUpdate();
     const expectedTransformedResult = {
       applicableSubsidyAccessPolicy: {
-        ...mockCanRedeemData[0].redeemableSubsidyAccessPolicy,
+        redeemableSubsidyAccessPolicy: mockCanRedeemData[0].redeemableSubsidyAccessPolicy,
         isPolicyRedemptionEnabled: true,
       },
       listPrice: mockCanRedeemData[0].listPrice.usd,

--- a/src/components/app/data/hooks/useCourseRedemptionEligibility.js
+++ b/src/components/app/data/hooks/useCourseRedemptionEligibility.js
@@ -66,7 +66,6 @@ export function transformCourseRedemptionEligibility({
   const hasSuccessfulRedemption = courseRunKey
     ? !!canRedeemDataForAvailableRuns.find(r => r.contentKey === courseRunKey)?.hasSuccessfulRedemption
     : canRedeemDataForAvailableRuns.some(r => r.hasSuccessfulRedemption);
-
   // If there is a redeemable subsidy access policy for the active course run, use that. Otherwise, use any other
   // redeemable subsidy access policy for any of the content keys.
   const redeemableSubsidyAccessPolicy = preferredSubsidyAccessPolicy || anyRedeemableSubsidyAccessPolicy;

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -769,8 +769,8 @@ export const getSubsidyToApplyForCourse = ({
     };
   }
 
-  if (applicableSubsidyAccessPolicy?.isPolicyRedemptionEnabled
-    && applicableSubsidyAccessPolicy?.redeemableSubsidyAccessPolicy) {
+  if (applicableSubsidyAccessPolicy.isPolicyRedemptionEnabled
+    && applicableSubsidyAccessPolicy.redeemableSubsidyAccessPolicy) {
     const { redeemableSubsidyAccessPolicy, availableCourseRuns } = applicableSubsidyAccessPolicy;
     return {
       discountType: 'percentage',

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -769,7 +769,8 @@ export const getSubsidyToApplyForCourse = ({
     };
   }
 
-  if (applicableSubsidyAccessPolicy?.isPolicyRedemptionEnabled) {
+  if (applicableSubsidyAccessPolicy?.isPolicyRedemptionEnabled
+    && applicableSubsidyAccessPolicy?.redeemableSubsidyAccessPolicy) {
     const { redeemableSubsidyAccessPolicy, availableCourseRuns } = applicableSubsidyAccessPolicy;
     return {
       discountType: 'percentage',

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -151,13 +151,7 @@ export const useCourseUpgradeData = ({
     const applicableSubsidy = getSubsidyToApplyForCourse({
       applicableSubscriptionLicense: subscriptionLicense,
       applicableCouponCode,
-      applicableSubsidyAccessPolicy: {
-        ...learnerCreditMetadata?.applicableSubsidyAccessPolicy,
-        // The original field, 'redeemableSubsidyAccessPolicy', was spread into applicableSubsidyAccessPolicy.
-        // 'redeemableSubsidyAccessPolicy' is intentionally duplicated from 'applicableSubsidyAccessPolicy'
-        // to match the expected data structure required by downstream consumers of this object.
-        redeemableSubsidyAccessPolicy: learnerCreditMetadata.applicableSubsidyAccessPolicy,
-      },
+      applicableSubsidyAccessPolicy: learnerCreditMetadata?.applicableSubsidyAccessPolicy,
     });
 
     // No applicable subsidy found, return early.
@@ -213,7 +207,8 @@ export const useCourseUpgradeData = ({
 
     // Construct and return learner credit based upgrade url
     if (applicableSubsidy.subsidyType === LEARNER_CREDIT_SUBSIDY_TYPE) {
-      applicableSubsidy.redemptionUrl = learnerCreditMetadata.applicableSubsidyAccessPolicy.policyRedemptionUrl;
+      applicableSubsidy.redemptionUrl = learnerCreditMetadata
+        .applicableSubsidyAccessPolicy.redeemableSubsidyAccessPolicy.policyRedemptionUrl;
       return {
         ...defaultReturn,
         subsidyForCourse: applicableSubsidy,

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -153,8 +153,9 @@ export const useCourseUpgradeData = ({
       applicableCouponCode,
       applicableSubsidyAccessPolicy: {
         ...learnerCreditMetadata?.applicableSubsidyAccessPolicy,
-        // The original field, 'redeemableSubsidyAccessPolicy', was spread into applicableSubsidyAccessPolicy
-        // 'redeemableSubsidyAccessPolicy' added to match data-structure
+        // The original field, 'redeemableSubsidyAccessPolicy', was spread into applicableSubsidyAccessPolicy.
+        // 'redeemableSubsidyAccessPolicy' is intentionally duplicated from 'applicableSubsidyAccessPolicy'
+        // to match the expected data structure required by downstream consumers of this object.
         redeemableSubsidyAccessPolicy: learnerCreditMetadata.applicableSubsidyAccessPolicy,
       },
     });

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -151,7 +151,12 @@ export const useCourseUpgradeData = ({
     const applicableSubsidy = getSubsidyToApplyForCourse({
       applicableSubscriptionLicense: subscriptionLicense,
       applicableCouponCode,
-      applicableSubsidyAccessPolicy: learnerCreditMetadata?.applicableSubsidyAccessPolicy,
+      applicableSubsidyAccessPolicy: {
+        ...learnerCreditMetadata?.applicableSubsidyAccessPolicy,
+        // The original field, 'redeemableSubsidyAccessPolicy', was spread into applicableSubsidyAccessPolicy
+        // 'redeemableSubsidyAccessPolicy' added to match data-structure
+        redeemableSubsidyAccessPolicy: learnerCreditMetadata.applicableSubsidyAccessPolicy,
+      },
     });
 
     // No applicable subsidy found, return early.

--- a/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/data/tests/hooks.test.jsx
@@ -143,7 +143,10 @@ describe('useCourseUpgradeData', () => {
     useSubscriptions.mockReturnValue({ data: null });
     useCanUpgradeWithLearnerCredit.mockReturnValue({
       data: {
-        applicableSubsidyAccessPolicy: null,
+        applicableSubsidyAccessPolicy: {
+          isPolicyRedemptionEnabled: false,
+          redeemableSubsidyAccessPolicy: null,
+        },
         listPrice: null,
       },
     });
@@ -450,7 +453,7 @@ describe('useCourseUpgradeData', () => {
       useCanUpgradeWithLearnerCredit.mockReturnValue({
         data: {
           applicableSubsidyAccessPolicy: {
-            ...mockCanUpgradeWithLearnerCredit.redeemableSubsidyAccessPolicy,
+            redeemableSubsidyAccessPolicy: mockCanUpgradeWithLearnerCredit.redeemableSubsidyAccessPolicy,
             isPolicyRedemptionEnabled: true,
           },
           listPrice: mockCanUpgradeWithLearnerCredit.listPrice.usd,


### PR DESCRIPTION
Fixes an issue where a course run was displayed as enroll-able despite no redeemable subsidy access policy despite policy redemption being enabled. 

For customers who have already redeemed a single course run and navigate back to the course about page of their redeemed course, if there exist more then one available run, the user should no longer be able to enroll if they are not allocated an assignment. 
Updates data structure for upgrade learner credit path to be in-line with redemptions and respect the newly added validation for `redeemableSubsidyAccessPolicy` 

To test locally: 
On a learner credit enabled customer, allocate and redeem a course with multiple course runs available to enroll in.
Navigate back to the course about page and the remaining runs should show as enroll-able despite no available `redeemableSubsidyAccessPolicy`.
This fix should now display the default error reason (since no error is being returned from the `can-redeem` endpoint)

Screenshot of fixed state:
![Screenshot 2025-04-30 at 11 01 42 AM](https://github.com/user-attachments/assets/fd5d8fb1-cfa6-4dce-9d0d-53efe213f63a)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
