### PR TITLE
feat: add learner credit requests in learner dashboard

### DIFF
--- a/src/components/app/data/hooks/useEnterpriseCourseEnrollments.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseCourseEnrollments.test.jsx
@@ -182,6 +182,8 @@ describe('useEnterpriseCourseEnrollments', () => {
         upcoming: [],
         completed: [],
         savedForLater: [],
+        approved: [],
+        lcRequested: [],
       },
     };
     const expectedRequests = {
@@ -284,10 +286,9 @@ describe('useEnterpriseCourseEnrollments', () => {
           },
           transformed: expectedEnterpriseCourseEnrollmentsData,
         });
-        expect(mockSelectEnrollment).toHaveBeenCalledWith({
-          original: [mockCourseEnrollment],
+        expect(mockSelectEnrollment).toHaveBeenCalledWith(expect.objectContaining({
           transformed: expectedEnterpriseCourseEnrollmentsData,
-        });
+        }));
       });
     }
 

--- a/src/components/app/data/queries/utils.ts
+++ b/src/components/app/data/queries/utils.ts
@@ -210,6 +210,7 @@ export async function safeEnsureQueryDataRedeemablePolicies({ queryClient, authe
         reversedAssignments: [],
         hasReversedAssignments: false,
       },
+      learnerRequests: [],
     },
   });
 }

--- a/src/components/app/data/services/subsidies/index.test.js
+++ b/src/components/app/data/services/subsidies/index.test.js
@@ -120,6 +120,7 @@ describe('fetchRedeemablePolicies', () => {
         hasExpiredAssignments: false,
         hasReversedAssignments: false,
       },
+      learnerRequests: [],
     };
     expect(result).toEqual(expectedRedeemablePolicies);
   });

--- a/src/components/app/data/services/subsidies/index.ts
+++ b/src/components/app/data/services/subsidies/index.ts
@@ -71,11 +71,13 @@ export async function fetchRedeemablePolicies(enterpriseUUID, userID) {
     redeemablePolicies?.flatMap(item => item.learnerContentAssignments || []),
   );
   const { expiredPolicies, unexpiredPolicies } = filterPoliciesByExpirationAndActive(redeemablePolicies);
+  const learnerRequests = redeemablePolicies?.flatMap(item => item.learnerRequests || []);
   return {
     redeemablePolicies,
     learnerContentAssignments,
     expiredPolicies,
     unexpiredPolicies,
+    learnerRequests,
   };
 }
 

--- a/src/components/app/data/utils.js
+++ b/src/components/app/data/utils.js
@@ -466,6 +466,34 @@ export const transformLearnerContentAssignment = (learnerContentAssignment, ente
   };
 };
 
