### PR TITLE
fix: ensure B&R config query falls back to null vs undefined

### DIFF
--- a/src/components/app/data/queries/utils.ts
+++ b/src/components/app/data/queries/utils.ts
@@ -6,6 +6,7 @@ import {
   queryAcademiesList,
   queryBrowseAndRequestConfiguration,
   queryCanRedeem,
+  queryContentHighlightsConfiguration,
   queryContentHighlightSets,
   queryCouponCodeRequests,
   queryCouponCodes,
@@ -407,6 +408,17 @@ export async function safeEnsureQueryDataAcademiesList({
     queryClient,
     query: queryAcademiesList(enterpriseCustomer.uuid),
     fallbackData: [],
+  });
+}
+
+export async function safeEnsureQueryDataContentHighlightsConfiguration({
+  queryClient,
+  enterpriseCustomer,
+}) {
+  return safeEnsureQueryData({
+    queryClient,
+    query: queryContentHighlightsConfiguration(enterpriseCustomer.uuid),
+    fallbackData: null,
   });
 }
 

--- a/src/components/app/data/queries/utils.ts
+++ b/src/components/app/data/queries/utils.ts
@@ -146,8 +146,7 @@ export async function safeEnsureQueryData<TData = unknown>({
   fallbackData,
 }: SafeEnsureQueryDataArgs<TData>) {
   try {
-    const data = await queryClient.ensureQueryData<TData>(query);
-    return data;
+    return await queryClient.ensureQueryData<TData>(query);
   } catch (err) {
     const shouldLogErrorResult = typeof shouldLogError === 'function'
       ? shouldLogError(err as Error)
@@ -288,6 +287,7 @@ export async function safeEnsureQueryDataBrowseAndRequestConfiguration({
     queryClient,
     query: queryBrowseAndRequestConfiguration(enterpriseCustomer.uuid),
     shouldLogError: ignoreQueryResponseError404,
+    fallbackData: null,
   });
 }
 

--- a/src/components/app/routes/data/utils.js
+++ b/src/components/app/routes/data/utils.js
@@ -11,7 +11,7 @@ import {
   resolveBFFQuery,
   safeEnsureQueryDataAcademiesList,
   safeEnsureQueryDataBrowseAndRequestConfiguration,
-  safeEnsureQueryDataContentHighlightSets,
+  safeEnsureQueryDataContentHighlightsConfiguration,
   safeEnsureQueryDataCouponCodeRequests,
   safeEnsureQueryDataCouponCodes,
   safeEnsureQueryDataEnterpriseOffers,
@@ -138,7 +138,7 @@ export async function ensureEnterpriseAppData({
       authenticatedUser: { email: userEmail },
     }),
     // Content Highlights
-    safeEnsureQueryDataContentHighlightSets({
+    safeEnsureQueryDataContentHighlightsConfiguration({
       queryClient,
       enterpriseCustomer,
     }),


### PR DESCRIPTION
During the rollout of the React 18 upgrade for this MFE in production, a handful of new error instances from an Online Campus Free/Essentials customer surfaced related to a 404 error on the B&R configuration API request, preventing the app from displaying (i.e., the error caught by parent error boundary). A 404 is raised by this API if learners are accessing the Learner Portal where that customer's Admin Portal was not yet visited (which triggers a create of the B&R configuration record).

After investigation, the API request is properly caught in the route loader (`rootLoader`) via `safeEnsureQueryData`, but it doesn't set a `fallbackData` (i.e., `fallbackData=undefined`). As such, when the UI components render and consume that query via `useBrowseAndRequestConfiguration`, having no data set in the query cache from the loader's attempt to make the request means the query is in an "empty"/error state when `useSuspenseQuery` is rendered, which raises any errors to the closest error boundary.

By setting the `fallbackData=null` within `safeEnsureQueryData` for the B&R configuration API request, `useSuspenseQuery` is no longer in an "empty"/error state, and does not surface any errors to the error boundary.

I've verified all other `safeEnsureQueryData` usages define `fallbackData`, as well.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
