### PR TITLE
feat: do not retry failed ecommerce calls

### DIFF
--- a/src/components/app/data/hooks/useBrowseAndRequest.ts
+++ b/src/components/app/data/hooks/useBrowseAndRequest.ts
@@ -84,6 +84,7 @@ export function useCouponCodeRequests<TData = CouponCodeRequest[], TSelectData =
   return useSuspenseQuery(
     queryOptions({
       ...queryCouponCodeRequests(enterpriseCustomer.uuid, authenticatedUser.email),
+      retry: false,
       select: (data) => {
         if (select) {
           return select(data as TData);

--- a/src/components/app/data/hooks/useCouponCodes.ts
+++ b/src/components/app/data/hooks/useCouponCodes.ts
@@ -18,6 +18,7 @@ export default function useCouponCodes<TData = CouponCodes, TSelectData = TData>
   return useSuspenseQuery(
     queryOptions({
       ...queryCouponCodes(enterpriseCustomer.uuid),
+      retry: false,
       select: (data) => {
         if (select) {
           return select(data as TData);

--- a/src/components/app/data/hooks/useEnterpriseOffers.ts
+++ b/src/components/app/data/hooks/useEnterpriseOffers.ts
@@ -7,6 +7,7 @@ export default function useEnterpriseOffers() {
   return useSuspenseQuery(
     queryOptions({
       ...queryEnterpriseLearnerOffers(enterpriseCustomer.uuid),
+      retry: false,
     }),
   );
 }

--- a/src/components/app/data/queries/utils.ts
+++ b/src/components/app/data/queries/utils.ts
@@ -130,6 +130,7 @@ type SafeEnsureQueryDataArgs<TData = unknown> = {
   query: {
     queryKey: QueryKey;
     queryFn: QueryFunction<TData>;
+    retry?: boolean | number;
   };
   shouldLogError?: boolean | ((err: Error) => boolean);
   fallbackData?: TData;
@@ -222,7 +223,10 @@ export async function safeEnsureQueryDataCouponCodes({
 }) {
   return safeEnsureQueryData({
     queryClient,
-    query: queryCouponCodes(enterpriseCustomer.uuid),
+    query: {
+      ...queryCouponCodes(enterpriseCustomer.uuid),
+      retry: false,
+    },
     fallbackData: {
       couponsOverview: [],
       couponCodeAssignments: [],
@@ -248,7 +252,10 @@ export async function safeEnsureQueryDataEnterpriseOffers({
 }) {
   return safeEnsureQueryData({
     queryClient,
-    query: queryEnterpriseLearnerOffers(enterpriseCustomer.uuid),
+    query: {
+      ...queryEnterpriseLearnerOffers(enterpriseCustomer.uuid),
+      retry: false,
+    },
     fallbackData: {
       enterpriseOffers: [],
       currentEnterpriseOffers: [],
@@ -279,7 +286,10 @@ export async function safeEnsureQueryDataCouponCodeRequests({
 }) {
   return safeEnsureQueryData({
     queryClient,
-    query: queryCouponCodeRequests(enterpriseCustomer.uuid, authenticatedUser.email),
+    query: {
+      ...queryCouponCodeRequests(enterpriseCustomer.uuid, authenticatedUser.email),
+      retry: false,
+    },
     fallbackData: [],
   });
 }


### PR DESCRIPTION
Tested on stage with https://localhost.stage.edx.org:8734/ 

  Applied retry: false to All Ecommerce Query Call Sites:

  1. React Hooks (Component Level):
  - useCouponCodes in /src/components/app/data/hooks/useCouponCodes.ts
  - useEnterpriseOffers in /src/components/app/data/hooks/useEnterpriseOffers.ts
  - useCouponCodeRequests in /src/components/app/data/hooks/useBrowseAndRequest.ts

  2. Route Loaders (Prefetch Level):
  - safeEnsureQueryDataCouponCodes in /src/components/app/data/queries/utils.ts
  - safeEnsureQueryDataEnterpriseOffers in /src/components/app/data/queries/utils.ts
  - safeEnsureQueryDataCouponCodeRequests in /src/components/app/data/queries/utils.ts

  Where These Queries Are Called:

  Route Loaders:
  - rootLoader (dashboard/main pages)
  - courseLoader (course detail pages)
  - externalCourseEnrollmentLoader (external course enrollment)

  React Components:
  - Dashboard sidebar components
  - Course enrollment components
  - Browse and request components

  Expected Behavior Now:

  When you block the ecommerce URLs in browser devtools, each query should now fail immediately instead of retrying. You should see exactly 2 failures per query (1 from route loader +
  1 from component hook) instead of the previous 6 failures per query (3 retries × 2 call sites).

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
