### PR TITLE
fix: do not show 'Request Enrollment' CTA on an archived course

### DIFF
--- a/src/components/course/course-header/CourseHeader.jsx
+++ b/src/components/course/course-header/CourseHeader.jsx
@@ -120,7 +120,7 @@ const CourseHeader = () => {
             {containsContentItems && (
               <>
                 <CourseRunCards />
-                <SubsidyRequestButton />
+                {!isCourseArchived && <SubsidyRequestButton />}
               </>
             )}
           </Col>

--- a/src/components/course/course-header/tests/CourseHeader.test.jsx
+++ b/src/components/course/course-header/tests/CourseHeader.test.jsx
@@ -369,6 +369,30 @@ describe('<CourseHeader />', () => {
     expect(screen.getByText('This course is archived.')).toBeInTheDocument();
   });
 
+  test('renders SubsidyRequestButton for non-archived courses', () => {
+    renderWithRouterProvider({
+      path: '/:enterpriseSlug/course/:courseKey',
+      element: <CourseHeaderWrapper />,
+    }, {
+      initialEntries: [`/${mockEnterpriseCustomer.slug}/course/${mockCourseMetadata.key}`],
+    });
+
+    expect(screen.getByText('SubsidyRequestButton')).toBeInTheDocument();
+  });
+
+  test('does not render SubsidyRequestButton for archived courses', () => {
+    useCourseMetadata.mockReturnValue({ data: mockArchivedCourseMetadata });
+
+    renderWithRouterProvider({
+      path: '/:enterpriseSlug/course/:courseKey',
+      element: <CourseHeaderWrapper />,
+    }, {
+      initialEntries: [`/${mockEnterpriseCustomer.slug}/course/${mockArchivedCourseMetadata.key}`],
+    });
+
+    expect(screen.queryByText('SubsidyRequestButton')).not.toBeInTheDocument();
+  });
+
   test('renders view course materials button if previously enrolled', () => {
     useCourseMetadata.mockReturnValue({ data: mockArchivedCourseMetadata });
     useEnterpriseCourseEnrollments.mockReturnValue({


### PR DESCRIPTION
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
