### PR TITLE
feat: add useUserHasLearnerCreditRequestForCourse hook

### DIFF
--- a/src/components/course/data/hooks/hooks.jsx
+++ b/src/components/course/data/hooks/hooks.jsx
@@ -425,6 +425,7 @@ export function useUserHasSubsidyRequestForCourse(courseKey) {
       requests: {
         subscriptionLicenses: subscriptionLicenseRequests,
         couponCodes: couponCodeRequests,
+        // learnerCreditRequests, // Not used directly here to preserve original behavior
       },
     },
   } = useBrowseAndRequest();
@@ -444,6 +445,33 @@ export function useUserHasSubsidyRequestForCourse(courseKey) {
     default:
       return false;
   }
+}
+
+/**
+ * Returns `true` if user has an existing Learner Credit Request for the course
+ * in a relevant state.
+ *
+ * @param {string} courseKey - The key of the course.
+ * @returns {boolean}
+ */
+export function useUserHasLearnerCreditRequestForCourse(courseKey) {
+  const {
+    data: {
+      requests: { learnerCreditRequests },
+    },
+  } = useBrowseAndRequest();
+
+  const LCR_EXISTING_REQUEST_STATES = ['requested', 'approved', 'errored', 'accepted'];
+
+  if (
+    learnerCreditRequests?.some(
+      (request) => request.courseId === courseKey
+        && LCR_EXISTING_REQUEST_STATES.includes(request.state),
+    )
+  ) {
+    return true;
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
Added a new hook to check if a user has a Learner Credit Request (LCR) for a course.
To preserve the original behavior, I did not modify useUserHasSubsidyRequestForCourse, since it’s used in multiple components and changing it could unintentionally disrupt existing functionality.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
