### PR TITLE
fix: handle multiple re-renders on course about page

### DIFF
--- a/src/components/app/data/hooks/useCourseCanRequestEligibility.ts
+++ b/src/components/app/data/hooks/useCourseCanRequestEligibility.ts
@@ -11,5 +11,7 @@ export default function useCourseCanRequestEligibility() {
   const { data: enterpriseCustomer } = useEnterpriseCustomer<EnterpriseCustomer>();
   const { courseKey } = useParams();
 
-  return useQuery(queryCanRequest(enterpriseCustomer.uuid, courseKey!));
+  return useQuery({
+    ...queryCanRequest(enterpriseCustomer.uuid, courseKey!),
+  });
 }

--- a/src/components/course/data/hooks/hooks.jsx
+++ b/src/components/course/data/hooks/hooks.jsx
@@ -34,22 +34,22 @@ import { SUBSIDY_TYPE } from '../../../../constants';
 import {
   COUPON_CODE_SUBSIDY_TYPE,
   determineAllocatedAssignmentsForCourse,
+  LEARNER_CREDIT_SUBSIDY_TYPE,
   LICENSE_SUBSIDY_TYPE,
   useBrowseAndRequest,
   useBrowseAndRequestConfiguration,
   useCatalogsForSubsidyRequests,
+  useCourseCanRequestEligibility,
   useCourseMetadata,
   useCourseRedemptionEligibility,
   useEnterpriseCustomer,
-  useRedeemablePolicies,
   useEnterpriseCustomerContainsContentSuspense,
-  LEARNER_CREDIT_SUBSIDY_TYPE,
+  useRedeemablePolicies,
 } from '../../../app/data';
 import { CourseContext } from '../../CourseContextProvider';
 import { POLICY_TYPES } from '../../../enterprise-user-subsidy/enterprise-offers/data/constants';
 import useUserSubsidyApplicableToCourse from './useUserSubsidyApplicableToCourse';
 import useCourseListPrice from './useCourseListPrice';
-import useCourseRequest from './useCourseRequest';
 
 // How long to delay an event, so that we allow enough time for any async analytics event call to resolve
 const CLICK_DELAY_MS = 300; // 300ms replicates Segment's ``trackLink`` function
@@ -578,7 +578,7 @@ export function useBrowseAndRequestCatalogsApplicableToCourse() {
 }
 
 export function useCanUserRequestSubsidyForCourse() {
-  const { data: canRequestLC } = useCourseRequest();
+  const { data: canRequestLC } = useCourseCanRequestEligibility();
 
   const { data: browseAndRequestConfiguration } = useBrowseAndRequestConfiguration();
   const subsidyRequestCatalogsApplicableToCourse = useBrowseAndRequestCatalogsApplicableToCourse();

--- a/src/components/course/data/hooks/useUserSubsidyApplicableToCourse.js
+++ b/src/components/course/data/hooks/useUserSubsidyApplicableToCourse.js
@@ -5,9 +5,9 @@ import {
   findCouponCodeForCourse,
   getSubsidyToApplyForCourse,
   useCouponCodes,
+  useCourseCanRequestEligibility,
   useCourseMetadata,
   useCourseRedemptionEligibility,
-  useCourseCanRequestEligibility,
   useEnterpriseCustomer,
   useEnterpriseCustomerContainsContentSuspense,
   useEnterpriseOffers,
@@ -46,6 +46,7 @@ const useUserSubsidyApplicableToCourse = () => {
   } = useEnterpriseCustomer({
     select: resolvedTransformedEnterpriseCustomerData,
   });
+  const { data: canRequestData, isPending: pendingRequest, isLoading: loadingError } = useCourseCanRequestEligibility();
   const { data: courseListPrice } = useCourseListPrice();
   const {
     data: {
@@ -86,7 +87,6 @@ const useUserSubsidyApplicableToCourse = () => {
  * This is used to determine if the user can request Learner Credit for the course and returns:
  * { can_request, reason, requestable_subsidy_access_policy }
  */
-  const { data: canRequestData, isPending: isCanRequestPending } = useCourseCanRequestEligibility();
 
   const isSubscriptionLicenseApplicable = determineSubscriptionLicenseApplicable(
     subscriptionLicense,
@@ -149,6 +149,10 @@ const useUserSubsidyApplicableToCourse = () => {
       userSubsidyApplicableToCourse?.availableCourseRuns || onlyUnrestrictedCourseRuns
     );
   }
+  let localPending = true;
+  if (!(isPending && pendingRequest)) {
+    localPending = false;
+  }
 
   // --- Learner Credit B&R ---
   const canRequestLearnerCredit = !!canRequestData?.canRequest;
@@ -158,7 +162,7 @@ const useUserSubsidyApplicableToCourse = () => {
   return useMemo(() => ({
     userSubsidyApplicableToCourse,
     missingUserSubsidyReason,
-    isPending: isPending || isCanRequestPending || false,
+    isPending: localPending,
     // Learner Credit B&R fields:
     canRequestLearnerCredit,
     learnerCreditRequestablePolicy,
@@ -167,7 +171,6 @@ const useUserSubsidyApplicableToCourse = () => {
     userSubsidyApplicableToCourse,
     missingUserSubsidyReason,
     isPending,
-    isCanRequestPending,
     canRequestLearnerCredit,
     learnerCreditRequestablePolicy,
     learnerCreditRequestReason,


### PR DESCRIPTION
In the course about page, we are seeing multiple API calls to both the can-redeem and can-request endpoint. In order to reproduce, enable a customer with no active policies and coupon codes with an active coupon available to redeem.

It results in infinite API call. 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
