### PR TITLE
fix: add page size to supercede license manager

### DIFF
--- a/src/components/app/data/services/subsidies/subscriptions.js
+++ b/src/components/app/data/services/subsidies/subscriptions.js
@@ -252,6 +252,7 @@ export async function fetchSubscriptions(enterpriseUUID) {
     enterprise_customer_uuid: enterpriseUUID,
     include_revoked: true,
     current_plans_only: false,
+    page_size: 100,
   });
   const url = `${getConfig().LICENSE_MANAGER_URL}/api/v1/learner-licenses/?${queryParams.toString()}`;
   /**

--- a/src/components/app/data/services/subsidies/subscriptions.test.js
+++ b/src/components/app/data/services/subsidies/subscriptions.test.js
@@ -161,6 +161,7 @@ describe('fetchSubscriptions', () => {
       enterprise_customer_uuid: mockEnterpriseId,
       include_revoked: true,
       current_plans_only: false,
+      page_size: 100,
     });
     const SUBSCRIPTIONS_URL = `${APP_CONFIG.LICENSE_MANAGER_URL}/api/v1/learner-licenses/?${queryParams.toString()}`;
     axiosMock.onGet(SUBSCRIPTIONS_URL).reply(200, mockResponse);
@@ -223,6 +224,7 @@ describe('fetchSubscriptions', () => {
       enterprise_customer_uuid: mockEnterpriseId,
       include_revoked: true,
       current_plans_only: false,
+      page_size: 100,
     });
     const SUBSCRIPTIONS_URL = `${APP_CONFIG.LICENSE_MANAGER_URL}/api/v1/learner-licenses/?${queryParams.toString()}`;
     axiosMock.onGet(SUBSCRIPTIONS_URL).reply(200, mockResponse);


### PR DESCRIPTION
Adds a `page_size` query parameter to allow more license request to pass through to the user to supercede a upstream error related to the paginated response from learner licenses.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
