### PR TITLE
feat: Modify Learner Credit Subsidy Box on Dashboard for B&R Budgets

### DIFF
--- a/src/components/app/data/hooks/useEnterpriseLearner.ts
+++ b/src/components/app/data/hooks/useEnterpriseLearner.ts
@@ -35,6 +35,7 @@ export default function useEnterpriseLearner<TData = EnterpriseLearnerData>(
           shouldUpdateActiveEnterpriseCustomerUser: data.shouldUpdateActiveEnterpriseCustomerUser,
           allLinkedEnterpriseCustomerUsers: data.allLinkedEnterpriseCustomerUsers as EnterpriseCustomerUser[],
           enterpriseFeatures: data.enterpriseFeatures as EnterpriseFeatures,
+          hasBnrEnabledPolicy: data.hasBnrEnabledPolicy as boolean,
         };
 
         // If custom `select` function is provided in `queryOptions`, call it with original and transformed data.

--- a/src/components/app/data/queries/utils.ts
+++ b/src/components/app/data/queries/utils.ts
@@ -93,6 +93,7 @@ export async function getEnterpriseLearnerQueryData({
     enterpriseFeatures: {},
     staffEnterpriseCustomer: null,
     shouldUpdateActiveEnterpriseCustomerUser: false,
+    hasBnrEnabledPolicy: false,
   };
 
   const matchedBFFQuery = resolveBFFQuery(requestUrl.pathname);
@@ -108,6 +109,7 @@ export async function getEnterpriseLearnerQueryData({
       staffEnterpriseCustomer: bffResponse.staffEnterpriseCustomer || null,
       enterpriseFeatures: bffResponse.enterpriseFeatures || {},
       shouldUpdateActiveEnterpriseCustomerUser: bffResponse.shouldUpdateActiveEnterpriseCustomerUser,
+      hasBnrEnabledPolicy: (bffResponse as any).hasBnrEnabledPolicy || false,
     };
   } else {
     // Otherwise, handle legacy direct query

--- a/src/components/app/data/services/bffs.ts
+++ b/src/components/app/data/services/bffs.ts
@@ -48,6 +48,7 @@ export const learnerDashboardBFFResponse: DashboardBFFResponse = {
     completed: [],
     savedForLater: [],
   },
+  hasBnrEnabledPolicy: false,
 };
 
 export const learnerSearchBFFResponse: SearchBFFResponse = {

--- a/src/components/app/data/services/enterpriseCustomerUser.test.js
+++ b/src/components/app/data/services/enterpriseCustomerUser.test.js
@@ -166,6 +166,7 @@ describe('fetchEnterpriseLearnerData', () => {
         .filter((ecu) => ecu.enterpriseCustomer),
       staffEnterpriseCustomer: isStaffUser ? expectedEnterpriseCustomer : null,
       shouldUpdateActiveEnterpriseCustomerUser: false,
+      hasBnrEnabledPolicy: false,
     });
   });
 });

--- a/src/components/app/data/services/enterpriseCustomerUser.ts
+++ b/src/components/app/data/services/enterpriseCustomerUser.ts
@@ -129,6 +129,7 @@ Promise<EnterpriseLearnerData> {
     enterpriseFeatures,
     staffEnterpriseCustomer,
     shouldUpdateActiveEnterpriseCustomerUser: false,
+    hasBnrEnabledPolicy: false,
   };
 }
 

