### PR TITLE
fix: remove nested `useCourseUpgradeData` hooks for audit upgrades

### DIFF
--- a/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/InProgressCourseCard.jsx
@@ -13,7 +13,7 @@ import Notification from './Notification';
 
 import UpgradeCourseButton from './UpgradeCourseButton';
 import { EXECUTIVE_EDUCATION_COURSE_MODES, LICENSE_SUBSIDY_TYPE, useEnterpriseCustomer } from '../../../../app/data';
-import { useCourseUpgradeData, useUpdateCourseEnrollmentStatus } from '../data';
+import { useCourseUpgradeData, useUpdateCourseEnrollmentStatus, useUpgradeCourseButton } from '../data';
 import { COURSE_STATUSES } from '../../../../../constants';
 import CourseEnrollmentsContext from '../CourseEnrollmentsContext';
 
@@ -206,14 +206,25 @@ export const UpgradeableInProgressCourseCard = (props) => {
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
 
   const {
+    confirmationButtonState,
+    setConfirmationButtonState,
+    handleRedeem,
+    handleRedemptionSuccess,
+    handleRedemptionError,
+  } = useUpgradeCourseButton();
+  const {
     subsidyForCourse,
     hasUpgradeAndConfirm,
     courseRunPrice,
     isPending,
+    redeem,
   } = useCourseUpgradeData({
     courseRunKey: courseRunId,
     enrollBy,
     mode,
+    onRedeem: handleRedeem,
+    onRedeemSuccess: handleRedemptionSuccess,
+    onRedeemError: handleRedemptionError,
   });
 
   const isExecutiveEducation = EXECUTIVE_EDUCATION_COURSE_MODES.includes(mode);
@@ -229,8 +240,11 @@ export const UpgradeableInProgressCourseCard = (props) => {
           variant={isExecutiveEducation ? 'inverse-brand' : 'brand'}
           title={title}
           courseRunKey={courseRunId}
-          mode={mode}
-          enrollBy={enrollBy}
+          courseRunPrice={courseRunPrice}
+          subsidyForCourse={subsidyForCourse}
+          redeem={redeem}
+          confirmationButtonState={confirmationButtonState}
+          onConfirmModalClose={() => setConfirmationButtonState('default')}
         />
       )}
       <ContinueLearningButton

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/UpgradeCourseButton.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/UpgradeCourseButton.jsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Button, OverlayTrigger, Tooltip } from '@openedx/paragon';
-import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { useEnterpriseCustomer, useCouponCodes } from '../../../../app/data';
-import { useCourseUpgradeData } from '../data';
 import EnrollModal from '../../../../course/EnrollModal';
 
 const messages = defineMessages({
@@ -64,52 +63,20 @@ OverlayTriggerWrapper.propTypes = {
  */
 const UpgradeCourseButton = ({
   className,
-  title,
   variant,
+  title,
   courseRunKey,
-  mode,
-  enrollBy,
+  courseRunPrice,
+  subsidyForCourse,
+  redeem,
+  confirmationButtonState,
+  onConfirmModalClose,
 }) => {
   const intl = useIntl();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [confirmationButtonState, setConfirmationButtonState] = useState('default');
 
   const { data: enterpriseCustomer } = useEnterpriseCustomer();
   const { data: { couponCodeRedemptionCount } } = useCouponCodes();
-
-  const handleRedeem = () => {
-    setConfirmationButtonState('pending');
-    sendEnterpriseTrackEvent(
-      enterpriseCustomer.uuid,
-      'edx.ui.enterprise.learner_portal.dashboard.course.upgrade_button.confirmed',
-    );
-  };
-
-  const handleRedemptionSuccess = async (transaction) => {
-    if (transaction?.state !== 'committed') {
-      return;
-    }
-    setConfirmationButtonState('complete');
-    const { coursewareUrl } = transaction;
-    global.location.assign(coursewareUrl);
-  };
-
-  const handleRedemptionError = () => {
-    setConfirmationButtonState('error');
-  };
-
-  const {
-    subsidyForCourse,
-    courseRunPrice,
-    redeem,
-  } = useCourseUpgradeData({
-    courseRunKey,
-    mode,
-    enrollBy,
-    onRedeem: handleRedeem,
-    onRedeemSuccess: handleRedemptionSuccess,
-    onRedeemError: handleRedemptionError,
-  });
 
   const handleClick = () => {
     setIsModalOpen(true);
@@ -128,7 +95,7 @@ const UpgradeCourseButton = ({
 
   const handleModalClose = () => {
     setIsModalOpen(false);
-    setConfirmationButtonState('default');
+    onConfirmModalClose();
   };
 
   return (
@@ -170,14 +137,19 @@ UpgradeCourseButton.propTypes = {
   variant: PropTypes.string,
   title: PropTypes.string.isRequired,
   courseRunKey: PropTypes.string.isRequired,
-  mode: PropTypes.string.isRequired,
-  enrollBy: PropTypes.string,
+  courseRunPrice: PropTypes.number,
+  subsidyForCourse: PropTypes.shape({
+    subsidyType: PropTypes.string,
+    redemptionUrl: PropTypes.string,
+  }),
+  redeem: PropTypes.func,
+  confirmationButtonState: PropTypes.string,
+  onConfirmModalClose: PropTypes.func,
 };
 
 UpgradeCourseButton.defaultProps = {
   className: undefined,
   variant: 'outline-primary',
-  enrollBy: undefined,
 };
 
 export default UpgradeCourseButton;

--- a/src/components/dashboard/main-content/course-enrollments/course-cards/tests/InProgressCourseCard.test.jsx
+++ b/src/components/dashboard/main-content/course-enrollments/course-cards/tests/InProgressCourseCard.test.jsx
@@ -163,7 +163,7 @@ describe('<InProgressCourseCard />', () => {
     });
     renderWithRouter(<InProgressCourseCardWrapper Component={UpgradeableInProgressCourseCard} {...baseProps} />);
 
-    const useCourseUpgradeDataArgs = useCourseUpgradeData.mock.calls[1][0];
+    const useCourseUpgradeDataArgs = useCourseUpgradeData.mock.calls[0][0];
     expect(useCourseUpgradeDataArgs).toEqual(
       expect.objectContaining({
         onRedeem: expect.any(Function),

--- a/src/components/dashboard/main-content/course-enrollments/data/hooks.js
+++ b/src/components/dashboard/main-content/course-enrollments/data/hooks.js
@@ -137,13 +137,9 @@ export const useCourseUpgradeData = ({
     userEnrollments: enterpriseCourseEnrollmentsMetadata.enterpriseCourseEnrollments,
   });
 
-  const hasPendingQueries = useMemo(() => (
+  const hasPendingQueries = (
     isCustomerContainsContentPending || isLearnerCreditMetadataPending || isCourseRunDetailsPending
-  ), [
-    isCustomerContainsContentPending,
-    isLearnerCreditMetadataPending,
-    isCourseRunDetailsPending,
-  ]);
+  );
 
   return useMemo(() => {
     const defaultReturn = {


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/browse/ENT-10510

Since the React 18 upgrade, when an enterprise learner had an audit enrollment and a code available but no active subsidy access policies (learner credit), the audit->verified skeleton loader was persistent and never going away for the learner. While replicating the issue, it was observed the `can-redeem` API was constantly being re-fetched.

This bug was not widespread given we only have ~8 legacy codes customers remaining, and requires to be enrolled in audit (atypical for enterprise).

The fix introduced in this PR removes the usage of `useCourseUpgradeData` from `UpgradeCourseButton` in favor of prop drilling the requisite data into `UpgradeCourseButton` from its parent component `UpgradeableInProgressCourseCard`.

### Before

Stuck on skeleton loading due to constant request loop against `can-redeem`.

![image](https://github.com/user-attachments/assets/55d6f19e-fdff-4070-9e49-e7ffde6fb43b)

### After

Upgrade-able for codes again.

<img width="778" alt="image" src="https://github.com/user-attachments/assets/ad37e022-f098-4bf3-b41d-723b93d75e6e" />

<img width="1197" alt="image" src="https://github.com/user-attachments/assets/8e6456d8-a651-4bb1-80bd-7cf677a0ab3b" />


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
