### PR TITLE
fix: deprecate use of offers

### DIFF
--- a/src/components/app/data/hooks/useEnterpriseOffers.test.jsx
+++ b/src/components/app/data/hooks/useEnterpriseOffers.test.jsx
@@ -14,17 +14,15 @@ jest.mock('../services', () => ({
   fetchEnterpriseOffers: jest.fn().mockResolvedValue(null),
 }));
 const mockEnterpriseCustomer = enterpriseCustomerFactory();
-const mockEnterpriseOffers = [{
-  discount_value: 100,
-  end_datetime: '2023-01-06T00:00:00Z',
-  enterprise_catalog_uuid: 'uuid',
-  id: 1,
-  max_discount: 200,
-  remaining_balance: 200,
-  start_datetime: '2022-06-09T00:00:00Z',
-  usage_type: 'Percentage',
-  is_current: true,
-}];
+
+const mockDeprecatedReturn = {
+  enterpriseOffers: [],
+  currentEnterpriseOffers: [],
+  canEnrollWithEnterpriseOffers: false,
+  hasCurrentEnterpriseOffers: false,
+  hasLowEnterpriseOffersBalance: false,
+  hasNoEnterpriseOffersBalance: true,
+};
 
 describe('useEnterpriseOffers', () => {
   const Wrapper = ({ children }) => (
@@ -37,14 +35,14 @@ describe('useEnterpriseOffers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useEnterpriseCustomer.mockReturnValue({ data: mockEnterpriseCustomer });
-    fetchEnterpriseOffers.mockResolvedValue(mockEnterpriseOffers);
+    fetchEnterpriseOffers.mockResolvedValue(mockDeprecatedReturn);
   });
-  it('should handle resolved value correctly', async () => {
+  it('should handle resolved value correctly related to deprecation', async () => {
     const { result } = renderHook(() => useEnterpriseOffers(), { wrapper: Wrapper });
     await waitFor(() => {
       expect(result.current).toEqual(
         expect.objectContaining({
-          data: mockEnterpriseOffers,
+          data: mockDeprecatedReturn,
           isPending: false,
           isFetching: false,
         }),

--- a/src/components/app/data/hooks/useEnterpriseOffers.ts
+++ b/src/components/app/data/hooks/useEnterpriseOffers.ts
@@ -6,7 +6,18 @@ export default function useEnterpriseOffers() {
   const { data: enterpriseCustomer } = useEnterpriseCustomer<EnterpriseCustomer>();
   return useSuspenseQuery(
     queryOptions({
-      ...queryEnterpriseLearnerOffers(enterpriseCustomer.uuid),
+      queryKey: queryEnterpriseLearnerOffers(enterpriseCustomer.uuid).queryKey,
+      queryFn: () => (
+        {
+          enterpriseOffers: [],
+          currentEnterpriseOffers: [],
+          // Note: We are hard coding to false since offers are now deprecated as of 09/15/2025, HU
+          canEnrollWithEnterpriseOffers: false,
+          hasCurrentEnterpriseOffers: false,
+          hasLowEnterpriseOffersBalance: false,
+          hasNoEnterpriseOffersBalance: true,
+        }
+      ),
       retry: false,
     }),
   );

--- a/src/components/app/data/queries/utils.test.ts
+++ b/src/components/app/data/queries/utils.test.ts
@@ -1,0 +1,153 @@
+import { QueryClient } from '@tanstack/react-query';
+import { safeEnsureQueryDataEnterpriseOffers } from './utils';
+import { queryEnterpriseLearnerOffers } from './queries';
+
+// Mock the queries module
+jest.mock('./queries', () => ({
+  queryEnterpriseLearnerOffers: jest.fn(),
+}));
+
+const mockQueryEnterpriseLearnerOffers = queryEnterpriseLearnerOffers as jest.MockedFunction<typeof queryEnterpriseLearnerOffers>;
+
+describe('safeEnsureQueryDataEnterpriseOffers', () => {
+  let queryClient: QueryClient;
+  let enterpriseCustomer: { uuid: string };
+  let mockEnsureQueryData: jest.SpyInstance;
+  let mockSetQueryData: jest.SpyInstance;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    enterpriseCustomer = { uuid: 'test-enterprise-uuid' };
+
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Mock QueryClient methods
+    mockEnsureQueryData = jest.spyOn(queryClient, 'ensureQueryData');
+    mockSetQueryData = jest.spyOn(queryClient, 'setQueryData');
+
+    // Setup default mock return values
+    mockQueryEnterpriseLearnerOffers.mockReturnValue({
+      queryKey: ['enterprise', 'test-enterprise-uuid', 'subsidies', 'enterpriseOffers'],
+      queryFn: jest.fn(),
+    });
+  });
+
+  it('should return hardcoded data when query succeeds', async () => {
+    const expectedReturnValue = {
+      enterpriseOffers: [],
+      currentEnterpriseOffers: [],
+      canEnrollWithEnterpriseOffers: false,
+      hasCurrentEnterpriseOffers: false,
+      hasLowEnterpriseOffersBalance: false,
+      hasNoEnterpriseOffersBalance: true,
+    };
+
+    mockEnsureQueryData.mockResolvedValue(expectedReturnValue);
+
+    const result = await safeEnsureQueryDataEnterpriseOffers({
+      queryClient,
+      enterpriseCustomer,
+    });
+
+    // Verify queryEnterpriseLearnerOffers was called with correct UUID
+    expect(mockQueryEnterpriseLearnerOffers).toHaveBeenCalledWith('test-enterprise-uuid');
+
+    // Verify ensureQueryData was called with correct query configuration
+    expect(mockEnsureQueryData).toHaveBeenCalledWith({
+      queryKey: ['enterprise', 'test-enterprise-uuid', 'subsidies', 'enterpriseOffers'],
+      queryFn: expect.any(Function),
+      retry: false,
+    });
+
+    expect(result).toEqual(expectedReturnValue);
+  });
+
+  it('should return hardcoded data from queryFn', async () => {
+    let capturedQuery: any;
+
+    mockEnsureQueryData.mockImplementation(async (query) => {
+      capturedQuery = query;
+      return query.queryFn();
+    });
+
+    const result = await safeEnsureQueryDataEnterpriseOffers({
+      queryClient,
+      enterpriseCustomer,
+    });
+
+    // Test the queryFn returns hardcoded data
+    expect(result).toEqual({
+      enterpriseOffers: [],
+      currentEnterpriseOffers: [],
+      canEnrollWithEnterpriseOffers: false,
+      hasCurrentEnterpriseOffers: false,
+      hasLowEnterpriseOffersBalance: false,
+      hasNoEnterpriseOffersBalance: true,
+    });
+
+    // Verify retry is false
+    expect(capturedQuery.retry).toBe(false);
+  });
+
+  it('should handle different enterprise customer UUID', async () => {
+    const differentEnterpriseCustomer = { uuid: 'different-uuid' };
+
+    mockQueryEnterpriseLearnerOffers.mockReturnValue({
+      queryKey: ['enterprise', 'different-uuid', 'subsidies', 'enterpriseOffers'],
+      queryFn: jest.fn(),
+    });
+
+    mockEnsureQueryData.mockResolvedValue({});
+
+    await safeEnsureQueryDataEnterpriseOffers({
+      queryClient,
+      enterpriseCustomer: differentEnterpriseCustomer,
+    });
+
+    expect(mockQueryEnterpriseLearnerOffers).toHaveBeenCalledWith('different-uuid');
+    expect(mockEnsureQueryData).toHaveBeenCalledWith({
+      queryKey: ['enterprise', 'different-uuid', 'subsidies', 'enterpriseOffers'],
+      queryFn: expect.any(Function),
+      retry: false,
+    });
+  });
+
+  it('should return fallback data when query fails', async () => {
+    const error = new Error('Query failed');
+    mockEnsureQueryData.mockRejectedValue(error);
+
+    const result = await safeEnsureQueryDataEnterpriseOffers({
+      queryClient,
+      enterpriseCustomer,
+    });
+
+    // Should return fallback data
+    expect(result).toEqual({
+      enterpriseOffers: [],
+      currentEnterpriseOffers: [],
+      canEnrollWithEnterpriseOffers: false,
+      hasCurrentEnterpriseOffers: false,
+      hasLowEnterpriseOffersBalance: false,
+      hasNoEnterpriseOffersBalance: false,
+    });
+
+    // Should set fallback data in query cache
+    expect(mockSetQueryData).toHaveBeenCalledWith(
+      ['enterprise', 'test-enterprise-uuid', 'subsidies', 'enterpriseOffers'],
+      {
+        enterpriseOffers: [],
+        currentEnterpriseOffers: [],
+        canEnrollWithEnterpriseOffers: false,
+        hasCurrentEnterpriseOffers: false,
+        hasLowEnterpriseOffersBalance: false,
+        hasNoEnterpriseOffersBalance: false,
+      }
+    );
+  });
+});

--- a/src/components/app/data/queries/utils.test.ts
+++ b/src/components/app/data/queries/utils.test.ts
@@ -7,6 +7,7 @@ jest.mock('./queries', () => ({
   queryEnterpriseLearnerOffers: jest.fn(),
 }));
 
+// eslint-disable-next-line max-len
 const mockQueryEnterpriseLearnerOffers = queryEnterpriseLearnerOffers as jest.MockedFunction<typeof queryEnterpriseLearnerOffers>;
 
 describe('safeEnsureQueryDataEnterpriseOffers', () => {
@@ -33,6 +34,7 @@ describe('safeEnsureQueryDataEnterpriseOffers', () => {
 
     // Setup default mock return values
     mockQueryEnterpriseLearnerOffers.mockReturnValue({
+      // @ts-ignore
       queryKey: ['enterprise', 'test-enterprise-uuid', 'subsidies', 'enterpriseOffers'],
       queryFn: jest.fn(),
     });
@@ -99,6 +101,7 @@ describe('safeEnsureQueryDataEnterpriseOffers', () => {
     const differentEnterpriseCustomer = { uuid: 'different-uuid' };
 
     mockQueryEnterpriseLearnerOffers.mockReturnValue({
+      // @ts-ignore
       queryKey: ['enterprise', 'different-uuid', 'subsidies', 'enterpriseOffers'],
       queryFn: jest.fn(),
     });
@@ -147,7 +150,7 @@ describe('safeEnsureQueryDataEnterpriseOffers', () => {
         hasCurrentEnterpriseOffers: false,
         hasLowEnterpriseOffersBalance: false,
         hasNoEnterpriseOffersBalance: false,
-      }
+      },
     );
   });
 });

--- a/src/components/app/data/queries/utils.ts
+++ b/src/components/app/data/queries/utils.ts
@@ -253,7 +253,18 @@ export async function safeEnsureQueryDataEnterpriseOffers({
   return safeEnsureQueryData({
     queryClient,
     query: {
-      ...queryEnterpriseLearnerOffers(enterpriseCustomer.uuid),
+      queryKey: queryEnterpriseLearnerOffers(enterpriseCustomer.uuid).queryKey,
+      queryFn: () => (
+        {
+          enterpriseOffers: [],
+          currentEnterpriseOffers: [],
+          // Note: We are hard coding to false since offers are now deprecated as of 09/15/2025, HU
+          canEnrollWithEnterpriseOffers: false,
+          hasCurrentEnterpriseOffers: false,
+          hasLowEnterpriseOffersBalance: false,
+          hasNoEnterpriseOffersBalance: true,
+        }
+      ),
       retry: false,
     },
     fallbackData: {


### PR DESCRIPTION
This pull request updates how enterprise offers are handled in the codebase to reflect the deprecation of offers as of 09/15/2025. Instead of fetching real offer data, the logic now returns hardcoded values indicating that no enterprise offers are available and related features are disabled.

Deprecation of enterprise offers:

* Updated `useEnterpriseOffers` hook to return hardcoded empty offers and set all related flags (such as `canEnrollWithEnterpriseOffers` and `hasCurrentEnterpriseOffers`) to indicate that offers are deprecated and unavailable. (`src/components/app/data/hooks/useEnterpriseOffers.ts`)
* Updated `safeEnsureQueryDataEnterpriseOffers` utility to use a hardcoded query function that returns empty offers and appropriate flags, matching the deprecation logic in the hook. (`src/components/app/data/queries/utils.ts`)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)
- [ ] Ensure English strings are marked for translation. See [documentation](https://openedx.atlassian.net/wiki/spaces/LOC/pages/3103293538/MFE+Translation+How+To+s#How-to-internationalize-your-React-App) for more details.

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
