### PR TITLE
fix: ensure`fetchEnterpriseLearnerData` and `AppErrorBoundary` handles null authenticated user

### DIFF
--- a/src/components/app/AppErrorBoundary.tsx
+++ b/src/components/app/AppErrorBoundary.tsx
@@ -190,7 +190,7 @@ const AppErrorBoundary = ({
             styling="basic"
             className="small"
             title={intl.formatMessage(messages.viewErrorDetails)}
-            defaultOpen={authenticatedUser.administrator}
+            defaultOpen={authenticatedUser?.administrator}
           >
             <pre>{errorMessageForDisplay}</pre>
             {errorStackForDisplay && <pre>{errorStackForDisplay}</pre>}

--- a/src/components/app/data/services/enterpriseCustomerUser.ts
+++ b/src/components/app/data/services/enterpriseCustomerUser.ts
@@ -104,7 +104,7 @@ Promise<EnterpriseLearnerData> {
   // linked), but the authenticated user is staff, attempt to retrieve enterprise
   // customer metadata from the `/enterprise-customer` LMS API.
   let staffEnterpriseCustomer: EnterpriseCustomer | null = null;
-  if (getAuthenticatedUser().administrator && enterpriseSlug && !foundEnterpriseCustomerUserForCurrentSlug) {
+  if (getAuthenticatedUser()?.administrator && enterpriseSlug && !foundEnterpriseCustomerUserForCurrentSlug) {
     const staffEnterpriseCustomerResult = await fetchEnterpriseCustomerForSlug(enterpriseSlug);
     if (staffEnterpriseCustomerResult?.enableLearnerPortal) {
       staffEnterpriseCustomer = transformEnterpriseCustomer(staffEnterpriseCustomerResult);


### PR DESCRIPTION
# Description

https://2u-internal.atlassian.net/browse/ENT-10495

<img width="865" alt="image" src="https://github.com/user-attachments/assets/24d2c3c7-1d52-40f2-a83f-78550417775f" />

These errors has impacted roughly ~10 sessions of the past week.

This PR addresses the above stack trace to ensure we handle when `authenticatedUser` is missing within `fetchEnterpriseLearnerData` and `AppErrorBoundary`. Note, however, it's still unclear _why_ we're getting into this `fetchEnterpriseLearnerData` code path given the upstream code seems to properly gate this code path when `authenticatedUser` is missing but this change should at least mitigate the immediate error we're seeing.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