+export const transformLearnerCreditRequest = (learnerCreditRequest, enterpriseSlug) => {
+  if (!learnerCreditRequest) {
+    return null;
+  }
+
+  const {
+    uuid,
+    courseTitle,
+    courseId,
+    coursePartners,
+    startDate,
+  } = learnerCreditRequest;
+
+  const orgName = coursePartners?.[0]?.name || null;
+  const state = learnerCreditRequest.state === 'requested' ? 'lc_requested' : learnerCreditRequest.state;
+
+  return {
+    uuid,
+    title: courseTitle,
+    courseRunId: courseId,
+    linkToCourse: `/${enterpriseSlug}/course/${courseId}`,
+    orgName,
+    courseRunStatus: state,
+    startDate: startDate || null,
+    isLearnerCreditRequest: true,
+  };
+};
+
 /**
  * Transforms a learner assignment into a shape consistent with course
  * enrollments, including additional fields specific to learner content

--- a/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseEnrollments.jsx
@@ -149,9 +149,9 @@ const CourseEnrollments = ({ children }) => {
               defaultMessage: 'Your learning journey starts now!',
               description: 'Title for the assigned courses section when the user visits the dashboard for the first time.',
             }) : intl.formatMessage({
-              id: 'enterprise.dashboard.course.enrollments.assigned.section.title',
-              defaultMessage: 'Assigned Courses',
-              description: 'Title for the assigned courses section.',
+              id: 'enterprise.dashboard.course.enrollments.pending.section.title',
+              defaultMessage: 'Pending enrollments',
+              description: 'Title for the pending enrollments section.',
             })}
             courseRuns={assignments}
           />

--- a/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
@@ -11,6 +11,8 @@ import {
   RequestedCourseCard,
   SavedForLaterCourseCard,
   UpcomingCourseCard,
+  ApprovedCourseCard,
+  LCRequestedCourseCard,
 } from './course-cards';
 
 import { COURSE_STATUSES } from '../../../../constants';
@@ -27,6 +29,8 @@ const CARD_COMPONENT_BY_COURSE_STATUS = {
   [COURSE_STATUSES.savedForLater]: SavedForLaterCourseCard,
   [COURSE_STATUSES.requested]: RequestedCourseCard,
   [COURSE_STATUSES.assigned]: AssignedCourseCard,
+  [COURSE_STATUSES.approved]: ApprovedCourseCard,
+  [COURSE_STATUSES.lcRequested]: LCRequestedCourseCard,
 };
 
 const CourseSection = ({

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/ApprovedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/ApprovedCourseCard.jsx
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+import { Button } from '@openedx/paragon';
+import { Link } from 'react-router-dom';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+
+import BaseCourseCard from './BaseCourseCard';
+import { COURSE_STATUSES } from '../../../../../constants';
+
+const ApprovedCourseCard = (props) => {
+  const {
+    linkToCourse,
+  } = props;
+  const renderButtons = () => (
+    <Button
+      as={Link}
+      to={linkToCourse}
+      className="btn-xs-block"
+      variant="inverse-brand"
+    >
+      <FormattedMessage
+        id="enterprise.learner.portal.dashboard.courses.assignments.assignment.enroll"
+        defaultMessage="Enroll"
+        description="Button text for approved course card to go to course about page to continue with enrollment"
+      />
+    </Button>
+  );
+
+  return (
+    <BaseCourseCard
+      buttons={renderButtons()}
+      type={COURSE_STATUSES.approved}
+      hasViewCertificateLink={false}
+      canUnenroll={false}
+      externalCourseLink={false}
+      {...props}
+    />
+  );
+};
+
+ApprovedCourseCard.propTypes = {
+  linkToCourse: PropTypes.string.isRequired,
+};
+
+export default ApprovedCourseCard;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -56,6 +56,11 @@ const messages = defineMessages({
     defaultMessage: 'Assigned',
     description: 'The label for the status badge for courses that are assigned',
   },
+  statusBadgeLabelApproved: {
+    id: 'enterprise.learner_portal.dashboard.enrollments.course.status_badge_label.approved',
+    defaultMessage: 'Approved',
+    description: 'The label for the status badge for course requests that are approved',
+  },
   emailSettings: {
     id: 'enterprise.learner_portal.dashboard.enrollments.course.email_settings',
     defaultMessage: 'Email settings <s>for {courseTitle}</s>',
@@ -70,6 +75,11 @@ const messages = defineMessages({
     id: 'enterprise.learner_portal.dashboard.enrollments.course.requested.help_text',
     defaultMessage: 'Please allow 5-10 business days for review. If approved, you will receive an email to get started.',
     description: 'Help text for requested courses',
+  },
+  lcRequestedCourseHelpText: {
+    id: 'enterprise.learner_portal.dashboard.enrollments.course.lcRequested.help_text',
+    defaultMessage: 'Please allow 5-10 business days for review. If approved by your edX administrator, you will be able to enroll.',
+    description: 'Help text for learner credit requested courses',
   },
   enrollByDateWarning: {
     id: 'enterprise.learner_portal.dashboard.enrollments.course.enroll_by_date_warning',
@@ -114,6 +124,14 @@ const BADGE_PROPS_BY_COURSE_STATUS = {
   [COURSE_STATUSES.assigned]: {
     variant: 'info',
     children: <FormattedMessage {...messages.statusBadgeLabelAssigned} />,
+  },
+  [COURSE_STATUSES.approved]: {
+    variant: 'info',
+    children: <FormattedMessage {...messages.statusBadgeLabelApproved} />,
+  },
+  [COURSE_STATUSES.lcRequested]: {
+    variant: 'light',
+    children: <FormattedMessage {...messages.statusBadgeLabelRequested} />,
   },
 };
 
@@ -364,12 +382,20 @@ const BaseCourseCard = ({
   };
 
   const renderAdditionalInfoOutline = () => {
-    if (type !== COURSE_STATUSES.requested) {
-      return null;
+    let message = null;
+    switch (type) {
+      case COURSE_STATUSES.requested:
+        message = messages.requestedCourseHelpText;
+        break;
+      case COURSE_STATUSES.lcRequested:
+        message = messages.lcRequestedCourseHelpText;
+        break;
+      default:
+        return null;
     }
     return (
       <div className="small">
-        <FormattedMessage {...messages.requestedCourseHelpText} />
+        <FormattedMessage {...message} />
       </div>
     );
   };

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/LCRequestedCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/LCRequestedCourseCard.jsx
@@ -1,0 +1,31 @@
+import { Button } from '@openedx/paragon';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+
+import BaseCourseCard from './BaseCourseCard';
+import { COURSE_STATUSES } from '../../../../../constants';
+
+const LCRequestedCourseCard = (props) => {
+  const renderButtons = () => (
+    <Button
+      className="btn-xs-block"
+      disabled
+    >
+      <FormattedMessage
+        id="enterprise.learner-portal.dashboard.courses.requested.requested.enroll"
+        defaultMessage="Enroll"
+        description="Button text for requested course card in disabled state"
+      />
+    </Button>
+  );
+
+  return (
+    <BaseCourseCard
+      type={COURSE_STATUSES.lcRequested}
+      hasViewCertificateLink={false}
+      buttons={renderButtons()}
+      {...props}
+    />
+  );
+};
+
+export default LCRequestedCourseCard;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/index.js
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/index.js
@@ -4,3 +4,5 @@ export { default as UpcomingCourseCard } from './UpcomingCourseCard';
 export { default as SavedForLaterCourseCard } from './SavedForLaterCourseCard';
 export { default as RequestedCourseCard } from './RequestedCourseCard';
 export { default as AssignedCourseCard } from './AssignedCourseCard';
+export { default as ApprovedCourseCard } from './ApprovedCourseCard';
+export { default as LCRequestedCourseCard } from './LCRequestedCourseCard';

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/ApprovedCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/ApprovedCourseCard.test.jsx
@@ -1,0 +1,29 @@
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import ApprovedCourseCard from '../ApprovedCourseCard';
+import { renderWithRouter } from '../../../../../../utils/tests';
+
+jest.mock('../../../../../app/data', () => ({
+  ...jest.requireActual('../../../../../app/data'),
+  useEnterpriseCustomer: jest.fn().mockReturnValue({ data: { uuid: 123 } }),
+}));
+
+const baseProps = {
+  linkToCourse: 'https://edx.org',
+};
+
+const ApprovedCourseCardWrapper = (props) => (
+  <IntlProvider locale="en">
+    <ApprovedCourseCard {...props} />
+  </IntlProvider>
+);
+
+describe('<ApprovedCourseCard />', () => {
+  it('should render enroll button and other related content', () => {
+    renderWithRouter(<ApprovedCourseCardWrapper {...baseProps} />);
+    expect(screen.getByText('Approved')).toBeInTheDocument();
+    expect(screen.getByText('Enroll')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/LCRequestedCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/LCRequestedCourseCard.test.jsx
@@ -1,0 +1,30 @@
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import LCRequestedCourseCard from '../LCRequestedCourseCard';
+import { renderWithRouter } from '../../../../../../utils/tests';
+
+jest.mock('../../../../../app/data', () => ({
+  ...jest.requireActual('../../../../../app/data'),
+  useEnterpriseCustomer: jest.fn().mockReturnValue({ data: { uuid: 123 } }),
+}));
+
+const baseProps = {
+  linkToCourse: 'https://edx.org',
+};
+
+const LCRequestedCourseCardWrapper = (props) => (
+  <IntlProvider locale="en">
+    <LCRequestedCourseCard {...props} />
+  </IntlProvider>
+);
+
+describe('<LCRequestedCourseCard />', () => {
+  it('should render enroll button and other related content', () => {
+    renderWithRouter(<LCRequestedCourseCardWrapper {...baseProps} />);
+    expect(screen.getByText('Requested')).toBeInTheDocument();
+    expect(screen.getByText('Enroll')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Enroll' })).toBeDisabled();
+  });
+});

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/RequestedCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/RequestedCourseCard.test.jsx
@@ -1,0 +1,34 @@
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import RequestedCourseCard from '../RequestedCourseCard';
+import { renderWithRouter } from '../../../../../../utils/tests';
+
+jest.mock('../../../../../app/data', () => ({
+  ...jest.requireActual('../../../../../app/data'),
+  useEnterpriseCustomer: jest.fn().mockReturnValue({ data: { uuid: 123 } }),
+}));
+
+const baseProps = {
+  title: 'edX Demonstration Course',
+  linkToCourse: 'https://edx.org',
+  courseRunStatus: 'upcoming',
+  courseRunId: 'my+course+key',
+  courseKey: 'my+course+key',
+  notifications: [],
+  mode: 'verified-audit',
+};
+
+const RequestedCourseCardWrapper = (props) => (
+  <IntlProvider locale="en">
+    <RequestedCourseCard {...props} />
+  </IntlProvider>
+);
+
+describe('<RequestedCourseCard />', () => {
+  it('should render enroll button and other related content', () => {
+    renderWithRouter(<RequestedCourseCardWrapper {...baseProps} />);
+    expect(screen.getByText('Requested')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/main-content/course-enrollments/tests/CourseSection.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/tests/CourseSection.test.jsx
@@ -18,6 +18,8 @@ jest.mock('../course-cards', () => ({
   SavedForLaterCourseCard: () => '<SavedForLaterCourseCard />',
   RequestedCourseCard: () => '<RequestedCourseCard />',
   AssignedCourseCard: () => '<AssignedCourseCard />',
+  ApprovedCourseCard: () => '<ApprovedCourseCard />',
+  LCRequestedCourseCard: () => '<LCRequestedCourseCard />',
 }));
 
 jest.mock('../../../../app/data', () => ({
@@ -32,6 +34,8 @@ const CARD_COMPONENT_BY_COURSE_STATUS = {
   [COURSE_STATUSES.savedForLater]: '<SavedForLaterCourseCard />',
   [COURSE_STATUSES.requested]: '<RequestedCourseCard />',
   [COURSE_STATUSES.assigned]: '<AssignedCourseCard />',
+  [COURSE_STATUSES.approved]: '<ApprovedCourseCard />',
+  [COURSE_STATUSES.lcRequested]: '<LCRequestedCourseCard />',
 };
 
 const mockEnterpriseCustomer = enterpriseCustomerFactory();

--- a/src/constants/course.js
+++ b/src/constants/course.js
@@ -8,6 +8,10 @@ export const COURSE_STATUSES = {
   requested: 'requested',
   // Not a real course status, represents a course assignment.
   assigned: 'assigned',
+  approved: 'approved',
+  // Learner Credit request status. It is used to differentiate between learner credit requests
+  // and subs / coupon requests.
+  lcRequested: 'lc_requested',
 };
 
 export const COURSE_PACING = {


### PR DESCRIPTION
Ticket: [ENT-10290](https://2u-internal.atlassian.net/browse/ENT-10290)
Description: I've displayed the requests returned by `credit_available` endpoint along with assignments. I've transformed them to match the assignments structure so that they can be integrated in the existing flow of rendering assignments. I've also added 2 new course card components which utilize the base card component for `approved` and `requested` state.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [x] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots

<img width="792" alt="image" src="https://github.com/user-attachments/assets/8639a537-79b0-46dd-b380-9a8697e5b9b9" />