--- a/src/components/dashboard/sidebar/LearnerCreditSummaryCard.jsx
+++ b/src/components/dashboard/sidebar/LearnerCreditSummaryCard.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { Badge, Card, Stack } from '@openedx/paragon';
 import dayjs from 'dayjs';
 import { defineMessages, FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
-import { useEnterpriseCustomer } from '../../app/data';
+import { useEnterpriseCustomer, useEnterpriseLearner } from '../../app/data';
 import { BUDGET_STATUSES } from '../data/constants';
 import { i18nFormatTimestamp } from '../../../utils/common';
 
@@ -74,6 +74,34 @@ const getStatusBadge = ({
   );
 };
 
+const getCreditSummaryMessage = (hasBnrEnabledPolicy, assignmentOnlyLearner) => {
+  if (hasBnrEnabledPolicy) {
+    return (
+      <FormattedMessage
+        id="enterprise.dashboard.sidebar.learner.credit.card.bnr.description"
+        defaultMessage="Browse your organization's catalog and request course enrollments with no out of pocket cost. "
+        description="Description for the learner credit summary card on the enterprise dashboard sidebar when BNR is enabled."
+      />
+    );
+  }
+  if (assignmentOnlyLearner) {
+    return (
+      <FormattedMessage
+        id="enterprise.dashboard.sidebar.learner.credit.card.assignment.only.description"
+        defaultMessage="Your organization will assign courses to learners. Please contact your administrator if you are interested in taking a course."
+        description="Description for the learner credit summary card on the enterprise dashboard sidebar when learner has assignment."
+      />
+    );
+  }
+  return (
+    <FormattedMessage
+      id="enterprise.dashboard.sidebar.learner.credit.card.description"
+      defaultMessage="Apply your organization's learner credit balance to enroll into courses with no out of pocket cost."
+      description="Description for the learner credit summary card on the enterprise dashboard sidebar when learner has no assignment."
+    />
+  );
+};
+
 const LearnerCreditSummaryCard = ({
   expirationDate,
   statusMetadata,
@@ -82,6 +110,7 @@ const LearnerCreditSummaryCard = ({
   const intl = useIntl();
   const { status, badgeVariant } = statusMetadata;
   const { data: { disableExpiryMessagingForLearnerCredit } } = useEnterpriseCustomer();
+  const { data: { hasBnrEnabledPolicy } } = useEnterpriseLearner();
   const isBudgetExpired = dayjs(expirationDate).isBefore(dayjs()) && status === BUDGET_STATUSES.expired;
 
   const cardBadge = getStatusBadge({
@@ -117,19 +146,7 @@ const LearnerCreditSummaryCard = ({
       />
       <Card.Section>
         <p data-testid="learner-credit-summary-text">
-          {assignmentOnlyLearner ? (
-            <FormattedMessage
-              id="enterprise.dashboard.sidebar.learner.credit.card.assignment.only.description"
-              defaultMessage="Your organization will assign courses to learners. Please contact your administrator if you are interested in taking a course."
-              description="Description for the learner credit summary card on the enterprise dashboard sidebar when learner has assignment."
-            />
-          ) : (
-            <FormattedMessage
-              id="enterprise.dashboard.sidebar.learner.credit.card.description"
-              defaultMessage="Apply your organization's learner credit balance to enroll into courses with no out of pocket cost."
-              description="Description for the learner credit summary card on the enterprise dashboard sidebar when learner has no assignment."
-            />
-          )}
+          {getCreditSummaryMessage(hasBnrEnabledPolicy, assignmentOnlyLearner)}
         </p>
 
         {!disableExpiryMessagingForLearnerCredit && (

--- a/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
+++ b/src/components/dashboard/sidebar/tests/DashboardSidebar.test.jsx
@@ -27,6 +27,7 @@ import {
   useCouponCodes,
   useEnterpriseCourseEnrollments,
   useEnterpriseCustomer,
+  useEnterpriseLearner,
   useEnterpriseOffers,
   useHasAvailableSubsidiesOrRequests,
   useIsAssignmentsOnlyLearner,
@@ -55,6 +56,7 @@ jest.mock('../../../app/data', () => ({
   useIsAssignmentsOnlyLearner: jest.fn(),
   useHasAvailableSubsidiesOrRequests: jest.fn(),
   useAcademies: jest.fn(),
+  useEnterpriseLearner: jest.fn(),
 }));
 
 const mockEnterpriseOffer = {
@@ -135,6 +137,17 @@ describe('<DashboardSidebar />', () => {
       useMockHasAvailableSubsidyOrRequests(mockUseActiveSubsidyOrRequestsData),
     );
     useAcademies.mockReturnValue({ data: academiesFactory(3) });
+    useEnterpriseLearner.mockReturnValue({
+      data: {
+        enterpriseCustomer: mockEnterpriseCustomer,
+        allLinkedEnterpriseCustomerUsers: [
+          {
+            active: true,
+            enterpriseCustomer: mockEnterpriseCustomer,
+          },
+        ],
+      },
+    });
   });
 
   test('Coupon codes summary card is displayed when coupon codes are available', () => {

--- a/src/components/dashboard/sidebar/tests/LearnerCreditSummaryCard.test.jsx
+++ b/src/components/dashboard/sidebar/tests/LearnerCreditSummaryCard.test.jsx
@@ -10,7 +10,7 @@ import {
   LEARNER_CREDIT_SUMMARY_CARD_TITLE,
 } from '../data/constants';
 import { BUDGET_STATUSES } from '../../data';
-import { useEnterpriseCustomer } from '../../../app/data';
+import { useEnterpriseCustomer, useEnterpriseLearner } from '../../../app/data';
 import { authenticatedUserFactory, enterpriseCustomerFactory } from '../../../app/data/services/data/__factories__';
 
 const TEST_UPCOMING_EXPIRATION_DATE = dayjs().add(10, 'days').toISOString();
@@ -26,6 +26,7 @@ const mockActiveStatusMetadata = {
 jest.mock('../../../app/data', () => ({
   ...jest.requireActual('../../../app/data'),
   useEnterpriseCustomer: jest.fn(),
+  useEnterpriseLearner: jest.fn(),
 }));
 
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
@@ -43,6 +44,17 @@ describe('<LearnerCreditSummaryCard />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
+    useEnterpriseLearner.mockReturnValue({
+      data: {
+        enterpriseCustomer: mockEnterpriseCustomer,
+        allLinkedEnterpriseCustomerUsers: [
+          {
+            active: true,
+            enterpriseCustomer: mockEnterpriseCustomer,
+          },
+        ],
+      },
+    });
   });
   it('should render searchCoursesCta', () => {
     render(
@@ -83,6 +95,29 @@ describe('<LearnerCreditSummaryCard />', () => {
       />,
     );
     expect(screen.getByText(summaryText)).toBeInTheDocument();
+  });
+
+  it('should render the bnr description when hasBnrEnabledPolicy is true', () => {
+    useEnterpriseLearner.mockReturnValue({
+      data: {
+        enterpriseCustomer: mockEnterpriseCustomer,
+        allLinkedEnterpriseCustomerUsers: [
+          {
+            active: true,
+            enterpriseCustomer: mockEnterpriseCustomer,
+          },
+        ],
+        hasBnrEnabledPolicy: true,
+      },
+    });
+    render(
+      <LearnerCreditSummaryCardWrapper
+        expirationDate={TEST_UPCOMING_EXPIRATION_DATE}
+        statusMetadata={mockActiveStatusMetadata}
+        assignmentOnlyLearner={false} // Set to false to ensure bnr description takes precedence
+      />,
+    );
+    expect(screen.getByText("Browse your organization's catalog and request course enrollments with no out of pocket cost.")).toBeInTheDocument();
   });
 
   it.each([{

--- a/src/types/enterprise-access.openapi.d.ts
+++ b/src/types/enterprise-access.openapi.d.ts
@@ -1748,6 +1748,7 @@ export interface components {
       enterprise_customer_user_subsidies: components["schemas"]["EnterpriseCustomerUserSubsidies"];
       enterprise_course_enrollments: components["schemas"]["EnterpriseCourseEnrollment"][];
       all_enrollments_by_status: components["schemas"]["LearnerEnrollmentsByStatus"];
+      has_bnr_enabled_policy: boolean;
     };
     /** @description Serializer for subscription license status. */
     LearnerEnrollmentsByStatus: {

--- a/src/types/openapi-schemas/enterprise-access.yaml
+++ b/src/types/openapi-schemas/enterprise-access.yaml
@@ -4983,6 +4983,8 @@ components:
             $ref: '#/components/schemas/EnterpriseCourseEnrollment'
         all_enrollments_by_status:
           $ref: '#/components/schemas/LearnerEnrollmentsByStatus'
+        has_bnr_enabled_policy:
+          type: boolean
       required:
         - all_enrollments_by_status
         - catalog_uuids_to_catalog_query_uuids

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -149,6 +149,7 @@ declare global {
     staffEnterpriseCustomer: EnterpriseCustomer | null;
     enterpriseFeatures: EnterpriseFeatures;
     shouldUpdateActiveEnterpriseCustomerUser: boolean;
+    hasBnrEnabledPolicy: boolean;
   };
 
   type SecuredAlgoliaApiData = {


### PR DESCRIPTION
**Description**
Show an appropriate message in the subsidy box if B&R is enabled on a budget. 

<img width="1433" alt="Screenshot 2025-05-21 at 2 59 11 PM" src="https://github.com/user-attachments/assets/a85a7932-e466-41f5-b290-9400843f0618" />


JIRA -> [ENT-10291](https://2u-internal.atlassian.net/browse/ENT-10291)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
