### PR TITLE
feat: set logging custom attribute for is_bff_concurrency_enabled flag

### DIFF
--- a/src/components/app/data/hooks/useEnterpriseLearner.ts
+++ b/src/components/app/data/hooks/useEnterpriseLearner.ts
@@ -35,6 +35,7 @@ export default function useEnterpriseLearner<TData = EnterpriseLearnerData>(
           shouldUpdateActiveEnterpriseCustomerUser: data.shouldUpdateActiveEnterpriseCustomerUser,
           allLinkedEnterpriseCustomerUsers: data.allLinkedEnterpriseCustomerUsers as EnterpriseCustomerUser[],
           enterpriseFeatures: data.enterpriseFeatures as EnterpriseFeatures,
+          enterpriseFeaturesByCustomer: data.enterpriseFeaturesByCustomer as EnterpriseFeaturesByCustomer,
           hasBnrEnabledPolicy: data.hasBnrEnabledPolicy as boolean,
         };
 

--- a/src/components/app/data/queries/utils.ts
+++ b/src/components/app/data/queries/utils.ts
@@ -91,6 +91,7 @@ export async function getEnterpriseLearnerQueryData({
     activeEnterpriseCustomer: null,
     allLinkedEnterpriseCustomerUsers: [],
     enterpriseFeatures: {},
+    enterpriseFeaturesByCustomer: {},
     staffEnterpriseCustomer: null,
     shouldUpdateActiveEnterpriseCustomerUser: false,
     hasBnrEnabledPolicy: false,
@@ -108,6 +109,8 @@ export async function getEnterpriseLearnerQueryData({
       allLinkedEnterpriseCustomerUsers: bffResponse.allLinkedEnterpriseCustomerUsers || [],
       staffEnterpriseCustomer: bffResponse.staffEnterpriseCustomer || null,
       enterpriseFeatures: bffResponse.enterpriseFeatures || {},
+      // @ts-expect-error
+      enterpriseFeaturesByCustomer: bffResponse.enterpriseFeaturesByCustomer || {},
       shouldUpdateActiveEnterpriseCustomerUser: bffResponse.shouldUpdateActiveEnterpriseCustomerUser,
       hasBnrEnabledPolicy: (bffResponse as any).hasBnrEnabledPolicy || false,
     };

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -139,6 +139,12 @@ declare global {
     catalogQuerySearchFiltersEnabled?: boolean;
   };
 
+  type EnterpriseFeaturesByCustomer = {
+    [key: string]: {
+      enterpriseLearnerBffConcurrentRequests?: boolean;
+    };
+  };
+
   type EnterpriseCustomerUserRaw = enterpriseAccessOpenApi.components['schemas']['EnterpriseCustomerUser'];
   type EnterpriseCustomerUser = CamelCasedPropertiesDeep<EnterpriseCustomerUserRaw>;
 
@@ -148,6 +154,7 @@ declare global {
     allLinkedEnterpriseCustomerUsers: EnterpriseCustomerUser[];
     staffEnterpriseCustomer: EnterpriseCustomer | null;
     enterpriseFeatures: EnterpriseFeatures;
+    enterpriseFeaturesByCustomer: EnterpriseFeaturesByCustomer;
     shouldUpdateActiveEnterpriseCustomerUser: boolean;
     hasBnrEnabledPolicy: boolean;
   };


### PR DESCRIPTION
> [!IMPORTANT]  
> **Depends on https://github.com/openedx/enterprise-access/pull/734 (for exposing enterprise-specific waffle-based feature flags in BFF API response)**

Through https://github.com/openedx/enterprise-access/pull/734, we will be experimenting with a performance improvement to adopt concurrent network requests within the BFF API layer supporting this frontend. There is now a customer-specific Waffle-based feature flag exposed in the BFF API around whether the concurrent network requests should be enabled or not.

This PR sets a custom attribute in the logging service (e.g., Datadog) for whether the BFF concurrency feature is enabled for the user/customer. By adding the custom attribute, we can use it to filter/compare sessions, etc. for users who had requests with concurrency vs. without concurrency to better understand performance impacts.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
