### PR TITLE
fix: prioritize the redemption over request

### DIFF
--- a/src/components/course/course-header/data/hooks/useCourseRunCardAction.jsx
+++ b/src/components/course/course-header/data/hooks/useCourseRunCardAction.jsx
@@ -88,7 +88,7 @@ const useCourseRunCardAction = ({
     );
   }
 
-  if (userCanRequestSubsidyForCourse) {
+  if (userCanRequestSubsidyForCourse && !userSubsidyApplicableToCourse) {
     // User can request a subsidy for the course, but is not enrolled so
     // hide the "Enroll" CTA in favor of the "Request enrollment" CTA below
     // the course run cards.


### PR DESCRIPTION
# Description 
Previously, the enrollment logic was hiding the "Enroll" button if a learner was eligible to request a subsidy, even when they also had a direct, redeemable subsidy (like a course assignment) available. This prevented learners from immediately enrolling in courses they already had access to.

This change adjusts the priority of the enrollment actions. The logic now checks for any applicable, redeemable subsidy before it checks for the ability to request one.

As a result, if a learner has any subsidy that allows for direct enrollment, the "Enroll" button will now be correctly displayed, taking precedence over the "Request" flow.


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
