### PR TITLE
chore: Remove feature flag for secured algolia api key

### DIFF
--- a/src/components/app/data/hooks/useAlgoliaSearch.test.tsx
+++ b/src/components/app/data/hooks/useAlgoliaSearch.test.tsx
@@ -42,9 +42,7 @@ const mockedUseEnterpriseCustomer = useEnterpriseCustomer as jest.Mock;
 const mockedUseEnterpriseFeatures = useEnterpriseFeatures as jest.Mock;
 
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
-const mockEnterpriseFeatures = {
-  catalogQuerySearchFiltersEnabled: true,
-};
+
 const mockCatalogUuidsToCatalogQueryUuids = Array.from({ length: 3 }, () => [uuidv4(), uuidv4()]);
 const mockEmptyBaseAlgoliaData = {
   algolia: {
@@ -151,9 +149,6 @@ describe('useAlgoliaSearch', () => {
     mockedUseEnterpriseCustomer.mockReturnValue({
       data: mockEnterpriseCustomer,
     });
-    mockedUseEnterpriseFeatures.mockReturnValue({
-      data: mockEnterpriseFeatures,
-    });
     (fetchEnterpriseLearnerDashboard as jest.Mock).mockResolvedValue(mockBaseBFFData);
     (fetchEnterpriseLearnerSearch as jest.Mock).mockResolvedValue(mockBFFSearchData);
     (fetchEnterpriseLearnerAcademy as jest.Mock).mockResolvedValue(mockBFFAcademyData);
@@ -169,7 +164,7 @@ describe('useAlgoliaSearch', () => {
         APP_CONFIG.ALGOLIA_INDEX_NAME,
         APP_CONFIG.ALGOLIA_INDEX_NAME_JOBS,
       ],
-      isCatalogQueryFiltersEnabled: [false, true],
+      isCatalogQueryFiltersEnabled: [true],
     }),
     // BFF Enabled Routes
     ...generateTestPermutations({
@@ -184,7 +179,7 @@ describe('useAlgoliaSearch', () => {
         APP_CONFIG.ALGOLIA_INDEX_NAME,
         APP_CONFIG.ALGOLIA_INDEX_NAME_JOBS,
       ],
-      isCatalogQueryFiltersEnabled: [false, true],
+      isCatalogQueryFiltersEnabled: [true],
     }),
   ])('should handle resolved value correctly for based on route (%s)', async ({
     isMatchedBFFRoute,

--- a/src/components/app/data/hooks/useAlgoliaSearch.ts
+++ b/src/components/app/data/hooks/useAlgoliaSearch.ts
@@ -6,7 +6,6 @@ import { SearchClient, SearchIndex } from 'algoliasearch/lite';
 import { UseSuspenseQueryResult } from '@tanstack/react-query';
 import { useSuspenseBFF } from './useBFF';
 import useEnterpriseCustomer from './useEnterpriseCustomer';
-import useEnterpriseFeatures from './useEnterpriseFeatures';
 import { queryDefaultEmptyFallback } from '../queries';
 
 type AlgoliaFeatureFlags = {
@@ -92,12 +91,8 @@ const useSecuredAlgoliaMetadata = (indexName: string | null): SecuredAlgoliaApiM
   const unsupportedSecuredAlgoliaIndices = [config.ALGOLIA_INDEX_NAME_JOBS];
   const enterpriseCustomerResult = useEnterpriseCustomer();
   const enterpriseCustomer = enterpriseCustomerResult.data as EnterpriseCustomer;
-  const enterpriseFeaturesResult = useEnterpriseFeatures();
-  const enterpriseFeatures = enterpriseFeaturesResult.data as EnterpriseFeatures;
-  // Enable catalog filters only if the waffle flag is enabled and Algolia app id is defined
-  const isCatalogQueryFiltersEnabled = !!(
-    enterpriseFeatures?.catalogQuerySearchFiltersEnabled && config.ALGOLIA_APP_ID
-  );
+  // Enable catalog filters only if the Algolia app id is defined
+  const isCatalogQueryFiltersEnabled = !!config.ALGOLIA_APP_ID;
   // An index is "supported" if it contains customer-specific data.
   // Supported indices should use the secured API key; unsupported indexes
   // (e.g., public jobs index) will default to the fallback key.

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -136,7 +136,6 @@ declare global {
 
   type EnterpriseFeatures = {
     enterpriseLearnerBffEnabled?: boolean;
-    catalogQuerySearchFiltersEnabled?: boolean;
   };
 
   type EnterpriseCustomerUserRaw = enterpriseAccessOpenApi.components['schemas']['EnterpriseCustomerUser'];


### PR DESCRIPTION
Removing feature flag related to the secured_algolia_api_key which validated if the enterprise customer had the catalogQuerySearchFiltersEnabled enabled. The feature is currently enabled for all customers deprecating the usage of the waffle flag itself.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
