### PR TITLE
fix: improve queries for audit->verified upgrades; better handle hard loading states

### DIFF
--- a/src/components/app/Layout.tsx
+++ b/src/components/app/Layout.tsx
@@ -5,7 +5,7 @@ import { getConfig } from '@edx/frontend-platform/config';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { isSystemMaintenanceAlertOpen, useEnterpriseCustomer } from './data';
-import { useStylesForCustomBrandColors } from '../layout/data/hooks';
+import { useBrandStylesInjection } from '../layout/data';
 import NotFoundPage from '../NotFoundPage';
 import { SiteHeader } from '../site-header';
 import { EnterpriseBanner } from '../enterprise-banner';
@@ -21,7 +21,8 @@ const Layout = () => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const licenseActivationRouteMatch = useMatch('/:enterpriseSlug/licenses/:activationKey/activate');
 
-  const brandStyles = useStylesForCustomBrandColors(enterpriseCustomer);
+  // Inject brand styles based on the enterprise customer's branding configuration
+  useBrandStylesInjection();
 
   // Authenticated user is NOT linked to an enterprise customer.
   if (!enterpriseCustomer) {
@@ -43,12 +44,7 @@ const Layout = () => {
 
   return (
     <EnterprisePage>
-      <Helmet titleTemplate={TITLE_TEMPLATE} defaultTitle={DEFAULT_TITLE}>
-        <html lang="en" />
-        {brandStyles?.map(({ key, styles }) => (
-          <style key={key} type="text/css">{styles}</style>
-        ))}
-      </Helmet>
+      <Helmet titleTemplate={TITLE_TEMPLATE} defaultTitle={DEFAULT_TITLE} />
       {isSystemMaintenanceAlertOpen(config) && (
         <SystemWideWarningBanner>
           {config.MAINTENANCE_ALERT_MESSAGE}

--- a/src/components/app/data/hooks/index.ts
+++ b/src/components/app/data/hooks/index.ts
@@ -11,7 +11,7 @@ export { default as useCourseRecommendations } from './useCourseRecommendations'
 export { default as useCatalogsForSubsidyRequests } from './useCatalogsForSubsidyRequests';
 export { default as useEnterpriseFeatures } from './useEnterpriseFeatures';
 export { default as useDefaultSearchFilters } from './useDefaultSearchFilters';
-export { default as useEnterpriseCustomerContainsContent } from './useEnterpriseCustomerContainsContent';
+export { useEnterpriseCustomerContainsContent, useEnterpriseCustomerContainsContentSuspense } from './useEnterpriseCustomerContainsContent';
 export { default as useCourseRedemptionEligibility } from './useCourseRedemptionEligibility';
 export { default as useSearchCatalogs } from './useSearchCatalogs';
 export { default as useSubscriptions } from './useSubscriptions';
@@ -41,7 +41,7 @@ export { default as useAcademies } from './useAcademies';
 export { default as useAcademyDetails } from './useAcademyDetails';
 export { default as usePassLearnerCsodParams } from './usePassLearnerCsodParams';
 export { default as useCanUpgradeWithLearnerCredit } from './useCanUpgradeWithLearnerCredit';
-export { default as useCourseRunMetadata } from './useCourseRunMetadata';
+export { useCourseRunMetadata, useCourseRunMetadataSuspense } from './useCourseRunMetadata';
 export { default as useVideoDetails } from './useVideoDetails';
 export { default as useVideoCourseMetadata } from './useVideoCourseMetadata';
 export { default as useVideoCourseReviews } from './useVideoCourseReviews';

--- a/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.js
+++ b/src/components/app/data/hooks/useCanUpgradeWithLearnerCredit.js
@@ -1,4 +1,4 @@
-import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { queryOptions, useQuery } from '@tanstack/react-query';
 
 import { queryCanUpgradeWithLearnerCredit } from '../queries';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
@@ -12,7 +12,7 @@ import useEnterpriseCustomer from './useEnterpriseCustomer';
 export default function useCanUpgradeWithLearnerCredit(courseRunKey, options = {}) {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { select } = options;
-  return useSuspenseQuery(
+  return useQuery(
     queryOptions({
       ...queryCanUpgradeWithLearnerCredit(enterpriseCustomer.uuid, courseRunKey),
       select: (data) => {

--- a/src/components/app/data/hooks/useCourseMetadata.test.jsx
+++ b/src/components/app/data/hooks/useCourseMetadata.test.jsx
@@ -9,13 +9,15 @@ import { fetchCourseMetadata } from '../services';
 import useLateEnrollmentBufferDays from './useLateEnrollmentBufferDays';
 import useCourseMetadata from './useCourseMetadata';
 import useRedeemablePolicies from './useRedeemablePolicies';
-import useEnterpriseCustomerContainsContent from './useEnterpriseCustomerContainsContent';
+import { useEnterpriseCustomerContainsContent } from './useEnterpriseCustomerContainsContent';
 import { ENTERPRISE_RESTRICTION_TYPE } from '../../../../constants';
 
 jest.mock('./useEnterpriseCustomer');
 jest.mock('./useLateEnrollmentBufferDays');
 jest.mock('./useRedeemablePolicies');
-jest.mock('./useEnterpriseCustomerContainsContent');
+jest.mock('./useEnterpriseCustomerContainsContent', () => ({
+  useEnterpriseCustomerContainsContent: jest.fn(),
+}));
 
 jest.mock('../services', () => ({
   ...jest.requireActual('../services'),

--- a/src/components/app/data/hooks/useCourseRedemptionEligibility.test.jsx
+++ b/src/components/app/data/hooks/useCourseRedemptionEligibility.test.jsx
@@ -23,7 +23,9 @@ import { ENTERPRISE_RESTRICTION_TYPE } from '../../../../constants';
 jest.mock('./useEnterpriseCustomer');
 jest.mock('./useCourseMetadata');
 jest.mock('./useLateEnrollmentBufferDays');
-jest.mock('./useEnterpriseCustomerContainsContent');
+jest.mock('./useEnterpriseCustomerContainsContent', () => ({
+  useEnterpriseCustomerContainsContent: jest.fn(),
+}));
 jest.mock('./useCourseRunKeyQueryParam');
 jest.mock('./useRedeemablePolicies');
 jest.mock('./useSubscriptions');

--- a/src/components/app/data/hooks/useCourseRedemptionEligibility.ts
+++ b/src/components/app/data/hooks/useCourseRedemptionEligibility.ts
@@ -11,7 +11,7 @@ import useCourseRunKeyQueryParam from './useCourseRunKeyQueryParam';
 import useRedeemablePolicies from './useRedeemablePolicies';
 import useSubscriptions from './useSubscriptions';
 import useCouponCodes from './useCouponCodes';
-import useEnterpriseCustomerContainsContent from './useEnterpriseCustomerContainsContent';
+import { useEnterpriseCustomerContainsContent } from './useEnterpriseCustomerContainsContent';
 
 const getContentListPriceRange = ({ courseRuns }) => {
   const flatContentPrice = courseRuns.flatMap(run => run.listPrice?.usd).filter(x => !!x);

--- a/src/components/app/data/hooks/useCourseRunMetadata.ts
+++ b/src/components/app/data/hooks/useCourseRunMetadata.ts
@@ -1,11 +1,24 @@
-import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { queryOptions, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { queryCourseRunMetadata } from '../queries';
 
 type UseCourseRunMetadataQueryOptions = {
   select?: (data: unknown) => unknown;
 };
 
-export default function useCourseRunMetadata(
+export function useCourseRunMetadata(
+  courseRunKey: string,
+  options: UseCourseRunMetadataQueryOptions = {},
+) {
+  const { select } = options;
+  return useQuery(
+    queryOptions({
+      ...queryCourseRunMetadata(courseRunKey),
+      select,
+    }),
+  );
+}
+
+export function useCourseRunMetadataSuspense(
   courseRunKey: string,
   options: UseCourseRunMetadataQueryOptions = {},
 ) {

--- a/src/components/app/data/hooks/useEnterpriseCustomerContainsContent.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseCustomerContainsContent.test.jsx
@@ -6,7 +6,7 @@ import { enterpriseCustomerFactory } from '../services/data/__factories__';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 import { queryClient } from '../../../../utils/tests';
 import { fetchEnterpriseCustomerContainsContent } from '../services';
-import useEnterpriseCustomerContainsContent from './useEnterpriseCustomerContainsContent';
+import { useEnterpriseCustomerContainsContentSuspense } from './useEnterpriseCustomerContainsContent';
 
 jest.mock('./useEnterpriseCustomer');
 jest.mock('../services', () => ({
@@ -19,7 +19,7 @@ const mockEnterpriseCustomerContainsContent = {
   catalogList: [],
 };
 
-describe('useEnterpriseCustomerContainsContent', () => {
+describe('useEnterpriseCustomerContainsContentSuspense', () => {
   const Wrapper = ({ children }) => (
     <QueryClientProvider client={queryClient()}>
       <Suspense fallback={<div>Loading...</div>}>
@@ -34,7 +34,7 @@ describe('useEnterpriseCustomerContainsContent', () => {
   });
   it('should handle resolved value correctly', async () => {
     const { result } = renderHook(
-      () => useEnterpriseCustomerContainsContent(),
+      () => useEnterpriseCustomerContainsContentSuspense(),
       { wrapper: Wrapper },
     );
     await waitFor(() => {

--- a/src/components/app/data/hooks/useEnterpriseCustomerContainsContent.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseCustomerContainsContent.test.jsx
@@ -6,7 +6,10 @@ import { enterpriseCustomerFactory } from '../services/data/__factories__';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
 import { queryClient } from '../../../../utils/tests';
 import { fetchEnterpriseCustomerContainsContent } from '../services';
-import { useEnterpriseCustomerContainsContentSuspense } from './useEnterpriseCustomerContainsContent';
+import {
+  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
+} from './useEnterpriseCustomerContainsContent';
 
 jest.mock('./useEnterpriseCustomer');
 jest.mock('../services', () => ({
@@ -19,23 +22,71 @@ const mockEnterpriseCustomerContainsContent = {
   catalogList: [],
 };
 
-describe('useEnterpriseCustomerContainsContentSuspense', () => {
-  const Wrapper = ({ children }) => (
-    <QueryClientProvider client={queryClient()}>
-      <Suspense fallback={<div>Loading...</div>}>
-        {children}
-      </Suspense>
-    </QueryClientProvider>
+const BaseWrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+const Wrapper = ({ children, options = {} }) => {
+  const { suspense = false } = options;
+  if (suspense) {
+    return (
+      <BaseWrapper>
+        <Suspense fallback={<div>Loading...</div>}>
+          {children}
+        </Suspense>
+      </BaseWrapper>
+    );
+  }
+  return (
+    <BaseWrapper>
+      {children}
+    </BaseWrapper>
   );
+};
+
+const WrapperWithSuspense = ({ children }) => (
+  <Wrapper options={{ suspense: true }}>
+    {children}
+  </Wrapper>
+);
+
+describe('useEnterpriseCustomerContainsContent', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
     fetchEnterpriseCustomerContainsContent.mockResolvedValue(mockEnterpriseCustomerContainsContent);
   });
+
+  it('should return the correct value', async () => {
+    const { result } = renderHook(
+      () => useEnterpriseCustomerContainsContent(),
+      { wrapper: Wrapper },
+    );
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          data: mockEnterpriseCustomerContainsContent,
+          isPending: false,
+          isFetching: false,
+        }),
+      );
+    });
+  });
+});
+
+describe('useEnterpriseCustomerContainsContentSuspense', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    fetchEnterpriseCustomerContainsContent.mockResolvedValue(mockEnterpriseCustomerContainsContent);
+  });
+
   it('should handle resolved value correctly', async () => {
     const { result } = renderHook(
       () => useEnterpriseCustomerContainsContentSuspense(),
-      { wrapper: Wrapper },
+      { wrapper: WrapperWithSuspense },
     );
     await waitFor(() => {
       expect(result.current).toEqual(

--- a/src/components/app/data/hooks/useEnterpriseCustomerContainsContent.ts
+++ b/src/components/app/data/hooks/useEnterpriseCustomerContainsContent.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { queryOptions, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { queryEnterpriseCustomerContainsContent } from '../queries';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
@@ -7,7 +7,16 @@ import useEnterpriseCustomer from './useEnterpriseCustomer';
  * Determines whether the given content identifier is contained within the enterprise customer's catalogs.
  * @returns The query result.
  */
-export default function useEnterpriseCustomerContainsContent(contentIdentifiers: string[]) {
+export function useEnterpriseCustomerContainsContent(contentIdentifiers: string[]) {
+  const { data: enterpriseCustomer } = useEnterpriseCustomer<EnterpriseCustomer>();
+  return useQuery(
+    queryOptions({
+      ...queryEnterpriseCustomerContainsContent(enterpriseCustomer.uuid, contentIdentifiers),
+    }),
+  );
+}
+
+export function useEnterpriseCustomerContainsContentSuspense(contentIdentifiers: string[]) {
   const { data: enterpriseCustomer } = useEnterpriseCustomer<EnterpriseCustomer>();
   return useSuspenseQuery(
     queryOptions({

--- a/src/components/app/data/hooks/useNProgressLoader.ts
+++ b/src/components/app/data/hooks/useNProgressLoader.ts
@@ -2,6 +2,7 @@ import { useContext, useEffect } from 'react';
 import { useFetchers, useNavigation } from 'react-router-dom';
 import nprogress from 'accessible-nprogress';
 import { AppContext } from '@edx/frontend-platform/react';
+import { useIsFetching } from '@tanstack/react-query';
 
 // Determines amount of time that must elapse before the
 // NProgress loader is shown in the UI. No need to show it
@@ -9,19 +10,26 @@ import { AppContext } from '@edx/frontend-platform/react';
 export const NPROGRESS_DELAY_MS = 300;
 
 export interface UseNProgressLoaderOptions {
+  // Whether to wait for the navigation to complete before completing the loader.
   shouldCompleteBeforeUnmount?: boolean;
+  // Whether to wait for the query fetching to complete before completing the loader.
+  handleQueryFetching?: boolean;
 }
 
-function useNProgressLoader({ shouldCompleteBeforeUnmount = true }: UseNProgressLoaderOptions = {}) {
+function useNProgressLoader({
+  shouldCompleteBeforeUnmount = true,
+  handleQueryFetching = false,
+}: UseNProgressLoaderOptions = {}) {
   const { authenticatedUser }: AppContextValue = useContext(AppContext);
   const isAuthenticatedUserHydrated = !!authenticatedUser?.extendedProfile;
   const navigation = useNavigation();
   const fetchers = useFetchers();
+  const isFetching = useIsFetching() > 0 && handleQueryFetching;
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {
       const fetchersIdle = fetchers.every((f) => f.state === 'idle');
-      if (shouldCompleteBeforeUnmount && navigation.state === 'idle' && fetchersIdle && isAuthenticatedUserHydrated) {
+      if (shouldCompleteBeforeUnmount && navigation.state === 'idle' && fetchersIdle && !isFetching && isAuthenticatedUserHydrated) {
         nprogress.done();
       } else {
         nprogress.start();
@@ -31,7 +39,7 @@ function useNProgressLoader({ shouldCompleteBeforeUnmount = true }: UseNProgress
       nprogress.done();
       clearTimeout(timeoutId);
     };
-  }, [navigation, fetchers, isAuthenticatedUserHydrated, shouldCompleteBeforeUnmount]);
+  }, [navigation, fetchers, isFetching, isAuthenticatedUserHydrated, shouldCompleteBeforeUnmount]);
 
   return isAuthenticatedUserHydrated;
 }

--- a/src/components/course/LicenseRequestedAlert.jsx
+++ b/src/components/course/LicenseRequestedAlert.jsx
@@ -10,7 +10,7 @@ import {
 } from './data/constants';
 import {
   useBrowseAndRequest,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   useSubscriptions,
 } from '../app/data';
 
@@ -20,7 +20,7 @@ import {
  */
 const LicenseRequestedAlert = () => {
   const { courseKey } = useParams();
-  const { data: { catalogList } } = useEnterpriseCustomerContainsContent([courseKey]);
+  const { data: { catalogList } } = useEnterpriseCustomerContainsContentSuspense([courseKey]);
   const cookies = new Cookies();
   const previouslyDismissed = cookies.get(LICENSE_REQUESTED_ALERT_DISMISSED_COOKIE_NAME);
   const [isAlertOpen, setIsAlertOpen] = useState(!previouslyDismissed);

--- a/src/components/course/course-header/CourseHeader.jsx
+++ b/src/components/course/course-header/CourseHeader.jsx
@@ -23,7 +23,7 @@ import {
   isArchived,
   useCourseMetadata,
   useEnterpriseCustomer,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   useIsAssignmentsOnlyLearner,
 } from '../../app/data';
 import CourseImportantDates from './CourseImportantDates';
@@ -33,7 +33,7 @@ const CourseHeader = () => {
   const { courseKey } = useParams();
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { data: courseMetadata } = useCourseMetadata();
-  const { data: { containsContentItems } } = useEnterpriseCustomerContainsContent([courseKey]);
+  const { data: { containsContentItems } } = useEnterpriseCustomerContainsContentSuspense([courseKey]);
   const isAssignmentsOnlyLearner = useIsAssignmentsOnlyLearner();
   const { shouldDisplayAssignmentsOnly } = useIsCourseAssigned();
   const isCourseArchived = courseMetadata.courseRuns.every((courseRun) => isArchived(courseRun));

--- a/src/components/course/course-header/CourseRunCards.jsx
+++ b/src/components/course/course-header/CourseRunCards.jsx
@@ -9,7 +9,7 @@ import {
   LEARNER_CREDIT_SUBSIDY_TYPE,
   useCourseMetadata,
   useEnterpriseCourseEnrollments,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   useUserEntitlements,
 } from '../../app/data';
 
@@ -25,7 +25,7 @@ const CourseRunCards = () => {
     missingUserSubsidyReason,
   } = useUserSubsidyApplicableToCourse();
   const { data: courseMetadata } = useCourseMetadata();
-  const { data: { catalogList } } = useEnterpriseCustomerContainsContent([courseKey]);
+  const { data: { catalogList } } = useEnterpriseCustomerContainsContentSuspense([courseKey]);
   const { data: { enterpriseCourseEnrollments } } = useEnterpriseCourseEnrollments();
   const { data: userEntitlements } = useUserEntitlements();
   // The DEPRECATED CourseRunCard should be used when the applicable subsidy is NOT Learner Credit.

--- a/src/components/course/course-header/tests/CourseHeader.test.jsx
+++ b/src/components/course/course-header/tests/CourseHeader.test.jsx
@@ -16,7 +16,7 @@ import {
   useCourseReviews,
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   useIsAssignmentsOnlyLearner,
   useRedeemablePolicies,
 } from '../../../app/data';
@@ -45,7 +45,7 @@ jest.mock('../../../app/data', () => ({
   useEnterpriseCourseEnrollments: jest.fn(),
   useCourseMetadata: jest.fn(),
   useCourseRedemptionEligibility: jest.fn(),
-  useEnterpriseCustomerContainsContent: jest.fn(),
+  useEnterpriseCustomerContainsContentSuspense: jest.fn(),
   useIsAssignmentsOnlyLearner: jest.fn(),
   useCourseReviews: jest.fn(),
   usePassLearnerCsodParams: jest.fn(),
@@ -167,7 +167,7 @@ describe('<CourseHeader />', () => {
     });
     useCourseMetadata.mockReturnValue({ data: mockCourseMetadata });
     useCourseRedemptionEligibility.mockReturnValue({ data: { isPolicyRedemptionEnabled: false } });
-    useEnterpriseCustomerContainsContent.mockReturnValue({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({
       data: {
         containsContentItems: true,
         catalogList: ['test-enterprise-catalog-uuid'],
@@ -258,7 +258,7 @@ describe('<CourseHeader />', () => {
   });
 
   test('does not renders course reviews section if course not part of catalog', () => {
-    useEnterpriseCustomerContainsContent.mockReturnValue({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({
       data: {
         containsContentItems: false,
         catalogList: [],
@@ -297,7 +297,7 @@ describe('<CourseHeader />', () => {
   });
 
   test('renders not in catalog messaging', () => {
-    useEnterpriseCustomerContainsContent.mockReturnValue({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({
       data: {
         containsContentItems: false,
         catalogList: [],

--- a/src/components/course/course-header/tests/CourseRunCard.test.jsx
+++ b/src/components/course/course-header/tests/CourseRunCard.test.jsx
@@ -13,7 +13,7 @@ import {
   useCourseRedemptionEligibility,
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   useEnterpriseOffers,
   useSubscriptions,
 } from '../../../app/data';
@@ -26,7 +26,7 @@ jest.mock('../../../app/data', () => ({
   useCourseMetadata: jest.fn(),
   useSubscriptions: jest.fn(),
   useEnterpriseOffers: jest.fn(),
-  useEnterpriseCustomerContainsContent: jest.fn(),
+  useEnterpriseCustomerContainsContentSuspense: jest.fn(),
   useCouponCodes: jest.fn(),
   useCourseRedemptionEligibility: jest.fn(),
   useEnterpriseCourseEnrollments: jest.fn(),
@@ -99,7 +99,7 @@ describe('<CourseRunCard />', () => {
         subscriptionPlan: undefined,
       },
     });
-    useEnterpriseCustomerContainsContent.mockReturnValue({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({
       data: {
         containsContentItems: false,
         catalogList: [],

--- a/src/components/course/course-header/tests/CourseRunCards.test.jsx
+++ b/src/components/course/course-header/tests/CourseRunCards.test.jsx
@@ -8,7 +8,7 @@ import { authenticatedUserFactory } from '../../../app/data/services/data/__fact
 import {
   useCourseMetadata,
   useEnterpriseCourseEnrollments,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   useUserEntitlements,
   LEARNER_CREDIT_SUBSIDY_TYPE,
   LICENSE_SUBSIDY_TYPE,
@@ -33,7 +33,7 @@ jest.mock('@edx/frontend-platform', () => ({
 jest.mock('../../../app/data', () => ({
   ...jest.requireActual('../../../app/data'),
   useCourseMetadata: jest.fn(),
-  useEnterpriseCustomerContainsContent: jest.fn(),
+  useEnterpriseCustomerContainsContentSuspense: jest.fn(),
   useEnterpriseCourseEnrollments: jest.fn(),
   useUserEntitlements: jest.fn(),
 }));
@@ -81,7 +81,7 @@ describe('<CourseRunCardStatus />', () => {
       missingUserSubsidyReason: undefined,
     });
     useCourseMetadata.mockReturnValue({ data: { availableCourseRuns: [mockCourseRunKey] } });
-    useEnterpriseCustomerContainsContent.mockReturnValue({ data: { catalogList: [] } });
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({ data: { catalogList: [] } });
     useEnterpriseCourseEnrollments.mockReturnValue({ data: { enterpriseCourseEnrollments: {} } });
     useUserEntitlements.mockReturnValue({ data: {} });
     getConfig.mockReturnValue({

--- a/src/components/course/course-header/tests/DeprecatedCourseRunCard.test.jsx
+++ b/src/components/course/course-header/tests/DeprecatedCourseRunCard.test.jsx
@@ -16,7 +16,7 @@ import {
   useCourseMetadata,
   useCourseRedemptionEligibility,
   useEnterpriseCustomer,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   useEnterpriseOffers,
   useRedeemablePolicies,
   useSubscriptions,
@@ -55,7 +55,7 @@ jest.mock('../../../app/data', () => ({
   useSubscriptions: jest.fn(),
   useRedeemablePolicies: jest.fn(),
   useCourseRedemptionEligibility: jest.fn(),
-  useEnterpriseCustomerContainsContent: jest.fn(),
+  useEnterpriseCustomerContainsContentSuspense: jest.fn(),
   useEnterpriseOffers: jest.fn(),
   useCouponCodes: jest.fn(),
   useBrowseAndRequest: jest.fn(),
@@ -130,7 +130,7 @@ describe('<DeprecatedCourseRunCard />', () => {
       },
     });
     useCourseRedemptionEligibility.mockReturnValue({ data: { listPrice: 100 } });
-    useEnterpriseCustomerContainsContent.mockReturnValue({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({
       data: {
         containsContentItems: false,
         catalogList: [],

--- a/src/components/course/data/hooks/hooks.jsx
+++ b/src/components/course/data/hooks/hooks.jsx
@@ -42,7 +42,7 @@ import {
   useCourseRedemptionEligibility,
   useEnterpriseCustomer,
   useRedeemablePolicies,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   LEARNER_CREDIT_SUBSIDY_TYPE,
 } from '../../../app/data';
 import { CourseContext } from '../../CourseContextProvider';
@@ -538,7 +538,7 @@ export function useCoursePrice() {
 export function useBrowseAndRequestCatalogsApplicableToCourse() {
   const { courseKey } = useParams();
   const catalogsForSubsidyRequests = useCatalogsForSubsidyRequests();
-  const { data: { catalogList: catalogsContainingCourse } } = useEnterpriseCustomerContainsContent([courseKey]);
+  const { data: { catalogList: catalogsContainingCourse } } = useEnterpriseCustomerContainsContentSuspense([courseKey]);
   const catalogsApplicableToCourse = useMemo(() => {
     const subsidyRequestCatalogIntersection = new Set(
       catalogsForSubsidyRequests.filter(catalog => catalogsContainingCourse.includes(catalog)),

--- a/src/components/course/data/hooks/hooks.test.jsx
+++ b/src/components/course/data/hooks/hooks.test.jsx
@@ -39,7 +39,7 @@ import {
   useCatalogsForSubsidyRequests,
   useCourseMetadata,
   useEnterpriseCustomer,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   useRedeemablePolicies,
 } from '../../../app/data';
 import { CourseContext } from '../../CourseContextProvider';
@@ -51,7 +51,7 @@ jest.mock('../../../app/data', () => ({
   useCourseMetadata: jest.fn(),
   useCourseRedemptionEligibility: jest.fn(),
   useSubscriptions: jest.fn(),
-  useEnterpriseCustomerContainsContent: jest.fn(),
+  useEnterpriseCustomerContainsContentSuspense: jest.fn(),
   useEnterpriseOffers: jest.fn(),
   useCouponCodes: jest.fn(),
   useBrowseAndRequest: jest.fn(),
@@ -1209,7 +1209,7 @@ describe('useBrowseAndRequestCatalogsApplicableToCourse', () => {
     jest.clearAllMocks();
     useParams.mockReturnValue({ courseKey: 'edX+DemoX' });
     useCatalogsForSubsidyRequests.mockReturnValue(['test-catalog']);
-    useEnterpriseCustomerContainsContent.mockReturnValue({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({
       data: { catalogList: ['test-catalog'] },
     });
   });
@@ -1227,7 +1227,7 @@ describe('useBrowseAndRequestCatalogsApplicableToCourse', () => {
   });
   it('filters sets effectively', () => {
     useCatalogsForSubsidyRequests.mockReturnValue(['test-catalog', 'test-catalog', 'test-catalog1']);
-    useEnterpriseCustomerContainsContent.mockReturnValue({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({
       data: { catalogList: ['test-catalog', 'test-catalog1', 'test-catalog2'] },
     });
 

--- a/src/components/course/data/hooks/tests/useUserSubsidyApplicableToCourse.test.jsx
+++ b/src/components/course/data/hooks/tests/useUserSubsidyApplicableToCourse.test.jsx
@@ -14,7 +14,7 @@ import {
   useCourseMetadata,
   useCourseRedemptionEligibility,
   useEnterpriseCustomer,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   useEnterpriseOffers,
   useRedeemablePolicies,
   useSubscriptions,
@@ -43,7 +43,7 @@ jest.mock('../../../../app/data', () => ({
   useRedeemablePolicies: jest.fn(),
   useCourseRedemptionEligibility: jest.fn(),
   useSubscriptions: jest.fn(),
-  useEnterpriseCustomerContainsContent: jest.fn(),
+  useEnterpriseCustomerContainsContentSuspense: jest.fn(),
   useEnterpriseOffers: jest.fn(),
   useCouponCodes: jest.fn(),
   getSubsidyToApplyForCourse: jest.fn(),
@@ -110,7 +110,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
         subscriptionPlan: undefined,
       },
     });
-    useEnterpriseCustomerContainsContent.mockReturnValue({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({
       data: {
         containsContentItems: false,
         catalogList: [],
@@ -249,7 +249,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
       },
     });
 
-    useEnterpriseCustomerContainsContent.mockReturnValueOnce({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValueOnce({
       data: {
         catalogList: ['test-catalog-uuid'],
         containsContentItems: true,
@@ -360,7 +360,7 @@ describe('useUserSubsidyApplicableToCourse', () => {
     });
     findCouponCodeForCourse.mockReturnValueOnce(mockCouponCode);
     useCouponCodes.mockReturnValueOnce({ data: { couponCodeAssignments: [mockCouponCode] } });
-    useEnterpriseCustomerContainsContent.mockReturnValueOnce({ data: { catalogList: [mockCatalogUUID] } });
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValueOnce({ data: { catalogList: [mockCatalogUUID] } });
     useCourseRedemptionEligibility.mockReturnValue({
       data: {
         isPolicyRedemptionEnabled: false,

--- a/src/components/course/data/hooks/useUserSubsidyApplicableToCourse.js
+++ b/src/components/course/data/hooks/useUserSubsidyApplicableToCourse.js
@@ -8,7 +8,7 @@ import {
   useCourseMetadata,
   useCourseRedemptionEligibility,
   useEnterpriseCustomer,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   useEnterpriseOffers,
   useSubscriptions,
 } from '../../../app/data';
@@ -57,7 +57,7 @@ const useUserSubsidyApplicableToCourse = () => {
       containsContentItems,
       catalogList: catalogsWithCourse,
     },
-  } = useEnterpriseCustomerContainsContent([courseKey]);
+  } = useEnterpriseCustomerContainsContentSuspense([courseKey]);
   const {
     data: {
       enterpriseOffers,

--- a/src/components/course/tests/LicenseRequestedAlert.test.jsx
+++ b/src/components/course/tests/LicenseRequestedAlert.test.jsx
@@ -15,7 +15,7 @@ import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../app/d
 import {
   useBrowseAndRequest,
   useEnterpriseCustomer,
-  useEnterpriseCustomerContainsContent,
+  useEnterpriseCustomerContainsContentSuspense,
   useSubscriptions,
 } from '../../app/data';
 import { renderWithRouterProvider } from '../../../utils/tests';
@@ -26,7 +26,7 @@ jest.mock('universal-cookie');
 jest.mock('../../app/data', () => ({
   ...jest.requireActual('../../app/data'),
   useEnterpriseCustomer: jest.fn(),
-  useEnterpriseCustomerContainsContent: jest.fn(),
+  useEnterpriseCustomerContainsContentSuspense: jest.fn(),
   useSubscriptions: jest.fn(),
   useBrowseAndRequest: jest.fn(),
 }));
@@ -53,7 +53,7 @@ describe('<LicenseRequestedAlert />', () => {
     jest.clearAllMocks();
     useParams.mockReturnValue({ courseKey: 'edX+DemoX' });
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    useEnterpriseCustomerContainsContent.mockReturnValue({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({
       data: {
         containsContentItems: false,
         catalogList: [],
@@ -84,7 +84,7 @@ describe('<LicenseRequestedAlert />', () => {
         },
       },
     });
-    useEnterpriseCustomerContainsContent.mockReturnValue({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({
       data: {
         catalogList: [mockCatalogUUID],
       },
@@ -131,7 +131,7 @@ describe('<LicenseRequestedAlert />', () => {
         },
       },
     });
-    useEnterpriseCustomerContainsContent.mockReturnValue({
+    useEnterpriseCustomerContainsContentSuspense.mockReturnValue({
       data: {
         catalogList: [mockCatalogUUID],
       },

--- a/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/CourseSection.jsx
@@ -1,8 +1,7 @@
-import { Suspense, useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
-import { Bubble, Collapsible, Skeleton } from '@openedx/paragon';
-import { v4 as uuidv4 } from 'uuid';
+import { Bubble, Collapsible } from '@openedx/paragon';
 
 import {
   AssignedCourseCard,
@@ -17,7 +16,6 @@ import {
 import { COURSE_STATUSES } from '../../../../constants';
 import { COURSE_SECTION_TITLES } from '../../data/constants';
 import { COURSE_MODES_MAP, isEnrollmentUpgradeable, useEnterpriseCustomer } from '../../../app/data';
-import DelayedFallbackContainer from '../../../DelayedFallback/DelayedFallbackContainer';
 
 const CARD_COMPONENT_BY_COURSE_STATUS = {
   [COURSE_STATUSES.upcoming]: UpcomingCourseCard,
@@ -115,21 +113,6 @@ const CourseSection = ({
       ? CARD_COMPONENT_BY_COURSE_STATUS[courseRun.courseRunStatus][inProgressCourseRunCardVariant]
       : CARD_COMPONENT_BY_COURSE_STATUS[courseRun.courseRunStatus];
 
-    if (inProgressCourseRunCardVariant === 'upgradeable') {
-      return (
-        <Suspense
-          key={courseRun.courseRunId}
-          fallback={(
-            <DelayedFallbackContainer className="dashboard-course-card border-bottom py-3 mb-2">
-              <div className="sr-only">Loading...</div>
-              <Skeleton key={uuidv4()} height={200} />
-            </DelayedFallbackContainer>
-          )}
-        >
-          <Component {...getCourseRunProps(courseRun)} />
-        </Suspense>
-      );
-    }
     return (
       <Component
         {...getCourseRunProps(courseRun)}

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
@@ -209,6 +209,7 @@ export const UpgradeableInProgressCourseCard = (props) => {
     subsidyForCourse,
     hasUpgradeAndConfirm,
     courseRunPrice,
+    isPending,
   } = useCourseUpgradeData({
     courseRunKey: courseRunId,
     enrollBy,
@@ -271,6 +272,7 @@ export const UpgradeableInProgressCourseCard = (props) => {
       linkToCourse={coursewareOrUpgradeLink}
       renderButtons={renderButtons}
       renderCourseUpgradePrice={renderCourseUpgradePrice}
+      isLoading={isPending}
     />
   );
 };

--- a/src/components/layout/data/hooks/index.ts
+++ b/src/components/layout/data/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useBrandStylesInjection } from './useBrandStylesInjection';
+export { default as useStylesForCustomBrandColors } from './useStylesForCustomBrandColors';

--- a/src/components/layout/data/hooks/useBrandStylesInjection.tsx
+++ b/src/components/layout/data/hooks/useBrandStylesInjection.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react';
+import useStylesForCustomBrandColors from './useStylesForCustomBrandColors';
+import { useEnterpriseCustomer } from '../../../app/data';
+
+/**
+ * Custom hook to manage the injection of brand styles into the document head.
+ * This hook directly manipulates the DOM to inject and update style elements
+ * based on the enterprise customer's brand colors.
+ */
+const useBrandStylesInjection = () => {
+  const { data: enterpriseCustomer } = useEnterpriseCustomer();
+  const brandStyles = useStylesForCustomBrandColors(enterpriseCustomer);
+  const stylesRef = useRef<Record<string, HTMLStyleElement>>({});
+
+  useEffect(() => {
+    // Skip if no brand styles are available
+    if (!brandStyles) {
+      // Remove any existing styles
+      Object.values(stylesRef.current).forEach((styleEl) => {
+        if (document.head.contains(styleEl)) {
+          document.head.removeChild(styleEl);
+        }
+      });
+      stylesRef.current = {};
+      return undefined;
+    }
+
+    // Add or update style elements for each brand style
+    brandStyles.forEach(({ key, styles }) => {
+      const existingStyleEl = stylesRef.current[key];
+
+      if (existingStyleEl) {
+        // Update existing style if content changed
+        if (existingStyleEl.textContent !== styles) {
+          existingStyleEl.textContent = styles;
+        }
+      } else {
+        // Create and inject a new style element
+        const styleEl = document.createElement('style');
+        styleEl.setAttribute('type', 'text/css');
+        styleEl.setAttribute('data-brand-style', key);
+        styleEl.textContent = styles;
+        document.head.appendChild(styleEl);
+
+        // Store reference
+        stylesRef.current[key] = styleEl;
+      }
+    });
+
+    // Cleanup function
+    return () => {
+      Object.values(stylesRef.current).forEach((styleEl) => {
+        if (document.head.contains(styleEl)) {
+          document.head.removeChild(styleEl);
+        }
+      });
+      stylesRef.current = {};
+    };
+  }, [brandStyles]);
+};
+
+export default useBrandStylesInjection;

--- a/src/components/layout/data/hooks/useStylesForCustomBrandColors.js
+++ b/src/components/layout/data/hooks/useStylesForCustomBrandColors.js
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
 import Color from 'color';
 
-import { isDefinedAndNotNull, isDefined, getBrandColorsFromCSSVariables } from '../../../utils/common';
+import { isDefinedAndNotNull, isDefined, getBrandColorsFromCSSVariables } from '../../../../utils/common';
 
 const COLOR_LIGHTEN_DARKEN_MODIFIER = 0.2;
 
-export const useStylesForCustomBrandColors = (enterpriseCustomer) => {
+const useStylesForCustomBrandColors = (enterpriseCustomer) => {
   const enterpriseBrandColors = useMemo(
     () => {
       if (!isDefinedAndNotNull(enterpriseCustomer)) {
@@ -115,3 +115,5 @@ export const useStylesForCustomBrandColors = (enterpriseCustomer) => {
 
   return styles;
 };
+
+export default useStylesForCustomBrandColors;

--- a/src/components/layout/data/index.js
+++ b/src/components/layout/data/index.js
@@ -1,0 +1,1 @@
+export * from './hooks';

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { QueryClient } from '@tanstack/react-query';
 import { matchPath, Outlet, RouteObject } from 'react-router-dom';
 import { PageWrap } from '@edx/frontend-platform/react';
@@ -7,6 +8,7 @@ import Root from './components/app/Root';
 import Layout from './components/app/Layout';
 import { makeRootLoader } from './components/app/routes/loaders';
 import NotFoundPage from './components/NotFoundPage';
+import RouterFallback from './components/app/routes/RouterFallback';
 
 /**
  * Returns the route loader function if a queryClient is available; otherwise, returns null.
@@ -255,7 +257,9 @@ export function getRoutes(queryClient?: QueryClient) {
       path: '/',
       element: (
         <PageWrap>
-          <Root />
+          <Suspense fallback={<RouterFallback loaderOptions={{ handleQueryFetching: true }} />}>
+            <Root />
+          </Suspense>
         </PageWrap>
       ),
       children: rootChildRoutes,


### PR DESCRIPTION
## CHANGELOG

* Refactor away from using `Suspense` with the API queries made to determine verified upgrade eligibility for audit enrollments a learner might have on their Dashboard, as it's not possible to "silence" errors to prevent them from surfacing to the user in the UI, when we should still render their existing audit enrollment, just without any upgrade path.
  * If these queries raise an error, it will now fail silently with a `logError`.
  * The `useCourseUpgradeData` hook was refactored to handle hard loading states, passing the `isLoading` to `BaseCourseCard` within `UpgradeableInProgressCourseCard` to still display a skeleton loading state.
* Wraps the `Root` component with `Suspense` to better handle if/when queries go into a hard loading state to prevent a suspense error from surfacing, integrating the `useNProgressLoader` hook with `useIsFetching` from `@tanstack/react-query`.
* No longer use `react-helmet` to inject the `<style>` tags into the HTML document's `<head>` for the enterprise customer's custom brand styles, as when the parent component tree suspends (unmounts and remounts), it seems `Helmet` does not re-apply the previously injected `<style>` tags, losing the custom colors throughout the portal. Instead, a new hook `useBrandStylesInjection` was created to manage the `<style>` tags directly with `document.head`.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
