### PR TITLE
refactor: migrate enrollment API call from v1 to v2

### DIFF
--- a/src/components/skills-quiz/data/service.js
+++ b/src/components/skills-quiz/data/service.js
@@ -14,7 +14,7 @@ export async function postSkillsGoalsAndJobsUserSelected(goal, interestedJobsId,
 
 export function fetchCourseEnrollments() {
   const config = getConfig();
-  const url = `${config.LMS_BASE_URL}/api/enrollment/v1/enrollment`;
+  const url = `${config.LMS_BASE_URL}/api/enrollment/v2/enrollment/`;
   return getAuthenticatedHttpClient().get(url);
 }
 

--- a/src/components/skills-quiz/data/tests/service.test.jsx
+++ b/src/components/skills-quiz/data/tests/service.test.jsx
@@ -44,7 +44,7 @@ describe('skills quiz service', () => {
 
   it('fetches course enrollments', async () => {
     const sampleResponse = { enrollments: ['course1', 'course2'] };
-    const url = `${APP_CONFIG.LMS_BASE_URL}/api/enrollment/v1/enrollment`;
+    const url = `${APP_CONFIG.LMS_BASE_URL}/api/enrollment/v2/enrollment/`;
     axiosMock.onGet(url).reply(200, sampleResponse);
     const response = await fetchCourseEnrollments();
     await waitFor(() => expect(response.data).toEqual(sampleResponse));


### PR DESCRIPTION
## Summary

Migrates the Skills Quiz `fetchCourseEnrollments()` call from `/api/enrollment/v1/enrollment` to `/api/enrollment/v2/enrollment/`, per the FC-0118 API standardization on `openedx/edx-platform`.

- `src/components/skills-quiz/data/service.js` — endpoint bumped v1 → v2. The trailing slash is required because the v2 endpoint is served by a DRF `DefaultRouter` (`GET /enrollment/`).
- `src/components/skills-quiz/data/tests/service.test.jsx` — updated the mocked URL to match.

## Behaviour

Response shape is unchanged; the Skills Quiz still uses the returned enrollments to match recommended skills against the learner's courses.

## Dependency

⚠️ Requires the Enrollment v2 API on the LMS (FC-0118, `openedx/edx-platform` PR #38724). Must be released before this is deployed.

## Test plan

- [ ] `npm test` — `skills-quiz/data/tests/service.test.jsx` passes with the updated mock URL
- [ ] Manual: Skills Quiz recommendations render against an LMS with v2 enabled

Closes #1517

🤖 Generated with [Claude Code](https://claude.com/claude-code)