### PR TITLE
build: remove unused reactifex packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,17 +36,6 @@ detect_changed_source_translations:
 	# Checking for changed translations...
 	git diff --exit-code $(i18n)
 
-# Pushes translations to Transifex.  You must run make extract_translations first.
-push_translations:
-	# Pushing strings to Transifex...
-	tx push -s
-	# Fetching hashes from Transifex...
-	./node_modules/@edx/reactifex/bash_scripts/get_hashed_strings_v3.sh
-	# Writing out comments to file...
-	$(transifex_utils) $(transifex_temp) --comments --v3-scripts-path
-	# Pushing comments to Transifex...
-	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
-
 pull_translations:
 	rm -rf src/i18n/messages
 	mkdir src/i18n/messages

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@edx/frontend-enterprise-utils": "^10.0.0",
         "@edx/frontend-platform": "^8.3.4",
         "@edx/openedx-atlas": "^0.7.0",
-        "@edx/reactifex": "^2.2.0",
         "@loadable/component": "^5.16.4",
         "@lukemorales/query-key-factory": "^1.3.4",
         "@openedx/frontend-slot-footer": "^1.2.1",
@@ -87,7 +86,6 @@
         "openapi-typescript": "^6.7.6",
         "prettier": "^2.8.8",
         "react-test-renderer": "^18.3.1",
-        "reactifex": "^1.1.1",
         "resize-observer-polyfill": "^1.5.1",
         "rosie": "^2.1.1",
         "ts-loader": "^9.5.2"
@@ -2400,28 +2398,6 @@
       "license": "AGPL-3.0",
       "bin": {
         "atlas": "atlas"
-      }
-    },
-    "node_modules/@edx/reactifex": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-2.2.0.tgz",
-      "integrity": "sha512-vyGDtx3BwCr6Gjbm4y6gJ8Bzc2TOSNBlBa2hMerz59HoXaot14MihxxiDU+JDNybGLLcKDBiK511bOi/77i1lw==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "yargs": "^17.1.1"
-      },
-      "bin": {
-        "edx_reactifex": "main.js"
-      }
-    },
-    "node_modules/@edx/reactifex/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@edx/typescript-config": {
@@ -17895,16 +17871,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/reactifex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reactifex/-/reactifex-1.1.1.tgz",
-      "integrity": "sha512-HH2N/b5tRxh7ypIgCRsiBl/CTxRkTEPf9DhIstaM6hne4WiwM5/bBbWuvVlRZc/i3FdqZED3pZ//6n4mtxma4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "reactifex": "main.js"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@edx/frontend-enterprise-utils": "^10.0.0",
     "@edx/frontend-platform": "^8.3.4",
     "@edx/openedx-atlas": "^0.7.0",
-    "@edx/reactifex": "^2.2.0",
     "@loadable/component": "^5.16.4",
     "@lukemorales/query-key-factory": "^1.3.4",
     "@openedx/frontend-slot-footer": "^1.2.1",
@@ -85,7 +84,6 @@
     "openapi-typescript": "^6.7.6",
     "prettier": "^2.8.8",
     "react-test-renderer": "^18.3.1",
-    "reactifex": "^1.1.1",
     "resize-observer-polyfill": "^1.5.1",
     "rosie": "^2.1.1",
     "ts-loader": "^9.5.2"


### PR DESCRIPTION
Remove reactifex and/or @edx/reactifex packages from devDependencies
as they are no longer needed. Translation extraction functionality has
been verified to work correctly without these dependencies.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
